### PR TITLE
feat:Added separate keyboard selection for all languages

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,16 +31,102 @@
             android:exported="false" />
 
         <service
-            android:name=".services.SimpleKeyboardIME"
             android:exported="true"
-            android:label="@string/app_name"
+            android:name=".services.EnglishKeyboardIME"
+            android:label="Scribe"
             android:permission="android.permission.BIND_INPUT_METHOD">
-            <meta-data
-                android:name="android.view.im"
-                android:resource="@xml/method" />
             <intent-filter>
                 <action android:name="android.view.InputMethod" />
             </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_english" />
+        </service>
+
+        <service
+            android:exported="true"
+            android:name=".services.GermanKeyboardIME"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_german" />
+        </service>
+
+        <service
+            android:exported="true"
+            android:name=".services.FrenchKeyboardIME"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_french" />
+        </service>
+        <service
+            android:exported="true"
+            android:name=".services.ItalianKeyboardIME"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_italian" />
+        </service>
+        <service
+            android:exported="true"
+            android:name=".services.PortugueseKeyboardIME"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_portuguese" />
+        </service>
+        <service
+            android:exported="true"
+            android:name=".services.RussianKeyboardIME"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_russian" />
+        </service>
+        <service
+            android:exported="true"
+            android:name=".services.SpanishKeyboardIME"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_spanish" />
+        </service>
+        <service
+            android:exported="true"
+            android:name=".services.SwedishKeyboardIME"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_swedish" />
         </service>
 
         <activity

--- a/app/src/main/kotlin/org/scribe/services/EnglishKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/EnglishKeyboardIME.kt
@@ -1,0 +1,7 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class EnglishKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_english
+}

--- a/app/src/main/kotlin/org/scribe/services/FrenchKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/FrenchKeyboardIME.kt
@@ -1,0 +1,8 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class FrenchKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_french
+}
+

--- a/app/src/main/kotlin/org/scribe/services/GermanKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/GermanKeyboardIME.kt
@@ -1,0 +1,7 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class GermanKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_german
+}

--- a/app/src/main/kotlin/org/scribe/services/ItalianKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/ItalianKeyboardIME.kt
@@ -1,0 +1,8 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class ItalianKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_italian
+}
+

--- a/app/src/main/kotlin/org/scribe/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/PortugueseKeyboardIME.kt
@@ -1,0 +1,8 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class PortugueseKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_portuguese
+}
+

--- a/app/src/main/kotlin/org/scribe/services/RussianKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/RussianKeyboardIME.kt
@@ -1,0 +1,7 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class RussianKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_russian
+}

--- a/app/src/main/kotlin/org/scribe/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/SimpleKeyboardIME.kt
@@ -22,7 +22,10 @@ import org.scribe.helpers.*
 import org.scribe.views.MyKeyboardView
 
 // based on https://www.androidauthority.com/lets-build-custom-keyboard-android-832362/
-class SimpleKeyboardIME : InputMethodService(), MyKeyboardView.OnKeyboardActionListener {
+
+
+abstract class SimpleKeyboardIME : InputMethodService(), MyKeyboardView.OnKeyboardActionListener {
+    abstract fun getKeyboardLayoutXML(): Int
     private var SHIFT_PERM_TOGGLE_SPEED = 500   // how quickly do we have to doubletap shift to enable permanent caps lock
     private val KEYBOARD_LETTERS = 0
     private val KEYBOARD_SYMBOLS = 1
@@ -258,16 +261,4 @@ class SimpleKeyboardIME : InputMethodService(), MyKeyboardView.OnKeyboardActionL
         }
     }
 
-    private fun getKeyboardLayoutXML(): Int {
-        return when (baseContext.config.keyboardLanguage) {
-            LANGUAGE_FRENCH -> R.xml.keys_letters_french
-            LANGUAGE_GERMAN -> R.xml.keys_letters_german
-            LANGUAGE_ITALIAN -> R.xml.keys_letters_italian
-            LANGUAGE_PORTUGUESE -> R.xml.keys_letters_portuguese
-            LANGUAGE_RUSSIAN -> R.xml.keys_letters_russian
-            LANGUAGE_SPANISH -> R.xml.keys_letters_spanish
-            LANGUAGE_SWEDISH -> R.xml.keys_letters_swedish
-            else -> R.xml.keys_letters_english
-        }
     }
-}

--- a/app/src/main/kotlin/org/scribe/services/SpanishKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/SpanishKeyboardIME.kt
@@ -1,0 +1,7 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class SpanishKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_spanish
+}

--- a/app/src/main/kotlin/org/scribe/services/SwedishKeyboardIME.kt
+++ b/app/src/main/kotlin/org/scribe/services/SwedishKeyboardIME.kt
@@ -1,0 +1,7 @@
+package org.scribe.services
+
+import org.scribe.R
+
+class SwedishKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_spanish
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1510,6 +1510,14 @@
 
     <!-- Message digest algorithms -->
     <string name="md5">MD5</string>
+    <string name="english_keyboard">English(US)</string>
+    <string name="german_keyboard">German</string>
+    <string name="french">French</string>
+    <string name="italian">Italian</string>
+    <string name="portugu_s">Português</string>
+    <string name="russian">Russian</string>
+    <string name="spanish">spanish</string>
+    <string name="swedish">swedish</string>
 
     <string-array name="months">
         <item>@string/january</item>

--- a/app/src/main/res/xml/method_english.xml
+++ b/app/src/main/res/xml/method_english.xml
@@ -1,0 +1,9 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.scribe.activities.SettingsActivity"
+    android:icon="@mipmap/ic_launcher" >
+    <subtype
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/english_keyboard"
+        android:imeSubtypeLocale="en_US"
+        android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/main/res/xml/method_french.xml
+++ b/app/src/main/res/xml/method_french.xml
@@ -1,0 +1,9 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.scribe.activities.SettingsActivity"
+    android:icon="@mipmap/ic_launcher" >
+    <subtype
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/french"
+        android:imeSubtypeLocale="fr"
+        android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/main/res/xml/method_german.xml
+++ b/app/src/main/res/xml/method_german.xml
@@ -1,0 +1,6 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android">
+    <subtype
+        android:label="@string/german_keyboard"
+        android:imeSubtypeLocale="ge"
+        android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/main/res/xml/method_italian.xml
+++ b/app/src/main/res/xml/method_italian.xml
@@ -1,0 +1,9 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.scribe.activities.SettingsActivity"
+    android:icon="@mipmap/ic_launcher" >
+    <subtype
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/italian"
+        android:imeSubtypeLocale="it"
+        android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/main/res/xml/method_portuguese.xml
+++ b/app/src/main/res/xml/method_portuguese.xml
@@ -1,0 +1,9 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.scribe.activities.SettingsActivity"
+    android:icon="@mipmap/ic_launcher" >
+    <subtype
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/portugu_s"
+        android:imeSubtypeLocale="po"
+        android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/main/res/xml/method_russian.xml
+++ b/app/src/main/res/xml/method_russian.xml
@@ -1,0 +1,9 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.scribe.activities.SettingsActivity"
+    android:icon="@mipmap/ic_launcher" >
+    <subtype
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/russian"
+        android:imeSubtypeLocale="ru"
+        android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/main/res/xml/method_spanish.xml
+++ b/app/src/main/res/xml/method_spanish.xml
@@ -1,0 +1,9 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.scribe.activities.SettingsActivity"
+    android:icon="@mipmap/ic_launcher" >
+    <subtype
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/spanish"
+        android:imeSubtypeLocale="sp"
+        android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/main/res/xml/method_swedish.xml
+++ b/app/src/main/res/xml/method_swedish.xml
@@ -1,0 +1,9 @@
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.scribe.activities.SettingsActivity"
+    android:icon="@mipmap/ic_launcher" >
+    <subtype
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/swedish"
+        android:imeSubtypeLocale="sw"
+        android:imeSubtypeMode="keyboard" />
+</input-method>


### PR DESCRIPTION
-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This pull request aims to make separate keyboard selection for separate languages into individual keyboards. Through this pull request the user could enable the keyboard that the user wants from the android settings and then when the user selected the keyboard from the input method picker. 

### Related issue

- #15 
