### PR TITLE
Reference strings from i18n folder 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,8 @@ if (keystorePropertiesFile.exists()) {
 android {
     compileSdk 34
 
+
+
     defaultConfig {
         applicationId "be.scri"
         minSdk 23

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,3 +93,33 @@ dependencies {
     kapt 'com.github.bumptech.glide:compiler:4.12.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
 }
+
+
+task moveFromi18n {
+    def locales = ['de','es','sv','en-US']
+
+    locales.each { locale ->
+        def fromDir = "src/main/assets/i18n/Scribe-i18n/values/${locale}/"
+        def toDir = locale == 'en-US' ? "src/main/res/values/" : "src/main/res/values-${locale}/"
+        def sourceDir = file(fromDir)
+
+        if (sourceDir.exists()) {
+            println "Preparing to move from $fromDir to $toDir"
+            doLast {
+                copy {
+                    from fileTree(dir: fromDir)
+                    into toDir
+                    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+                }
+            }
+        } else {
+            println "Source directory does not exist: $fromDir"
+        }
+    }
+}
+
+tasks.named('preBuild').configure {
+    dependsOn tasks.named('moveFromi18n')
+}
+
+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         android:label="@string/app_launcher_name"
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:localeConfig="@xml/locales_config">
 
         <activity
             android:name=".activities.SplashActivity"
@@ -132,7 +133,7 @@
         <activity
             android:name=".activities.SettingsActivity"
             android:exported="true"
-            android:label="@string/settings"
+            android:label="@string/app.settings.title"
             android:parentActivityName=".activities.MainActivity">
 
             <intent-filter>
@@ -147,11 +148,11 @@
 
         <activity
             android:name="be.scri.activities.AboutActivity"
-            android:label="@string/about"
+            android:label="@string/app.about.title"
             android:parentActivityName=".activities.MainActivity" />
         <activity
             android:name="be.scri.activities.WikimediaScribeActivity"
-            android:label="@string/wikimedia_and_scribe"
+            android:label="@string/app.about.wikimedia"
             android:parentActivityName=".activities.MainActivity" />
 
         <activity-alias

--- a/app/src/main/kotlin/be/scri/activities/AboutActivity.kt
+++ b/app/src/main/kotlin/be/scri/activities/AboutActivity.kt
@@ -87,7 +87,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         val data = ArrayList<ItemsViewModel>()
         data.add(ItemsViewModel(
             image = R.drawable.github_logo,
-            "Get the code on GitHub",
+            R.string.app_about_github,
             image2 = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android",
             activity = null,
@@ -95,7 +95,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data.add(ItemsViewModel(
             image = R.drawable.matrix_icon,
-            "Chat with the team on Matrix",
+            R.string.app_about_matrix,
             image2 = R.drawable.external_link,
             url = "https://matrix.to/%23/%23scribe_community:matrix.org",
             activity = null,
@@ -103,7 +103,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data.add(ItemsViewModel(
             image = R.drawable.mastodon_svg_icon,
-            "Follow us on Mastodon",
+            R.string.app_about_mastodon,
             image2 = R.drawable.external_link,
             url = "https://wikis.world/@scribe",
             activity = null,
@@ -111,7 +111,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data.add(ItemsViewModel(
             image = R.drawable.share_icon,
-            "Share Scribe",
+            R.string.app_about_share,
             image2 = R.drawable.external_link,
             url = null,
             activity = null,
@@ -119,7 +119,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data.add(ItemsViewModel(
             image = R.drawable.scribe_icon,
-            "View all Scribe Apps",
+            R.string.app_about_scribe,
             image2 = R.drawable.external_link,
             url = null,
             activity = null,
@@ -127,7 +127,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data.add(ItemsViewModel(
             image = R.drawable.wikimedia_logo_black,
-            "Wikimedia and Scribe",
+            R.string.app_about_wikimedia,
             image2 = R.drawable.right_arrow,
             url = null,
             activity = WikimediaScribeActivity::class.java,
@@ -142,7 +142,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         val data2 = ArrayList<ItemsViewModel>()
         data2.add(ItemsViewModel(
             image = R.drawable.star,
-            "Rate Scribe",
+            R.string.app_about_rate,
             image2 = R.drawable.external_link,
             url = null,
             activity = null,
@@ -150,7 +150,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data2.add(ItemsViewModel(
             image = R.drawable.bug_report_icon,
-            "Report a bug",
+            R.string.app_about_bugReport,
             image2 = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android/issues",
             activity = null,
@@ -158,7 +158,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data2.add(ItemsViewModel(
             image = R.drawable.mail_icon,
-            "Send us an email",
+            R.string.app_about_email,
             image2 = R.drawable.external_link,
             url = null,
             activity = null,
@@ -166,7 +166,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data2.add(ItemsViewModel(
             image = R.drawable.bookmark_icon,
-            "Version x.x.x",
+            R.string.app_version,
             image2 = R.drawable.right_arrow,
             url = null,
             activity = null,
@@ -174,7 +174,7 @@ class AboutActivity : BaseSimpleActivity(), GestureDetector.OnGestureListener{
         ))
         data2.add(ItemsViewModel(
             image = R.drawable.light_bulb_icon,
-            "Reset App hints",
+            R.string.app_about_appHints,
             image2 = R.drawable.counter_clockwise_icon,
             url = null,
             activity = null,

--- a/app/src/main/kotlin/be/scri/helpers/CustomAdapter.kt
+++ b/app/src/main/kotlin/be/scri/helpers/CustomAdapter.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.content.ContextCompat.getString
 import androidx.recyclerview.widget.RecyclerView
 import be.scri.R
 import be.scri.models.ItemsViewModel
@@ -28,7 +29,7 @@ class CustomAdapter(private val mList: List<ItemsViewModel> , private val contex
         val itemViewModel = mList[position]
         holder.imageView.setImageResource(itemViewModel.image)
 
-        holder.textView.text = itemViewModel.text
+        holder.textView.text = getString(context,itemViewModel.textResId)
         holder.imageView2.setImageResource(itemViewModel.image2)
         if (position == 0) {
             holder.itemView.setBackgroundResource(R.drawable.rounded_top);

--- a/app/src/main/kotlin/be/scri/models/ItemsViewModel.kt
+++ b/app/src/main/kotlin/be/scri/models/ItemsViewModel.kt
@@ -4,4 +4,4 @@ import android.app.Activity
 import kotlin.reflect.KFunction0
 
 
-data class ItemsViewModel(val image: Int, val text: String, val image2:Int, val url: String? = null, val activity: Class<out Activity>? = null, val action: KFunction0<Unit>? = null)
+data class ItemsViewModel(val image: Int, val textResId: Int, val image2:Int, val url: String? = null, val activity: Class<out Activity>? = null, val action: KFunction0<Unit>? = null)

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -32,7 +32,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:text="@string/community_title"
+                android:text="@string/app.about.community"
                 android:textColor="@color/text_color"
                 android:textSize="20sp"
                 android:textStyle="bold" />
@@ -49,7 +49,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginStart="16dp"
-                android:text="@string/feedback_and_support"
+                android:text="@string/app.about.feedback"
                 android:textColor="@color/text_color"
                 android:textSize="20sp"
                 android:textStyle="bold" />

--- a/app/src/main/res/layout/activity_wikimedia_scribe.xml
+++ b/app/src/main/res/layout/activity_wikimedia_scribe.xml
@@ -28,14 +28,15 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="40dp" />
+
             <TextView
                 android:id="@+id/textView"
                 android:layout_width="303dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="56dp"
+                android:text="@string/app.about.wikimedia.caption"
                 android:layout_marginEnd="16dp"
-                android:text="@string/wikimedia_and_scribe_title"
                 android:textColor="@color/app_text_color"
                 android:textSize="20sp"
                 android:textStyle="bold" />
@@ -63,10 +64,10 @@
                         android:padding="16dp">
 
                         <TextView
-                            android:layout_width="321dp"
-                            android:layout_height="136dp"
+                            android:layout_width="304dp"
+                            android:layout_height="146dp"
                             android:layout_gravity=""
-                            android:text="@string/scribe_wikimedia"
+                            android:text="@string/app.about.wikimedia.text1"
                             android:textSize="16sp" />
 
                         <ImageView
@@ -80,7 +81,7 @@
                         <TextView
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="@string/wikidata_and_scribe"
+                            android:text="@string/app.about.wikimedia.text2"
                             android:textSize="16sp" />
 
                         <ImageView
@@ -93,7 +94,7 @@
                         <TextView
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="@string/wikipedia_and_scribe"
+                            android:text="@string/app.about.wikimedia.text3"
                             android:textSize="16sp" />
 
                     </LinearLayout>
@@ -103,7 +104,7 @@
                         android:layout_height="76dp"
                         android:layout_gravity="top|end"
                         android:alpha="0.9"
-                        android:contentDescription="@string/wikimedia_logo"
+                        android:contentDescription="@string/app.about.wikimedia"
                         android:src="@drawable/corner_polygon" />
 
                     <ImageView
@@ -112,7 +113,7 @@
                         android:layout_gravity="top|end"
                         android:layout_margin="8dp"
 
-                        android:contentDescription="@string/wikimedia_logo"
+                        android:contentDescription="@string/app.about.wikimedia"
                         android:src="@drawable/wikimedia_logo_black" />
                 </androidx.cardview.widget.CardView>
             </FrameLayout>

--- a/app/src/main/res/layout/card_view_design.xml
+++ b/app/src/main/res/layout/card_view_design.xml
@@ -29,7 +29,10 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="Get the code on GitHub"
-            android:textSize="16sp"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="15sp"
+            android:autoSizeMaxTextSize="24sp"
+            android:autoSizeStepGranularity="2sp"
             android:textStyle="normal" />
 
         <ImageView

--- a/app/src/main/res/menu/menu_navigation_bottom.xml
+++ b/app/src/main/res/menu/menu_navigation_bottom.xml
@@ -2,16 +2,16 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/installation"
-        android:title="Installation"
+        android:title="@string/app.install"
         android:icon="@drawable/material_keyboard"/>
     <item
         android:id="@+id/settings"
-        android:title="Settings"
+        android:title="@string/app.settings.title"
         android:icon="@drawable/material_settings"/>
 
     <item
         android:id="@+id/info"
-        android:title="About"
+        android:title="@string/app.about.title"
         android:icon="@drawable/material_info"/>
 
 </menu>

--- a/app/src/main/res/values-de/string.xml
+++ b/app/src/main/res/values-de/string.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="_global.english">Englisch</string>
+    <string name="_global.french">Französisch</string>
+    <string name="_global.german">Deutsch</string>
+    <string name="_global.italian">Italienisch</string>
+    <string name="_global.portuguese">Portugiesisch</string>
+    <string name="_global.russian">Russisch</string>
+    <string name="_global.spanish">Spanisch</string>
+    <string name="_global.swedish">Schwedisch</string>
+    <string name="app.about.appHint">Hier kannst du mehr über Scribe und seine Community erfahren.</string>
+    <string name="app.about.appHints">App-Hinweise zurücksetzen</string>
+    <string name="app.about.bugReport">Bug melden</string>
+    <string name="app.about.community">Community</string>
+    <string name="app.about.email">Schicke uns eine E-Mail</string>
+    <string name="app.about.feedback">Feedback und Support</string>
+    <string name="app.about.github">Den Code auf GitHub ansehen</string>
+    <string name="app.about.legal">Rechtliches</string>
+    <string name="app.about.mastodon">Folge uns auf Mastodon</string>
+    <string name="app.about.matrix">Chatte mit dem Team auf Matrix</string>
+    <string name="app.about.privacyPolicy">Datenschutzrichtlinie</string>
+    <string name="app.about.privacyPolicy.body">Bitte beachten Sie, dass die englische Version dieser Richtlinie Vorrang vor allen anderen Versionen hat.
+
+Die Scribe-Entwickler (SCRIBE) haben die iOS-App „Scribe – Language Keyboards“ (SERVICE) als Open-Source-App entwickelt. Dieser DIENST wird von SCRIBE kostenlos zur Verfügung gestellt und ist zur Verwendung so wie er ist bestimmt.
+
+Diese Datenschutzrichtlinie (RICHTLINIE) dient dazu, den Leser über die Bedingungen für den Zugriff auf, sowie die Verfolgung, Erfassung, Aufbewahrung, Verwendung und Offenlegung von persönlichen Informationen (NUTZERINFORMATIONEN) und Nutzungsdaten (NUTZERDATEN) aller Benutzer (NUTZER) dieses DIENSTES aufzuklären.
+
+NUTZERINFORMATIONEN sind insbesondere alle Informationen, die sich auf die NUTZER selbst oder die Geräte beziehen, die sie für den Zugriff auf den DIENST verwenden.
+
+NUTZERDATEN sind definiert als eingegebener Text oder Aktionen, die von den NUTZERN während der Nutzung des DIENSTES ausgeführt werden.
+
+1. Grundsatzerklärung
+
+Dieser DIENST greift nicht auf NUTZERINFORMATIONEN oder NUTZERDATEN zu und verfolgt, sammelt, speichert, verwendet und gibt keine NUTZERDATEN weiter.
+
+2. Do Not Track
+
+NUTZER, die SCRIBE kontaktieren, um zu verlangen, dass ihre NUTZERINFORMATIONEN und NUTZERDATEN nicht verfolgt werden, erhalten eine Kopie dieser RICHTLINIE sowie einen Link zu allen Quellcodes als Nachweis, dass sie nicht verfolgt werden.
+
+3. Daten von Drittanbietern
+
+Dieser DIENST verwendet Daten von Drittanbietern. Alle Daten, die bei der Erstellung dieses DIENSTES verwendet werden, stammen aus Quellen, die ihre vollständige Nutzung in der vom DIENST durchgeführten Weise ermöglichen. Primär stammen die Daten für diesen DIENST von Wikidata, Wikipedia und Unicode. Wikidata erklärt: „Alle strukturierten Daten in den Haupt-, Eigenschafts- und Lexem-Namespaces werden unter der Creative Commons CC0-Lizenz verfügbar gemacht; Text in anderen Namespaces wird unter der Creative Commons Attribution Share-Alike Lizenz verfügbar gemacht.“ Die Wikidata-Richtlinie zur Verwendung von Daten ist unter https://www.wikidata.org/wiki/Wikidata:Licensing zu finden. Wikipedia gibt an, dass Texte, also die Daten, die vom DIENST verwendet werden, „… unter den Bedingungen der Creative Commons Attribution Share-Alike Lizenz verwendet werden können“. Die Wikipedia-Richtlinie zur Verwendung von Daten ist unter https://en.wikipedia.org/wiki/Wikipedia:Reusing_Wikipedia_content zu finden. Unicode gewährt die Erlaubnis, „… kostenlos, für alle Inhaber einer Kopie der Unicode-Daten und der zugehörigen Dokumentation (der „Data Files“) oder der Unicode-Software und der zugehörigen Dokumentation (der „Software“), die Data Files oder Software ohne Einschränkung zu verwenden …“ Die Unicode-Richtlinie zur Verwendung von Daten ist unter https://www.unicode.org/license.txt zu finden.
+
+4. Quellcode von Drittanbietern
+
+Dieser DIENST basiert auf Code von Dritten. Der gesamte bei der Erstellung dieses DIENSTES verwendete Quellcode stammt von Quellen, die ihre Nutzung in der vom DIENST durchgeführten Weise gestatten. Grundlage dieses Projekts war im Besonderen das Projekt CustomKeyboard von Ethan Sarif-Kattan. CustomKeyboard wurde unter der MIT-Lizenz veröffentlicht, welche unter https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE abrufbar ist.
+
+5. Dienste von Drittanbietern
+
+Dieser DIENST nutzt Drittanbieterdienste, um einige der Daten von Drittanbietern zu modifizieren. Namentlich wurden Daten unter Verwendung von Modellen von Hugging Face’ Transformers übersetzt. Dieser Dienst ist durch eine Apache 2.0 Lizenz abgedeckt, die besagt, dass er für die kommerzielle Nutzung, Änderung, Verteilung, Patent- und private Nutzung verfügbar ist. Die Lizenz für den oben genannten Dienst finden Sie unter https://github.com/huggingface/transformers/blob/master/LICENSE.
+
+6. Links zu Drittanbietern
+
+Dieser DIENST enthält Links zu externen Webseiten. Wenn NUTZER auf einen Link eines Drittanbieters klicken, werden sie auf eine Webseite weitergeleitet. Beachten Sie, dass diese externen Websites nicht von diesem DIENST betrieben werden. Daher wird NUTZERN dringend empfohlen, die Datenschutzrichtlinie dieser Webseiten zu lesen. Dieser DIENST hat keine Kontrolle über und übernimmt keine Haftung für Inhalte, Datenschutzrichtlinien oder Praktiken von Webseiten oder Diensten Dritter.
+
+7. Bilder von Drittanbietern
+
+Dieser SERVICE enthält Bilder, die von Dritten urheberrechtlich geschützt sind. Insbesondere enthält diese App eine Kopie der Logos von GitHub, Inc. und Wikidata, Warenzeichen von Wikimedia Foundation, Inc. Die Bedingungen, unter denen das GitHub-Logo verwendet werden kann, ist unter https://github.com/logo abrufbar. Die Bedingungen für das Wikidata-Logo ist zu finden auf der folgenden Wikimedia-Seite: https://foundation.wikimedia.org/wiki/Policy:Trademark_policy. Dieser DIENST verwendet die urheberrechtlich geschützten Bilder in einer Weise, die diesen Kriterien entspricht, wobei die einzige Abweichung eine rotierte Version des GitHub-Logos ist, was in der Open-Source-Community üblich ist, um einen Link zur GitHub-Website darzustellen.
+
+8. Inhaltshinweis
+
+Dieser DIENST ermöglicht NUTZERN den Zugriff auf sprachliche Inhalte (INHALTE). Einige dieser INHALTE könnten für Kinder und Minderjährige als ungeeignet eingestuft werden. Der Zugriff auf INHALTE über den DIENST erfolgt auf eine Weise, in der die Informationen nur bekannt sind, wenn diese ausdrücklich angefragt werden. Speziell können NUTZER Wörter übersetzen, Verben konjugieren und auf andere grammatikalische Merkmale von INHALTEN zugreifen, die sexueller, gewalttätiger oder anderweitig nicht altersgerechter Natur sein können. NUTZER können keine Wörter übersetzen, Verben konjugieren und auf andere grammatikalische Merkmale von INHALTEN zugreifen, die sexueller, gewalttätiger oder anderweitig nicht altersgerechter Natur sein können, wenn sie nicht bereits über diese Art INHALTE Bescheid wissen. SCRIBE übernimmt keine Haftung für den Zugriff auf solche INHALTE.
+
+9. Änderungen
+
+Der DIENST behält sich Änderungen dieser RICHTLINIE vor. Aktualisierungen dieser RICHTLINIE ersetzen alle vorherigen Versionen, und werden, wenn sie als wesentlich erachtet werden, in der nächsten anwendbaren Aktualisierung des DIENSTES deutlich aufgeführt. SCRIBE animiert NUTZER dazu, diese RICHTLINIE regelmäßig auf die neuesten Informationen zu unseren Datenschutzpraktiken zu prüfen und sich mit etwaigen Änderungen vertraut zu machen.
+
+10. Kontakt
+
+Wenn Sie Fragen, Bedenken oder Vorschläge zu dieser RICHTLINIE haben, zögern Sie nicht, https://github.com/scribe-org zu besuchen oder SCRIBE unter scribe.langauge@gmail.com zu kontaktieren. Verantwortlich für solche Anfragen ist Andrew Tavis McAllister.
+
+11. Datum des Inkrafttretens
+
+Diese RICHTLINIE tritt am 24. Mai 2022 in Kraft.</string>
+    <string name="app.about.privacyPolicy.caption">Wir sorgen für Ihre Sicherheit</string>
+    <string name="app.about.rate">Scribe bewerten</string>
+    <string name="app.about.scribe">Alle Scribe Apps anzeigen</string>
+    <string name="app.about.share">Scribe teilen</string>
+    <string name="app.about.thirdParty">Lizenzen von Drittanbietern</string>
+    <string name="app.about.thirdParty.author">Autor</string>
+    <string name="app.about.thirdParty.body">Die iOS-App „Scribe - Language Keyboards“ (DIENST) wurde von den Scribe-Entwicklern (SCRIBE) unter Verwendung von Code von Dritten erstellt. Der gesamte bei der Erstellung dieses DIENSTES verwendete Quellcode stammt von Quellen, die ihre Nutzung in der vom DIENST durchgeführten Weise gestatten. Dieser Abschnitt enthält den Quellcode, auf dem der DIENST basiert, sowie die zugehörigen Lizenzen.
+
+Im Folgenden ist eine Liste des benutzten Quellcodes, des oder der jeweiligen Autor:innen und der Lizenz zur Zeit der Verwendung durch SCRIBE mit einem Link zu dieser zu finden.
+
+1. Custom Keyboard
+• Autor: EthanSK
+• Lizenz: MIT
+• Link: https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE</string>
+    <string name="app.about.thirdParty.caption">Der von uns verwendete Code</string>
+    <string name="app.about.thirdParty.license">Lizenz</string>
+    <string name="app.about.thirdParty.link">Link</string>
+    <string name="app.about.title">Über uns</string>
+    <string name="app.about.wikimedia">Wikimedia und Scribe</string>
+    <string name="app.about.wikimedia.caption">Wie wir zusammenarbeiten</string>
+    <string name="app.about.wikimedia.text1">Scribe wäre ohne die etlichen Mitwirkungen von Wikimedia Mitwirkenden, den Projekten, die sie unterstützen, gegenüber, nicht möglich. Genauer benutzt Scribe Daten der Lexikografischen Datencommunity in Wikidata, sowie solche von Wikipedia für jede von Scribe unterstützte Sprache.</string>
+    <string name="app.about.wikimedia.text2">Wikidata ist ein kollaborativ gestalteter, mehrsprachiger Wissensgraf, der von der Wikimedia Foundation gehostet wird. Sie stellt frei verfügbare Daten, die unter einer Creative Commons Public Domain Lizenz (CC0) stehen, zur Verfügung. Scribe benutzt Sprachdaten von Wikidata, um Nutzern Verbkonjugationen, Kasusannotationen, Plurale und viele andere Funktionen zu bieten.</string>
+    <string name="app.about.wikimedia.text3">Wikipedia ist eine mehrsprachige, freie, Online-Enzyklopädie, die von einer Community an Freiwilligen durch offene Kollaboration und einem Wiki-basierten Bearbeitungssystem geschrieben und aufrechterhalten wird. Scribe nutzt Wikipedia-Daten, um automatische Empfehlungen zu erstellen, indem die häufigsten Wörter und Folgewörter einer Sprache erlangt werden.</string>
+    <string name="app.install">Installation</string>
+    <string name="app.installation.appHint">Folge den Anweisungen unten, um Scribe-Tastaturen auf deinem Gerät zu installieren.</string>
+    <string name="app.installation.settingsLink">Scribe-Einstellungen öffnen</string>
+    <string name="app.installation.text1">Drücke auf</string>
+    <string name="app.installation.text2">Wähle die Tastaturen aus, die du benutzen möchtest
+
+4. Drücke beim Tippen auf</string>
+    <string name="app.installation.text3">um Tastaturen auszuwählen</string>
+    <string name="app.installation.title">Tastaturinstallation</string>
+    <string name="app.keyboards">Tastaturen</string>
+    <string name="app.settings.appHint">Hier sind die Einstellungen der App und installierte Tastaturen zu finden.</string>
+    <string name="app.settings.appSettings">App-Einstellungen</string>
+    <string name="app.settings.appSettings.appLanguage">App-Sprache</string>
+    <string name="app.settings.functionality">Funktionalität</string>
+    <string name="app.settings.functionality.autoSuggestEmoji">Schlage Emojis vor</string>
+    <string name="app.settings.installedKeyboards">Wähle installierte Tastatur aus</string>
+    <string name="app.settings.layout">Layout</string>
+    <string name="app.settings.layout.autoSuggestEmoji.description">Schlage für ausdrucksvolleres Schreiben Emojis vor.</string>
+    <string name="app.settings.layout.disableAccentCharacters">Buchstaben mit Akzent deaktivieren</string>
+    <string name="app.settings.layout.disableAccentCharacters.description">Entscheide, ob Buchstaben mit Akzenten wie Umlaute auf der Haupttastatur angezeigt werden.</string>
+    <string name="app.settings.layout.periodAndComma">Punkt und Komma auf ABC</string>
+    <string name="app.settings.layout.periodAndComma.description">Füge der Haupttastatur Punkt- und Komma-Tasten für bequemeres Schreiben hinzu.</string>
+    <string name="app.settings.oneDeviceLanguage.message">Auf Ihrem Gerät ist nur eine Sprache installiert. Bitte installieren Sie weitere Sprachen in den Einstellungen. Anschließend können Sie verschiedene Lokalisierungen von Scribe auswählen.</string>
+    <string name="app.settings.oneDeviceLanguage.title">Nur eine Gerätesprache</string>
+    <string name="app.settings.title">Einstellungen</string>
+    <string name="app.settings.translation">Übersetzung</string>
+    <string name="app.settings.translation.translateLang">Übersetzungssprache</string>
+    <string name="app.settings.translation.translateLang.caption">Wähle die Sprache, von der übersetzt wird</string>
+    <string name="app.wikidataExplanation1">Wikidata ist ein kollaborativ gestalteter, mehrsprachiger Wissensgraf, der von der Wikimedia Foundation gehostet wird. Sie dient als Quelle für offene Daten für unzählige Projekte, beispielsweise Wikipedia.</string>
+    <string name="app.wikidataExplanation2">Scribe nutzt Sprachdaten von Wikidata für viele Kernfunktionen. Von dort erhalten wir Informationen wie Genera, Verbkonjugationen und viele mehr!</string>
+    <string name="app.wikidataExplanation3">Du kannst auf wikidata.org einen Account erstellen, um der Community, die Scribe und viele andere Projekte unterstützt, beizutreten. Hilf uns dabei, der Welt freie Informationen zu geben!</string>
+</resources>

--- a/app/src/main/res/values-es/string.xml
+++ b/app/src/main/res/values-es/string.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="_global.english">Inglés</string>
+    <string name="_global.french">Francés</string>
+    <string name="_global.german">Alemán</string>
+    <string name="_global.italian">Italiano</string>
+    <string name="_global.portuguese">Portugués</string>
+    <string name="_global.russian">Ruso</string>
+    <string name="_global.spanish">Español</string>
+    <string name="_global.swedish">Sueco</string>
+    <string name="app.about.appHint">Aquí puedes obtener más información sobre Scribe y su comunidad.</string>
+    <string name="app.about.appHints">Restablecer notificaciones de aplicaciones</string>
+    <string name="app.about.bugReport">Reportar un error</string>
+    <string name="app.about.community">Comunidad</string>
+    <string name="app.about.email">Envianos un correo electrónico</string>
+    <string name="app.about.feedback">Comentarios y soporte</string>
+    <string name="app.about.github">Ver el código en GitHub</string>
+    <string name="app.about.legal">Legal</string>
+    <string name="app.about.mastodon">Siguenos en Mastodon</string>
+    <string name="app.about.matrix">Chatea con el equipo en Matrix</string>
+    <string name="app.about.privacyPolicy">Política de privacidad</string>
+    <string name="app.about.privacyPolicy.body">Tenga en cuenta que la versión en inglés de esta política tiene prioridad sobre todas las demás versiones.
+
+Los desarrolladores de Scribe (SCRIBE) crearon la aplicación para iOS "Scribe - Language Keyboards" (SERVICIO) como una aplicación de código abierto. SCRIBE proporciona este SERVICIO sin coste y está destinado a usarse tal como está.
+
+Esta política de privacidad (POLÍTICA) se utiliza para informar al lector sobre las políticas de acceso, seguimiento, recopilación, retención, uso y divulgación de información personal (INFORMACIÓN DEL USUARIO) y datos de uso (DATOS DEL USUARIO) para todas las personas que hacen uso de este SERVICIO (USUARIOS).
+
+LA INFORMACIÓN DEL USUARIO se define específicamente como cualquier información relacionada con los propios USUARIOS o los dispositivos que utilizan para acceder al SERVICIO.
+
+LOS DATOS DEL USUARIO se definen específicamente como cualquier texto escrito o acción realizada por los USUARIOS mientras utilizan el SERVICIO.
+
+1. Declaración de política
+
+Este SERVICIO no accede, rastrea, recopila, retiene, utiliza ni divulga ninguna INFORMACIÓN DEL USUARIO ni DATOS DEL USUARIO.
+
+2. No rastrear
+
+A los USUARIOS que se comuniquen con SCRIBE para solicitar que su INFORMACIÓN DE USUARIO y sus DATOS DE USUARIO no sean rastreados se les proporcionará una copia de esta POLÍTICA así como un enlace a todos los códigos fuente como prueba de que no están siendo rastreados.
+
+3. Datos de terceros
+
+Este SERVICIO hace uso de datos de terceros. Todos los datos utilizados en la creación de este SERVICIO provienen de fuentes que permiten su uso completo en la forma en que lo hace el SERVICIO. En concreto, los datos de este SERVICIO provienen de Wikidata, Wikipedia y Unicode. Wikidata afirma que "Todos los datos estructurados en los espacios de nombres principal, de propiedad y de lexema están disponibles bajo la Licencia Creative Commons CC0; el texto en otros espacios de nombres está disponible bajo la Licencia Creative Commons Attribution-Share Alike". La política que detalla el uso de los datos de Wikidata se puede encontrar en https://www.wikidata.org/wiki/Wikidata:Licensing. Wikipedia afirma que los datos de texto, el tipo de datos utilizados por el SERVICIO, "... pueden usarse bajo los términos de la licencia Creative Commons Attribution Share-Alike". La política que detalla el uso de los datos de Wikipedia se puede encontrar en https://en.wikipedia.org/wiki/Wikipedia:Reusing_Wikipedia_content. Unicode otorga permiso, "... sin cargo, a cualquier persona que obtenga una copia de los archivos de datos Unicode y cualquier documentación asociada (los "Archivos de Datos") o el software Unicode y cualquier documentación asociada (el "Software") para tratar los Archivos de Datos o el Software sin restricción..." La política que detalla el uso de datos Unicode se puede encontrar en https://www.unicode.org/license.txt.
+
+4. Código fuente de terceros
+
+Este SERVICIO se basó en código de terceros. Todo el código fuente utilizado en la creación de este SERVICIO proviene de fuentes que permiten su uso completo en la forma en que lo hace el SERVICIO. En concreto, la base de este proyecto fue el proyecto CustomKeyboard de Ethan Sarif-Kattan. CustomKeyboard se publicó bajo una licencia MIT, que está disponible en https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE.
+
+5. Servicios de terceros
+
+Este SERVICIO hace uso de servicios de terceros para manipular algunos de los datos de terceros. En concreto, los datos se han traducido utilizando modelos de los transformadores de Hugging Face. Este servicio está cubierto por una Licencia Apache 2.0, que establece que está disponible para uso comercial, modificación, distribución, uso de patentes y uso privado. La licencia para el servicio mencionado anteriormente se puede encontrar en https://github.com/huggingface/transformers/blob/master/LICENSE.
+
+6. Enlaces de terceros
+
+Este SERVICIO contiene enlaces a páginas web externas. Si los USUARIOS hacen clic en un enlace de un tercero, serán dirigidos a un sitio web. Tenga en cuenta que estos sitios web externos no son operados por este SERVICIO. Por lo tanto, se recomienda encarecidamente a los USUARIOS que revisen la política de privacidad de estos sitios web. Este SERVICIO no tiene control ni asume ninguna responsabilidad por el contenido, las políticas de privacidad o las prácticas de los sitios o servicios de terceros.
+
+7. Imágenes de terceros
+
+Este SERVICIO contiene imágenes con derechos de autor de terceros. En concreto, esta aplicación incluye una copia de los logotipos de GitHub, Inc. y Wikidata, marcas registradas de Wikimedia Foundation, Inc. Los términos por los que se puede utilizar el logotipo de GitHub se encuentran en https://github.com/logos, y los términos para el logotipo de Wikidata se encuentran en la siguiente página de Wikimedia: https://foundation.wikimedia.org/wiki/Policy:Trademark_policy. Este SERVICIO utiliza las imágenes con derechos de autor de una manera que cumple con estos criterios, con la única desviación de una rotación del logotipo de GitHub que es común en la comunidad de código abierto para indicar que hay un enlace al sitio web de GitHub.
+
+8. Aviso de contenido
+
+Este SERVICIO permite a los USUARIOS acceder a contenido lingüístico (CONTENIDO). Parte de este CONTENIDO podría considerarse inapropiado para niños y menores de edad. El acceso al CONTENIDO mediante el SERVICIO se realiza de forma que la información no esté disponible a menos que se conozca explícitamente. En concreto, los USUARIOS "pueden" traducir palabras, conjugar verbos y acceder a otras características gramaticales del CONTENIDO que puedan ser de naturaleza sexual, violenta o inapropiada de otro modo. Los USUARIOS "no pueden" traducir palabras, conjugar verbos y acceder a otras características gramaticales del CONTENIDO que puedan ser de naturaleza sexual, violenta o inapropiada de otro modo si no conocen ya la naturaleza de este CONTENIDO. SCRIBE no asume ninguna responsabilidad por el acceso a dicho CONTENIDO.
+
+9. Cambios
+
+Esta POLÍTICA está sujeta a cambios. Las actualizaciones de esta POLÍTICA reemplazarán todas las anteriores y, si se consideran importantes, se indicarán claramente en la próxima actualización correspondiente del SERVICIO. SCRIBE alienta a los USUARIOS a revisar periódicamente esta POLÍTICA para obtener la información más reciente sobre nuestras prácticas de privacidad y familiarizarse con los cambios.
+
+10. Contacto
+
+Si tiene alguna pregunta, inquietud o sugerencia sobre esta POLÍTICA, no dude en visitar https://github.com/scribe-org o comunicarse con SCRIBE a través de scribe.langauge@gmail.com. La persona responsable de dichas consultas es Andrew Tavis McAllister.
+
+11. Fecha de entrada en vigor
+
+Esta POLÍTICA entra en vigencia a partir del 24 de mayo de 2022.</string>
+    <string name="app.about.privacyPolicy.caption">Velamos por tu seguridad</string>
+    <string name="app.about.rate">Puntúa a Scribe</string>
+    <string name="app.about.scribe">Ver todas las aplicaciones de Scribe</string>
+    <string name="app.about.share">Compartir Scribe</string>
+    <string name="app.about.thirdParty">Licencias de terceros</string>
+    <string name="app.about.thirdParty.author">Autor</string>
+    <string name="app.about.thirdParty.body">Los desarrolladores de Scribe (SCRIBE) han creado la aplicación iOS "Scribe - Language Keyboards" (SERVICIO) utilizando código de terceros. Todo el código fuente utilizado en la creación de este SERVICIO proviene de fuentes que permiten su uso completo en la forma en que lo hace el SERVICIO. En esta sección se enumera el código fuente en el que se basó el SERVICIO, así como las licencias coincidentes de cada uno.
+
+A continuación se muestra una lista de todo el código fuente utilizado, el autor o autores principales del código, la licencia bajo la cual fue publicado en el momento de su uso y un enlace a la licencia.
+
+1. Teclado personalizado
+• Autor: EthanSK
+• Licencia: MIT
+• Enlace: https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE</string>
+    <string name="app.about.thirdParty.caption">¿De quién es el código que utilizamos?</string>
+    <string name="app.about.thirdParty.license">Licencia</string>
+    <string name="app.about.thirdParty.link">Enlace</string>
+    <string name="app.about.title">Acerca de</string>
+    <string name="app.about.wikimedia">Wikimedia y Scribe</string>
+    <string name="app.about.wikimedia.caption">¿Cómo funcionan juntos?</string>
+    <string name="app.about.wikimedia.text1">Scribe no sería posible sin las innumerables contribuciones de los colaboradores de Wikimedia a los numerosos proyectos que apoya. En concreto, Scribe utiliza datos de la comunidad de datos lexicográficos de Wikidata, así como datos de Wikipedia para cada idioma que Scribe admite.</string>
+    <string name="app.about.wikimedia.text2">Wikidata es un gráfico de conocimiento colaborativo y multilingüe alojado por la Fundación Wikimedia. Proporciona datos disponibles gratuitamente bajo una licencia de dominio público Creative Commons (CC0). Scribe utiliza datos de idioma de Wikidata para proporcionar a los usuarios conjugaciones verbales, anotaciones de casos, plurales y muchas otras características.</string>
+    <string name="app.about.wikimedia.text3">La Wikipedia es una enciclopedia libre multilingüe escrita y mantenida por una comunidad de voluntarios mediante una colaboración abierta y un sistema de edición basado en wiki. Scribe utiliza datos de la Wikipedia para generar autosugestiones derivando las palabras más comunes de un idioma, así como las palabras más comunes que las siguen.</string>
+    <string name="app.install">Instalación</string>
+    <string name="app.installation.appHint">Sigue las instrucciones para instalar los teclados Scribe en tu dispositivo.</string>
+    <string name="app.installation.settingsLink">Abrir la configuración de Scribe</string>
+    <string name="app.installation.text1">Seleccionar</string>
+    <string name="app.installation.text2">Activa los teclados que quieras utilizar
+
+4. Al escribir, presiona</string>
+    <string name="app.installation.text3">para seleccionar teclados</string>
+    <string name="app.installation.title">Instalación del teclado</string>
+    <string name="app.keyboards">Teclados</string>
+    <string name="app.settings.appHint">La configuración de la aplicación y los teclados de idiomas instalados se encuentran aquí.</string>
+    <string name="app.settings.appSettings">Ajustes de la aplicación</string>
+    <string name="app.settings.appSettings.appLanguage">Idioma de la aplicación</string>
+    <string name="app.settings.functionality">Funcionalidad</string>
+    <string name="app.settings.functionality.autoSuggestEmoji">Autosugerir emojis</string>
+    <string name="app.settings.installedKeyboards">Seleccionar el teclado instalado</string>
+    <string name="app.settings.layout">Disposición</string>
+    <string name="app.settings.layout.autoSuggestEmoji.description">Active las sugerencias y el autocompletado de los emojis para una escritura más expresiva.</string>
+    <string name="app.settings.layout.disableAccentCharacters">Deshabilitar caracteres acentuados</string>
+    <string name="app.settings.layout.disableAccentCharacters.description">Elimine las teclas de los letras acentuadas en la distribución del teclado principal.</string>
+    <string name="app.settings.layout.periodAndComma">Punto y coma en ABC</string>
+    <string name="app.settings.layout.periodAndComma.description">Agrega teclas de punto y coma al teclado principal para escribir más cómodamente.</string>
+    <string name="app.settings.oneDeviceLanguage.message">Solo tienes un idioma instalado en tu dispositivo. Instala más idiomas en Configuración y luego podrás seleccionar diferentes localizaciones de Scribe.</string>
+    <string name="app.settings.oneDeviceLanguage.title">Solo un idioma para el dispositivo</string>
+    <string name="app.settings.title">Ajustes</string>
+    <string name="app.settings.translation">Traducción</string>
+    <string name="app.settings.translation.translateLang">Idioma de la traducción</string>
+    <string name="app.settings.translation.translateLang.caption">Elige un idioma para traducir</string>
+    <string name="app.wikidataExplanation1">Wikidata es un gráfico de conocimiento editado de forma colaborativa y mantenido por la Fundación Wikimedia. Sirve como fuente de datos abiertos para proyectos como Wikipedia y muchos otros.</string>
+    <string name="app.wikidataExplanation2">Scribe utiliza los datos lingüísticos de Wikidata para muchas de sus funciones principales. ¡Obtenemos información como géneros de sustantivos, conjugaciones de verbos y mucho más!</string>
+    <string name="app.wikidataExplanation3">Puedes crear una cuenta en wikidata.org para unirte a la comunidad que apoya a Scribe y a muchos otros proyectos. ¡Ayúdanos a llevar información gratuita al mundo!</string>
+</resources>

--- a/app/src/main/res/values-sv/string.xml
+++ b/app/src/main/res/values-sv/string.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="_global.english">Engelska</string>
+    <string name="_global.french">Franska</string>
+    <string name="_global.german">Tyska</string>
+    <string name="_global.italian">Italienska</string>
+    <string name="_global.portuguese">Portugisiska</string>
+    <string name="_global.russian">Ryska</string>
+    <string name="_global.spanish">Spanska</string>
+    <string name="_global.swedish">Svenska</string>
+    <string name="app.about.appHint">Här kan du lära dig mer om Scribe och dess community.</string>
+    <string name="app.about.appHints">Återställ app-tips</string>
+    <string name="app.about.bugReport">Rapportera ett fel</string>
+    <string name="app.about.community">Community</string>
+    <string name="app.about.email">Skicka ett e-mail till oss</string>
+    <string name="app.about.feedback">Feedback och support</string>
+    <string name="app.about.github">See koden på GitHub</string>
+    <string name="app.about.legal">Legalitet</string>
+    <string name="app.about.mastodon">Följ oss på Mastodon</string>
+    <string name="app.about.matrix">Chatta med teamet på Matrix</string>
+    <string name="app.about.privacyPolicy">Integritetspolicy</string>
+    <string name="app.about.privacyPolicy.body">Observera att den engelska versionen av denna policy har företräde framför alla andra versioner.
+
+Scribe-utvecklarna (SCRIBE) byggde iOS-applikationen "Scribe - Language Keyboards" (SERVICE) som en applikation med öppen källkod.
+Denna TJÄNST tillhandahålls av SCRIBE utan kostnad och är avsedd att användas i befintligt skick.
+
+Denna sekretesspolicy (POLICY) används för att informera läsaren om policyerna för åtkomst, spårning, insamling, lagring, användning och utlämnande av personlig information (ANVÄNDARINFORMATION) och användningsdata (ANVÄNDARDATA) för alla individer som använder denna TJÄNST (ANVÄNDARE).
+
+ANVÄNDARINFORMATION definieras specifikt som all information som är relaterad till användarna själva eller de enheter de använder för att få tillgång till tjänsten.
+
+ANVÄNDARDATA definieras specifikt som all text som skrivs eller åtgärder som utförs av ANVÄNDARNA när de använder TJÄNSTEN.
+
+1. Uttalande om policy
+
+Denna TJÄNST får inte tillgång till, spårar, samlar in, behåller, använder eller avslöjar någon ANVÄNDARINFORMATION eller ANVÄNDARDATA.
+
+2. Spårar inte
+
+ANVÄNDARE som kontaktar SCRIBE för att be om att deras ANVÄNDARINFORMATION och ANVÄNDARDATA inte spåras kommer att förses med en kopia av denna POLICY samt en länk till alla källkoder som bevis på att de inte spåras.
+
+3. Uppgifter från tredje part
+
+Denna TJÄNST använder sig av data från tredje part. All data som används vid skapandet av denna TJÄNST kommer från källor som tillåter dess fulla användning på det sätt som görs av TJÄNSTEN. Specifikt kommer data för denna TJÄNST från Wikidata, Wikipedia och Unicode. Wikidata säger att "All strukturerad data i namnrymderna main, property och lexeme görs tillgänglig under Creative Commons CC0-licensen; text i andra namnrymder görs tillgänglig under Creative Commons Attribution-Share Alike-Licens." Policyn som beskriver Wikidatas dataanvändning finns på https://www.wikidata.org/wiki/Wikidata:Licensing. Wikipedia anger att textdata, den typ av data som används av TJÄNSTEN, "... kan användas enligt villkoren i Creative Commons Attribution-Share Alike-licensen". Policyn som beskriver Wikipedias dataanvändning kan hittas på https://en.wikipedia.org/wiki/Wikipedia:Reusing_Wikipedia_content. Unicode ger tillstånd, "... kostnadsfritt, till alla personer som erhåller en kopia av Unicode-datafilerna och all tillhörande dokumentation ("datafilerna") eller Unicode-programvaran och all tillhörande dokumentation ("programvaran") för att hantera datafilerna eller programvaran utan begränsning..." Policyn för användning av Unicode-data finns på https://www.unicode.org/license.txt.
+
+4. Källkod från tredje part
+
+Denna TJÄNST baserades på kod från tredje part. All källkod som används vid skapandet av denna TJÄNST kommer från källor som tillåter dess fulla användning på det sätt som görs av TJÄNSTEN. Grunden för detta projekt var projektet CustomKeyboard av Ethan Sarif-Kattan. CustomKeyboard släpptes under en MIT-licens, och denna licens är tillgänglig på https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE.
+
+5. Tjänster från tredje part
+
+Denna TJÄNST använder sig av tjänster från tredje part för att manipulera en del av data från tredje part. Specifikt har data översatts med hjälp av modeller från Hugging Face-transformatorer. Denna tjänst omfattas av en Apache License 2.0, som anger att den är tillgänglig för kommersiellt bruk, modifiering, distribution, patentanvändning och privat bruk. Licensen för ovannämnda tjänst finns på https://github.com/huggingface/transformers/blob/master/LICENSE.
+
+6. Länkar till tredje part
+
+Denna TJÄNST innehåller länkar till externa webbplatser. Om ANVÄNDARE klickar på en länk från tredje part kommer de att dirigeras till en webbplats. Observera att dessa externa webbplatser inte drivs av denna TJÄNST. Därför rekommenderas ANVÄNDARE starkt att granska sekretesspolicyn för dessa webbplatser. Denna TJÄNST har ingen kontroll över och tar inget ansvar för innehållet, sekretesspolicyn eller praxis på tredje parts webbplatser eller tjänster.
+
+7. Bilder från tredje part
+
+Denna TJÄNST innehåller bilder som är upphovsrättsskyddade av tredje part. Specifikt innehåller den här appen en kopia av logotyperna för GitHub, Inc och Wikidata, varumärkesskyddade av Wikimedia Foundation, Inc. Villkoren för hur GitHub-logotypen kan användas finns på https://github.com/logos, och villkoren för Wikidata-logotypen finns på följande Wikimedia-sida: https://foundation.wikimedia.org/wiki/Policy:Trademark_policy. Den här tjänsten använder de upphovsrättsskyddade bilderna på ett sätt som matchar dessa kriterier, med den enda avvikelsen är en rotation av GitHub-logotypen som är vanlig i öppen källkodsgemenskapen för att indikera att det finns en länk till GitHub-webbplatsen.
+
+8. Meddelande om innehåll
+
+Denna TJÄNST gör det möjligt för ANVÄNDARE att få tillgång till språkligt innehåll (INNEHÅLL). En del av detta INNEHÅLL kan anses vara olämpligt för barn och minderåriga som har rätt att göra det. Åtkomst till INNEHÅLL med hjälp av TJÄNSTEN görs på ett sätt så att informationen inte är tillgänglig om den inte uttryckligen är känd. Specifikt "kan" ANVÄNDARE översätta ord, böja verb och få tillgång till andra grammatiska egenskaper i INNEHÅLL som kan vara sexuella, våldsamma eller på annat sätt olämpliga till sin natur. ANVÄNDARE "kan" översätta ord, böja verb och få tillgång till andra grammatiska egenskaper i INNEHÅLL som kan vara sexuella, våldsamma eller på annat sätt olämpliga till sin natur om de inte redan känner till detta INNEHÅLLS natur. SCRIBE tar inget ansvar för åtkomsten till sådant INNEHÅLL.
+
+9. Ändringar
+
+Denna POLICY kan komma att ändras. Uppdateringar av denna POLICY kommer att ersätta alla tidigare instanser, och om de anses vara väsentliga kommer de att anges tydligt i nästa tillämpliga uppdatering av TJÄNSTEN. SCRIBE uppmuntrar ANVÄNDARE att regelbundet granska denna POLICY för den senaste informationen om vår integritetspraxis och att bekanta sig med eventuella ändringar.
+
+10. Kontakt
+
+Om du har några frågor, funderingar eller förslag om denna POLICY, tveka inte att besöka https://github.com/scribe-org eller kontakta SCRIBE på scribe.langauge@gmail.com. Ansvarig för sådana förfrågningar är Andrew Tavis McAllister.
+
+11. Ikraftträdande
+
+Denna POLICY gäller från och med den 24 maj 2022.</string>
+    <string name="app.about.privacyPolicy.caption">Håller dig säker</string>
+    <string name="app.about.rate">Betygsätt Scribe</string>
+    <string name="app.about.scribe">Visa all Scribe-applikationer</string>
+    <string name="app.about.share">Dela Scribe</string>
+    <string name="app.about.thirdParty">Licenser från tredje part</string>
+    <string name="app.about.thirdParty.author">Författare</string>
+    <string name="app.about.thirdParty.body">Utvecklarna på Scribe (SCRIBE) har utvecklat iOS-applikationen "Scribe - Language Keyboards" (TJÄNST) med hjälp av kod från tredje part. All källkod använd i skapelsen av denna TJÄNST kommer ifrån källor som ger oss full tillåtelse att använda koden på det sätt som görs av TJÄNSTEN. Nedan listas källkoden som TJÄNSTEN är baserad på och licenserna som sammanfaller. 
+
+Följande lista listar all källkod, upphovsmän, licensen som gällde vid tillfället av användandet och en länk till licensen.
+
+1. Custom Keyboard
+• Upphovsman: EthanSK
+• Licens: MIT
+• Länk: https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE</string>
+    <string name="app.about.thirdParty.caption">Vems kod vi använde</string>
+    <string name="app.about.thirdParty.license">Licens</string>
+    <string name="app.about.thirdParty.link">Länk</string>
+    <string name="app.about.title">Om</string>
+    <string name="app.about.wikimedia">Wikimedia och Scribe</string>
+    <string name="app.about.wikimedia.caption">Om vårt samarbete</string>
+    <string name="app.about.wikimedia.text1">Scribe skulle inte vara möjligt utan de otaliga bidrag som görs till de olika Wikimedia-projekten. Scribe använder sig specifikt av data från Wikidata Lexicographical data community, och data från Wikipedia för de olika språk som Scribe stöder.</string>
+    <string name="app.about.wikimedia.text2">Wikidata är en flerspråkig kunskapsgraf som underhålls kollektivt. Den hostas av Wikimedia Foundation. Den tillhandahåller data som kan användas under Creative Commons Public Domain-licensen (CC0). Scribe använder sig av språk-relaterad data från Wikidata för att ge användare tillgång till diverse grammatiska funktioner.</string>
+    <string name="app.about.wikimedia.text3">Wikipedia är en flerspråkig gratis online-encyklopedi skriven och underhållen av en gemenskap av volontärer genom öppet samarbete och ett wiki-baserat redigeringssystem. Scribe använder data från Wikipedia för att producera autoförslag genom att härleda de vanligaste orden i ett språk samt de vanligaste orden som följer dem.</string>
+    <string name="app.install">Installation</string>
+    <string name="app.installation.appHint">Följ instruktionerna nedan för att installera Scribe-tangentbord på din enhet.</string>
+    <string name="app.installation.settingsLink">Öppna Scribe-inställningar</string>
+    <string name="app.installation.text1">Välj</string>
+    <string name="app.installation.text2">Aktivera tangenbort som du vill använda
+
+4. Medans du skriver, tryck</string>
+    <string name="app.installation.text3">För att välja tangentbord</string>
+    <string name="app.installation.title">Tangentbords-installation</string>
+    <string name="app.keyboards">Tangentbord</string>
+    <string name="app.settings.appHint">Inställningar för appen och installerade tangentbord finns här.</string>
+    <string name="app.settings.appSettings">App-inställningar</string>
+    <string name="app.settings.appSettings.appLanguage">App-språk</string>
+    <string name="app.settings.functionality">Funktionalitet</string>
+    <string name="app.settings.functionality.autoSuggestEmoji">Föreslå automatiskt emojis</string>
+    <string name="app.settings.installedKeyboards">Välj installerade tangentbord</string>
+    <string name="app.settings.layout">Layout</string>
+    <string name="app.settings.layout.autoSuggestEmoji.description">Aktivera emojiförslag och kompletteringar för mer uttrycksfullt skrivande.</string>
+    <string name="app.settings.layout.disableAccentCharacters">Inaktivera accenter</string>
+    <string name="app.settings.layout.disableAccentCharacters.description">Ta bort tangenter med accenter på den primära tangentbordslayouten.</string>
+    <string name="app.settings.layout.periodAndComma">Punk och komma på ABC</string>
+    <string name="app.settings.layout.periodAndComma.description">Inkludera komma- och punkttangenter på huvudtangentbordet för att underlätta skrivandet.</string>
+    <string name="app.settings.oneDeviceLanguage.message">Du har bara ett språk installerat på din enhet. Installera fler språk i Inställningar och efter det kan du välja olika lokaliseringar av Scribe.</string>
+    <string name="app.settings.oneDeviceLanguage.title">Endast ett enhetsspråk</string>
+    <string name="app.settings.title">Inställningar</string>
+    <string name="app.settings.translation">Översättning</string>
+    <string name="app.settings.translation.translateLang">Språk för översättning</string>
+    <string name="app.settings.translation.translateLang.caption">Välj ett språk att översätta ifrån</string>
+    <string name="app.wikidataExplanation1">Wikidata är en gemensamt redigerad kunskapsgraf som underhålls av Wikimedia Foundation. Det fungerar som en källa till öppen data för projekt som Wikipedia och flera andra.</string>
+    <string name="app.wikidataExplanation2">Scribe använder Wikidatas språkdata för många av sina kärnfunktioner. Vi får information som substantiv, genus, verbböjningar och mycket mer!</string>
+    <string name="app.wikidataExplanation3">Du kan skapa ett konto på wikidata.org för att gå med i communityn som stöder Scribe och så många andra projekt. Hjälp oss att ge gratis information till världen!</string>
+</resources>

--- a/app/src/main/res/values/string.xml
+++ b/app/src/main/res/values/string.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="_global.english">English</string>
+    <string name="_global.french">French</string>
+    <string name="_global.german">German</string>
+    <string name="_global.italian">Italian</string>
+    <string name="_global.portuguese">Portuguese</string>
+    <string name="_global.russian">Russian</string>
+    <string name="_global.spanish">Spanish</string>
+    <string name="_global.swedish">Swedish</string>
+    <string name="app.about.appHint">Here\'s where you can learn more about Scribe and its community.</string>
+    <string name="app.about.appHints">Reset app hints</string>
+    <string name="app.about.bugReport">Report a bug</string>
+    <string name="app.about.community">Community</string>
+    <string name="app.about.email">Send us an email</string>
+    <string name="app.about.feedback">Feedback and support</string>
+    <string name="app.about.github">See the code on GitHub</string>
+    <string name="app.about.legal">Legal</string>
+    <string name="app.about.mastodon">Follow us on Mastodon</string>
+    <string name="app.about.matrix">Chat with the team on Matrix</string>
+    <string name="app.about.privacyPolicy">Privacy policy</string>
+    <string name="app.about.privacyPolicy.body">Please note that the English version of this policy takes precedence over all other versions.
+
+The Scribe developers (SCRIBE) built the iOS application "Scribe - Language Keyboards" (SERVICE) as an open-source application. This SERVICE is provided by SCRIBE at no cost and is intended for use as is.
+
+This privacy policy (POLICY) is used to inform the reader of the policies for the access, tracking, collection, retention, use, and disclosure of personal information (USER INFORMATION) and usage data (USER DATA) for all individuals who make use of this SERVICE (USERS).
+
+USER INFORMATION is specifically defined as any information related to the USERS themselves or the devices they use to access the SERVICE.
+
+USER DATA is specifically defined as any text that is typed or actions that are done by the USERS while using the SERVICE.
+
+1. Policy Statement
+
+This SERVICE does not access, track, collect, retain, use, or disclose any USER INFORMATION or USER DATA.
+
+2. Do Not Track
+
+USERS contacting SCRIBE to ask that their USER INFORMATION and USER DATA not be tracked will be provided with a copy of this POLICY as well as a link to all source codes as proof that they are not being tracked.
+
+3. Third-Party Data
+
+This SERVICE makes use of third-party data. All data used in the creation of this SERVICE comes from sources that allow its full use in the manner done so by the SERVICE. Specifically, the data for this SERVICE comes from Wikidata, Wikipedia and Unicode. Wikidata states that, "All structured data in the main, property and lexeme namespaces is made available under the Creative Commons CC0 License; text in other namespaces is made available under the Creative Commons Attribution-Share Alike License." The policy detailing Wikidata data usage can be found at https://www.wikidata.org/wiki/Wikidata:Licensing. Wikipedia states that text data, the type of data used by the SERVICE, "… can be used under the terms of the Creative Commons Attribution Share-Alike license". The policy detailing Wikipedia data usage can be found at https://en.wikipedia.org/wiki/Wikipedia:Reusing_Wikipedia_content. Unicode provides permission, "… free of charge, to any person obtaining a copy of the Unicode data files and any associated documentation (the "Data Files") or Unicode software and any associated documentation (the "Software") to deal in the Data Files or Software without restriction…" The policy detailing Unicode data usage can be found at https://www.unicode.org/license.txt.
+
+4. Third-Party Source Code
+
+This SERVICE was based on third-party code. All source code used in the creation of this SERVICE comes from sources that allow its full use in the manner done so by the SERVICE. Specifically, the basis of this project was the project CustomKeyboard by Ethan Sarif-Kattan. CustomKeyboard was released under an MIT license, with this license being available at https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE.
+
+5. Third-Party Services
+
+This SERVICE makes use of third-party services to manipulate some of the third-party data. Specifically, data has been translated using models from Hugging Face transformers. This service is covered by an Apache License 2.0, which states that it is available for commercial use, modification, distribution, patent use, and private use. The license for the aforementioned service can be found at https://github.com/huggingface/transformers/blob/master/LICENSE.
+
+6. Third-Party Links
+
+This SERVICE contains links to external websites. If USERS click on a third-party link, they will be directed to a website. Note that these external websites are not operated by this SERVICE. Therefore, USERS are strongly advised to review the privacy policy of these websites. This SERVICE has no control over and assumes no responsibility for the content, privacy policies, or practices of any third-party sites or services.
+
+7. Third-Party Images
+
+This SERVICE contains images that are copyrighted by third-parties. Specifically, this app includes a copy of the logos of GitHub, Inc and Wikidata, trademarked by Wikimedia Foundation, Inc. The terms by which the GitHub logo can be used are found on https://github.com/logos, and the terms for the Wikidata logo are found on the following Wikimedia page: https://foundation.wikimedia.org/wiki/Policy:Trademark_policy. This SERVICE uses the copyrighted images in a way that matches these criteria, with the only deviation being a rotation of the GitHub logo that is common in the open-source community to indicate that there is a link to the GitHub website.
+
+8. Content Notice
+
+This SERVICE allows USERS to access linguistic content (CONTENT). Some of this CONTENT could be deemed inappropriate for children and legal minors. Accessing CONTENT using the SERVICE is done in a way that the information is unavailable unless explicitly known. Specifically, USERS "can" translate words, conjugate verbs, and access other grammatical features of CONTENT that may be sexual, violent, or otherwise inappropriate in nature. USERS "cannot" translate words, conjugate verbs, and access other grammatical features of CONTENT that may be sexual, violent, or otherwise inappropriate in nature if they do not already know about the nature of this CONTENT. SCRIBE takes no responsibility for the access of such CONTENT.
+
+9. Changes
+
+This POLICY is subject to change. Updates to this POLICY will replace all prior instances, and if deemed material will further be clearly stated in the next applicable update to the SERVICE. SCRIBE encourages USERS to periodically review this POLICY for the latest information on our privacy practices and to familiarize themselves with any changes.
+
+10. Contact
+
+If you have any questions, concerns, or suggestions about this POLICY, do not hesitate to visit https://github.com/scribe-org or contact SCRIBE at scribe.langauge@gmail.com. The person responsible for such inquiries is Andrew Tavis McAllister.
+
+11. Effective Date
+
+This POLICY is effective as of the 24th of May, 2022.</string>
+    <string name="app.about.privacyPolicy.caption">Keeping you safe</string>
+    <string name="app.about.rate">Rate Scribe</string>
+    <string name="app.about.scribe">View all Scribe apps</string>
+    <string name="app.about.share">Share Scribe</string>
+    <string name="app.about.thirdParty">Third-party licenses</string>
+    <string name="app.about.thirdParty.author">Author</string>
+    <string name="app.about.thirdParty.body">The Scribe developers (SCRIBE) built the iOS application "Scribe - Language Keyboards" (SERVICE) using third party code. All source code used in the creation of this SERVICE comes from sources that allow its full use in the manner done so by the SERVICE. This section lists the source code on which the SERVICE was based as well as the coinciding licenses of each.
+
+The following is a list of all used source code, the main author or authors of the code, the license under which it was released at time of usage, and a link to the license.
+
+1. Custom Keyboard
+• Author: EthanSK
+• License: MIT
+• Link: https://github.com/EthanSK/CustomKeyboard/blob/master/LICENSE</string>
+    <string name="app.about.thirdParty.caption">Whose code we used</string>
+    <string name="app.about.thirdParty.license">License</string>
+    <string name="app.about.thirdParty.link">Link</string>
+    <string name="app.about.title">About</string>
+    <string name="app.about.wikimedia">Wikimedia and Scribe</string>
+    <string name="app.about.wikimedia.caption">How we work together</string>
+    <string name="app.about.wikimedia.text1">Scribe would not be possible without countless contributions by Wikimedia contributors to the many projects that they support. Specifically Scribe makes use of data from the Wikidata Lexicographical data community, as well as data from Wikipedia for each language that Scribe supports.</string>
+    <string name="app.about.wikimedia.text2">Wikidata is a collaboratively edited multilingual knowledge graph hosted by the Wikimedia Foundation. It provides freely available data that anyone can use under a Creative Commons Public Domain license (CC0). Scribe uses language data from Wikidata to provide users with verb conjugations, noun-form annotations, noun plurals, and many other features.</string>
+    <string name="app.about.wikimedia.text3">Wikipedia is a multilingual free online encyclopedia written and maintained by a community of volunteers through open collaboration and a wiki-based editing system. Scribe uses data from Wikipedia to produce autosuggestions by deriving the most common words in a language as well as the most common words that follow them.</string>
+    <string name="app.install">Installation</string>
+    <string name="app.installation.appHint">Follow the directions below to install Scribe keyboards on your device.</string>
+    <string name="app.installation.settingsLink">Open Scribe settings</string>
+    <string name="app.installation.text1">Select</string>
+    <string name="app.installation.text2">Activate keyboards that you want to use
+
+4. When typing, press</string>
+    <string name="app.installation.text3">to select keyboards</string>
+    <string name="app.installation.title">Keyboard installation</string>
+    <string name="app.keyboards">Keyboards</string>
+    <string name="app.settings.appHint">Settings for the app and installed language keyboards are found here.</string>
+    <string name="app.settings.appSettings">App settings</string>
+    <string name="app.settings.appSettings.appLanguage">App language</string>
+    <string name="app.settings.functionality">Functionality</string>
+    <string name="app.settings.functionality.autoSuggestEmoji">Autosuggest emojis</string>
+    <string name="app.settings.installedKeyboards">Select installed keyboard</string>
+    <string name="app.settings.layout">Layout</string>
+    <string name="app.settings.layout.autoSuggestEmoji.description">Turn on emoji suggestions and completions for more expressive typing.</string>
+    <string name="app.settings.layout.disableAccentCharacters">Disable accent characters</string>
+    <string name="app.settings.layout.disableAccentCharacters.description">Remove accented letter keys on the primary keyboard layout.</string>
+    <string name="app.settings.layout.periodAndComma">Period and comma on ABC</string>
+    <string name="app.settings.layout.periodAndComma.description">Include comma and period keys on the main keyboard for convenient typing.</string>
+    <string name="app.settings.oneDeviceLanguage.message">You only have one language installed on your device. Please install more languages in Settings and then you can select different localizations of Scribe.</string>
+    <string name="app.settings.oneDeviceLanguage.title">Only one device language</string>
+    <string name="app.settings.title">Settings</string>
+    <string name="app.settings.translation">Translation</string>
+    <string name="app.settings.translation.translateLang">Translation language</string>
+    <string name="app.settings.translation.translateLang.caption">Choose a language to translate from</string>
+    <string name="app.wikidataExplanation1">Wikidata is a collaboratively edited knowledge graph that\'s maintained by the Wikimedia Foundation. It serves as a source of open data for projects like Wikipedia and countless others.</string>
+    <string name="app.wikidataExplanation2">Scribe uses Wikidata\'s language data for many of its core features. We get information like noun genders, verb conjugations and much more!</string>
+    <string name="app.wikidataExplanation3">You can make an account at wikidata.org to join the community that\'s supporting Scribe and so many other projects. Help us bring free information to the world!</string>
+</resources>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en-US"/>
+    <locale android:name="de"/>
+    <locale android:name="es"/>
+    <locale android:name="sv"/>
+</locale-config>

--- a/app/src/main/res/xml/method_english.xml
+++ b/app/src/main/res/xml/method_english.xml
@@ -3,7 +3,7 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/english_keyboard"
+        android:label="@string/_global.english"
         android:imeSubtypeLocale="en_US"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_french.xml
+++ b/app/src/main/res/xml/method_french.xml
@@ -3,7 +3,7 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/french"
+        android:label="@string/_global.french"
         android:imeSubtypeLocale="fr"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_german.xml
+++ b/app/src/main/res/xml/method_german.xml
@@ -1,6 +1,6 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android">
     <subtype
-        android:label="@string/german_keyboard"
+        android:label="@string/_global.german"
         android:imeSubtypeLocale="ge"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_italian.xml
+++ b/app/src/main/res/xml/method_italian.xml
@@ -3,7 +3,7 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/italian"
+        android:label="@string/_global.italian"
         android:imeSubtypeLocale="it"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_portuguese.xml
+++ b/app/src/main/res/xml/method_portuguese.xml
@@ -3,7 +3,7 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/portugu_s"
+        android:label="@string/_global.portuguese"
         android:imeSubtypeLocale="po"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_russian.xml
+++ b/app/src/main/res/xml/method_russian.xml
@@ -3,7 +3,7 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/russian"
+        android:label="@string/_global.russian"
         android:imeSubtypeLocale="ru"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_spanish.xml
+++ b/app/src/main/res/xml/method_spanish.xml
@@ -3,7 +3,7 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/spanish"
+        android:label="@string/_global.spanish"
         android:imeSubtypeLocale="sp"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_swedish.xml
+++ b/app/src/main/res/xml/method_swedish.xml
@@ -3,7 +3,7 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/swedish"
+        android:label="@string/_global.swedish"
         android:imeSubtypeLocale="sw"
         android:imeSubtypeMode="keyboard" />
 </input-method>


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

The strings will now be referenced from the i18n folder, which is a subtree of Scribe-i18n. The About page is fully localized, as it was recently created and all the strings were available. The bottom navigation bar is also localized. However, the other pages could not be localized because the strings were not present. As a result, the old strings.xml is still present. I will create a document for the strings currently referenced in the various files from strings.xml.

### Related issue

-   #44 
