### PR TITLE
Add Autosuggest emojis menu item

### DIFF
--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
@@ -16,7 +17,6 @@ import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentLanguageSettingsBinding
 import be.scri.helpers.CustomAdapter
 import be.scri.models.SwitchItem
-import android.widget.Toast
 
 class LanguageSettingsFragment : Fragment() {
     private var _binding: FragmentLanguageSettingsBinding? = null
@@ -117,8 +117,7 @@ class LanguageSettingsFragment : Fragment() {
                 title = "Autosuggest emojis",
                 action = { enableEmojiAutosuggestions(language) },
                 action2 = { disableEmojiAutosuggestions(language) },
-            )
-
+            ),
         )
     }
 
@@ -141,7 +140,7 @@ class LanguageSettingsFragment : Fragment() {
         val editor = sharedPref.edit()
         editor.putBoolean("emoji_suggestions_$language", true)
         editor.apply()
-        Toast.makeText(requireContext() , "$language Emoji Autosuggestions on", Toast.LENGTH_SHORT).show();
+        Toast.makeText(requireContext(), "$language Emoji Autosuggestions on", Toast.LENGTH_SHORT).show()
     }
 
     private fun disableEmojiAutosuggestions(language: String) {
@@ -149,7 +148,7 @@ class LanguageSettingsFragment : Fragment() {
         val editor = sharedPref.edit()
         editor.putBoolean("emoji_suggestions_$language", false)
         editor.apply()
-        Toast.makeText(requireContext(), "$language Emoji Autosuggestions off", Toast.LENGTH_SHORT).show();
+        Toast.makeText(requireContext(), "$language Emoji Autosuggestions off", Toast.LENGTH_SHORT).show()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -16,6 +16,7 @@ import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentLanguageSettingsBinding
 import be.scri.helpers.CustomAdapter
 import be.scri.models.SwitchItem
+import android.widget.Toast
 
 class LanguageSettingsFragment : Fragment() {
     private var _binding: FragmentLanguageSettingsBinding? = null
@@ -107,10 +108,17 @@ class LanguageSettingsFragment : Fragment() {
         return listOf(
             SwitchItem(
                 isChecked = sharedPref.getBoolean("period_on_double_tap_$language", false),
-                title = "Double space Periods",
+                title = "Double space periods",
                 action = { enablePeriodOnSpaceBarDoubleTap(language) },
                 action2 = { disablePeriodOnSpaceBarDoubleTap(language) },
             ),
+            SwitchItem(
+                isChecked = sharedPref.getBoolean("autosuggest_emojis_$language", true),
+                title = "Autosuggest emojis",
+                action = { enableEmojiAutosuggestions(language) },
+                action2 = { disableEmojiAutosuggestions(language) },
+            )
+
         )
     }
 
@@ -126,6 +134,22 @@ class LanguageSettingsFragment : Fragment() {
         val editor = sharedPref.edit()
         editor.putBoolean("period_on_double_tap_$language", false)
         editor.apply()
+    }
+
+    private fun enableEmojiAutosuggestions(language: String) {
+        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val editor = sharedPref.edit()
+        editor.putBoolean("emoji_suggestions_$language", true)
+        editor.apply()
+        Toast.makeText(requireContext() , "$language Emoji Autosuggestions on", Toast.LENGTH_SHORT).show();
+    }
+
+    private fun disableEmojiAutosuggestions(language: String) {
+        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val editor = sharedPref.edit()
+        editor.putBoolean("emoji_suggestions_$language", false)
+        editor.apply()
+        Toast.makeText(requireContext(), "$language Emoji Autosuggestions off", Toast.LENGTH_SHORT).show();
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
This PR add an menu item to trigger emoji autosuggestions and a Toast message while switching.
### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #64
