### PR TITLE
fix:Fixed Null Point Error due to toolbar being changed in Language IME

### DIFF
--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -1,6 +1,7 @@
 package be.scri.services
 
 import android.content.Context
+import android.text.InputType
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
@@ -8,7 +9,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class FrenchKeyboardIME : SimpleKeyboardIME() {
@@ -33,10 +33,19 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
     private var currentState: ScribeState = ScribeState.IDLE
     private lateinit var keyboardBinding: KeyboardViewKeyboardBinding
     private lateinit var commandBinding: KeyboardViewCommandOptionsBinding
-    private lateinit var binding: KeyboardViewCommandOptionsBinding
-    private var keyboardView: MyKeyboardView? = null
-    private var keyboard: MyKeyboard? = null
-    private var enterKeyType = IME_ACTION_NONE
+    override lateinit var binding: KeyboardViewCommandOptionsBinding
+    override var keyboardView: MyKeyboardView? = null
+    override var keyboard: MyKeyboard? = null
+    override var enterKeyType = IME_ACTION_NONE
+    override var shiftPermToggleSpeed = 500
+    override val keyboardLetters = 0
+    override val keyboardSymbols = 1
+    override val keyboardSymbolShift = 2
+    override var lastShiftPressTS = 0L
+    override var keyboardMode = keyboardLetters
+    override var inputTypeClass = InputType.TYPE_CLASS_TEXT
+    override var switchToLetters = false
+    override var hasTextBeforeCursor = false
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
@@ -53,6 +62,41 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
             val inputConnection = currentInputConnection ?: return
             inputConnection.deleteSurroundingText(1, 0)
             inputConnection.commitText(". ", 1)
+        }
+    }
+
+    override fun onKey(code: Int) {
+        val inputConnection = currentInputConnection
+        if (keyboard == null || inputConnection == null) {
+            return
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            lastShiftPressTS = 0
+        }
+
+        when (code) {
+            MyKeyboard.KEYCODE_DELETE -> {
+                super.handleDelete()
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_SHIFT -> {
+                super.handleKeyboardLetters(keyboardMode, keyboardView, this)
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_ENTER -> {
+                super.handleKeycodeEnter()
+            }
+            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+                handleModeChange(keyboardMode, keyboardView, this)
+            }
+            else -> {
+                super.handleElseCondition(code, keyboardMode)
+            }
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            super.updateShiftKeyState()
         }
     }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -1,6 +1,7 @@
 package be.scri.services
 
 import android.content.Context
+import android.text.InputType
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
@@ -8,7 +9,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class ItalianKeyboardIME : SimpleKeyboardIME() {
@@ -30,10 +30,19 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
     private var currentState: ScribeState = ScribeState.IDLE
     private lateinit var keyboardBinding: KeyboardViewKeyboardBinding
     private lateinit var commandBinding: KeyboardViewCommandOptionsBinding
-    private lateinit var binding: KeyboardViewCommandOptionsBinding
-    private var keyboardView: MyKeyboardView? = null
-    private var keyboard: MyKeyboard? = null
-    private var enterKeyType = IME_ACTION_NONE
+    override lateinit var binding: KeyboardViewCommandOptionsBinding
+    override var keyboardView: MyKeyboardView? = null
+    override var keyboard: MyKeyboard? = null
+    override var enterKeyType = IME_ACTION_NONE
+    override var shiftPermToggleSpeed = 500
+    override val keyboardLetters = 0
+    override val keyboardSymbols = 1
+    override val keyboardSymbolShift = 2
+    override var lastShiftPressTS = 0L
+    override var keyboardMode = keyboardLetters
+    override var inputTypeClass = InputType.TYPE_CLASS_TEXT
+    override var switchToLetters = false
+    override var hasTextBeforeCursor = false
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
@@ -80,6 +89,41 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
             Log.i("MY-TAG", "SELECT COMMAND STATE")
             binding.scribeKey.foreground = getDrawable(R.drawable.close)
             updateUI()
+        }
+    }
+
+    override fun onKey(code: Int) {
+        val inputConnection = currentInputConnection
+        if (keyboard == null || inputConnection == null) {
+            return
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            lastShiftPressTS = 0
+        }
+
+        when (code) {
+            MyKeyboard.KEYCODE_DELETE -> {
+                super.handleDelete()
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_SHIFT -> {
+                super.handleKeyboardLetters(keyboardMode, keyboardView, this)
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_ENTER -> {
+                super.handleKeycodeEnter()
+            }
+            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+                handleModeChange(keyboardMode, keyboardView, this)
+            }
+            else -> {
+                super.handleElseCondition(code, keyboardMode)
+            }
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            super.updateShiftKeyState()
         }
     }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -1,6 +1,7 @@
 package be.scri.services
 
 import android.content.Context
+import android.text.InputType
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
@@ -8,7 +9,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class PortugueseKeyboardIME : SimpleKeyboardIME() {
@@ -30,10 +30,19 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
     private var currentState: ScribeState = ScribeState.IDLE
     private lateinit var keyboardBinding: KeyboardViewKeyboardBinding
     private lateinit var commandBinding: KeyboardViewCommandOptionsBinding
-    private lateinit var binding: KeyboardViewCommandOptionsBinding
-    private var keyboardView: MyKeyboardView? = null
-    private var keyboard: MyKeyboard? = null
-    private var enterKeyType = IME_ACTION_NONE
+    override lateinit var binding: KeyboardViewCommandOptionsBinding
+    override var keyboardView: MyKeyboardView? = null
+    override var keyboard: MyKeyboard? = null
+    override var enterKeyType = IME_ACTION_NONE
+    override var shiftPermToggleSpeed = 500
+    override val keyboardLetters = 0
+    override val keyboardSymbols = 1
+    override val keyboardSymbolShift = 2
+    override var lastShiftPressTS = 0L
+    override var keyboardMode = keyboardLetters
+    override var inputTypeClass = InputType.TYPE_CLASS_TEXT
+    override var switchToLetters = false
+    override var hasTextBeforeCursor = false
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
@@ -110,6 +119,41 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
             Log.i("MY-TAG", "PLURAL STATE")
             currentState = ScribeState.PLURAL
             updateUI()
+        }
+    }
+
+    override fun onKey(code: Int) {
+        val inputConnection = currentInputConnection
+        if (keyboard == null || inputConnection == null) {
+            return
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            lastShiftPressTS = 0
+        }
+
+        when (code) {
+            MyKeyboard.KEYCODE_DELETE -> {
+                super.handleDelete()
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_SHIFT -> {
+                super.handleKeyboardLetters(keyboardMode, keyboardView, this)
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_ENTER -> {
+                super.handleKeycodeEnter()
+            }
+            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+                handleModeChange(keyboardMode, keyboardView, this)
+            }
+            else -> {
+                super.handleElseCondition(code, keyboardMode)
+            }
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            super.updateShiftKeyState()
         }
     }
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -1,6 +1,7 @@
 package be.scri.services
 
 import android.content.Context
+import android.text.InputType
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
@@ -8,7 +9,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class RussianKeyboardIME : SimpleKeyboardIME() {
@@ -30,10 +30,19 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
     private var currentState: ScribeState = ScribeState.IDLE
     private lateinit var keyboardBinding: KeyboardViewKeyboardBinding
     private lateinit var commandBinding: KeyboardViewCommandOptionsBinding
-    private lateinit var binding: KeyboardViewCommandOptionsBinding
-    private var keyboardView: MyKeyboardView? = null
-    private var keyboard: MyKeyboard? = null
-    private var enterKeyType = IME_ACTION_NONE
+    override lateinit var binding: KeyboardViewCommandOptionsBinding
+    override var keyboardView: MyKeyboardView? = null
+    override var keyboard: MyKeyboard? = null
+    override var enterKeyType = IME_ACTION_NONE
+    override var shiftPermToggleSpeed = 500
+    override val keyboardLetters = 0
+    override val keyboardSymbols = 1
+    override val keyboardSymbolShift = 2
+    override var lastShiftPressTS = 0L
+    override var keyboardMode = keyboardLetters
+    override var inputTypeClass = InputType.TYPE_CLASS_TEXT
+    override var switchToLetters = false
+    override var hasTextBeforeCursor = false
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
@@ -80,6 +89,41 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
             Log.i("MY-TAG", "SELECT COMMAND STATE")
             binding.scribeKey.foreground = getDrawable(R.drawable.close)
             updateUI()
+        }
+    }
+
+    override fun onKey(code: Int) {
+        val inputConnection = currentInputConnection
+        if (keyboard == null || inputConnection == null) {
+            return
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            lastShiftPressTS = 0
+        }
+
+        when (code) {
+            MyKeyboard.KEYCODE_DELETE -> {
+                super.handleDelete()
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_SHIFT -> {
+                super.handleKeyboardLetters(keyboardMode, keyboardView, this)
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_ENTER -> {
+                super.handleKeycodeEnter()
+            }
+            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+                handleModeChange(keyboardMode, keyboardView, this)
+            }
+            else -> {
+                super.handleElseCondition(code, keyboardMode)
+            }
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            super.updateShiftKeyState()
         }
     }
 

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -1,5 +1,6 @@
 package be.scri.services
 
+import android.content.Context
 import android.inputmethodservice.InputMethodService
 import android.text.InputType
 import android.text.InputType.TYPE_CLASS_DATETIME
@@ -7,6 +8,7 @@ import android.text.InputType.TYPE_CLASS_NUMBER
 import android.text.InputType.TYPE_CLASS_PHONE
 import android.text.InputType.TYPE_MASK_CLASS
 import android.text.TextUtils
+import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
@@ -16,7 +18,6 @@ import android.view.inputmethod.EditorInfo.IME_MASK_ACTION
 import android.view.inputmethod.ExtractedTextRequest
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
@@ -30,33 +31,20 @@ abstract class SimpleKeyboardIME :
     MyKeyboardView.OnKeyboardActionListener {
     abstract fun getKeyboardLayoutXML(): Int
 
-    enum class ScribeState {
-        IDLE,
-        SELECT_COMMAND,
-        TRANSLATE,
-        CONJUGATE,
-        PLURAL,
-        SELECT_VERB_CONJUNCTION,
-        SELECT_CASE_DECLENSION,
-        ALREADY_PLURAL,
-        INVALID,
-        DISPLAY_INFORMATION,
-    }
+    abstract var shiftPermToggleSpeed: Int // how quickly do we have to doubletap shift to enable permanent caps lock
+    abstract val keyboardLetters: Int
+    abstract val keyboardSymbols: Int
+    abstract val keyboardSymbolShift: Int
 
-    private var currentState: ScribeState = ScribeState.IDLE
-    private lateinit var keyboardBinding: KeyboardViewKeyboardBinding
-    private lateinit var commandBinding: KeyboardViewCommandOptionsBinding
-    private var keyboard: MyKeyboard? = null
-    private var keyboardView: MyKeyboardView? = null
-    private var lastShiftPressTS = 0L
-    private var keyboardMode = Companion.KEYBOARD_LETTERS
-    private var inputTypeClass = InputType.TYPE_CLASS_TEXT
-    private var enterKeyType = IME_ACTION_NONE
-
-    private var switchToLetters = false
-    private var hasTextBeforeCursor = false
-    private var commandText: StringBuilder = StringBuilder()
-    private lateinit var binding: KeyboardViewCommandOptionsBinding
+    abstract var keyboard: MyKeyboard?
+    abstract var keyboardView: MyKeyboardView?
+    abstract var lastShiftPressTS: Long
+    abstract var keyboardMode: Int
+    abstract var inputTypeClass: Int
+    abstract var enterKeyType: Int
+    abstract var switchToLetters: Boolean
+    abstract var hasTextBeforeCursor: Boolean
+    abstract var binding: KeyboardViewCommandOptionsBinding
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
@@ -87,89 +75,7 @@ abstract class SimpleKeyboardIME :
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
-        updateUI()
-        return keyboardHolder
-    }
-
-    private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
-        binding.scribeKey.setOnClickListener {
-            currentState = ScribeState.SELECT_COMMAND
-            binding.scribeKey.foreground = getDrawable(R.drawable.close)
-            updateUI()
-        }
-    }
-
-    private fun setupSelectCommandView() {
-        binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
-        binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
-        binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
-        binding.translateBtn.text = "Translate"
-        binding.conjugateBtn.text = "Conjugate"
-        binding.pluralBtn.text = "Plural"
-        binding.scribeKey.setOnClickListener {
-            currentState = ScribeState.IDLE
-            binding.scribeKey.foreground = getDrawable(R.drawable.ic_scribe_icon_vector)
-            updateUI()
-        }
-        binding.translateBtn.setOnClickListener {
-            currentState = ScribeState.TRANSLATE
-            commandText.clear()
-            updateUI()
-        }
-        binding.conjugateBtn.setOnClickListener {
-            currentState = ScribeState.CONJUGATE
-            commandText.clear()
-            updateUI()
-        }
-        binding.pluralBtn.setOnClickListener {
-            currentState = ScribeState.PLURAL
-            commandText.clear()
-            updateUI()
-        }
-    }
-
-    private fun switchToToolBar() {
-        val keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
-        this.keyboardBinding = keyboardBinding
-        val keyboardHolder = keyboardBinding.root
-        keyboardView = keyboardBinding.keyboardView
-        keyboardView!!.setKeyboard(keyboard!!)
-        keyboardView!!.mOnKeyboardActionListener = this
-        keyboardBinding.scribeKey.setOnClickListener {
-            currentState = ScribeState.IDLE
-            switchToCommandToolBar()
-            updateUI()
-        }
-        setInputView(keyboardHolder)
-    }
-
-    private fun switchToCommandToolBar() {
-        val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
-        this.binding = binding
-        val keyboardHolder = binding.root
-        keyboardView = binding.keyboardView
-        keyboardView!!.setKeyboard(keyboard!!)
-        keyboardView!!.mOnKeyboardActionListener = this
-        keyboardBinding.scribeKey.setOnClickListener {
-            currentState = ScribeState.IDLE
-            setupSelectCommandView()
-            updateUI()
-        }
-        setInputView(keyboardHolder)
-    }
-
-    private fun updateUI() {
-        when (currentState) {
-            ScribeState.IDLE -> setupIdleView()
-            ScribeState.SELECT_COMMAND -> setupSelectCommandView()
-            else -> switchToToolBar()
-        }
+        return keyboardHolder!!
     }
 
     override fun onPress(primaryCode: Int) {
@@ -191,11 +97,11 @@ abstract class SimpleKeyboardIME :
         val keyboardXml =
             when (inputTypeClass) {
                 TYPE_CLASS_NUMBER, TYPE_CLASS_DATETIME, TYPE_CLASS_PHONE -> {
-                    keyboardMode = Companion.KEYBOARD_SYMBOLS
+                    keyboardMode = keyboardSymbols
                     R.xml.keys_symbols
                 }
                 else -> {
-                    keyboardMode = Companion.KEYBOARD_LETTERS
+                    keyboardMode = keyboardLetters
                     getKeyboardLayoutXML()
                 }
             }
@@ -205,8 +111,8 @@ abstract class SimpleKeyboardIME :
         updateShiftKeyState()
     }
 
-    private fun updateShiftKeyState() {
-        if (keyboardMode == Companion.KEYBOARD_LETTERS) {
+    fun updateShiftKeyState() {
+        if (keyboardMode == keyboardLetters) {
             val editorInfo = currentInputEditorInfo
             if (editorInfo != null && editorInfo.inputType != InputType.TYPE_NULL && keyboard?.mShiftState != SHIFT_ON_PERMANENT) {
                 if (currentInputConnection.getCursorCapsMode(editorInfo.inputType) != 0) {
@@ -217,108 +123,9 @@ abstract class SimpleKeyboardIME :
         }
     }
 
-    override fun onKey(code: Int) {
-        val inputConnection = currentInputConnection
-        if (keyboard == null || inputConnection == null) {
-            return
-        }
-
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
-            lastShiftPressTS = 0
-        }
-
-        when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
-                if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR) {
-                    keyboard!!.mShiftState = SHIFT_OFF
-                }
-
-                val selectedText = inputConnection.getSelectedText(0)
-                if (TextUtils.isEmpty(selectedText)) {
-                    inputConnection.deleteSurroundingText(1, 0)
-                } else {
-                    inputConnection.commitText("", 1)
-                }
-                keyboardView!!.invalidateAllKeys()
-            }
-            MyKeyboard.KEYCODE_SHIFT -> {
-                if (keyboardMode == Companion.KEYBOARD_LETTERS) {
-                    when {
-                        keyboard!!.mShiftState == SHIFT_ON_PERMANENT -> keyboard!!.mShiftState = SHIFT_OFF
-                        System.currentTimeMillis() - lastShiftPressTS < Companion.SHIFT_PERM_TOGGLE_SPEED -> keyboard!!.mShiftState = SHIFT_ON_PERMANENT
-                        keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR -> keyboard!!.mShiftState = SHIFT_OFF
-                        keyboard!!.mShiftState == SHIFT_OFF -> keyboard!!.mShiftState = SHIFT_ON_ONE_CHAR
-                    }
-
-                    lastShiftPressTS = System.currentTimeMillis()
-                } else {
-                    val keyboardXml =
-                        if (keyboardMode == Companion.KEYBOARD_SYMBOLS) {
-                            keyboardMode = Companion.KEYBOARD_SYMBOLS_SHIFT
-                            R.xml.keys_symbols_shift
-                        } else {
-                            keyboardMode = Companion.KEYBOARD_SYMBOLS
-                            R.xml.keys_symbols
-                        }
-                    keyboard = MyKeyboard(this, keyboardXml, enterKeyType)
-                    keyboardView!!.setKeyboard(keyboard!!)
-                }
-                keyboardView!!.invalidateAllKeys()
-            }
-            MyKeyboard.KEYCODE_ENTER -> {
-                val imeOptionsActionId = getImeOptionsActionId()
-                if (imeOptionsActionId != IME_ACTION_NONE) {
-                    inputConnection.performEditorAction(imeOptionsActionId)
-                } else {
-                    inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
-                    inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
-                }
-            }
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
-                val keyboardXml =
-                    if (keyboardMode == Companion.KEYBOARD_LETTERS) {
-                        keyboardMode = Companion.KEYBOARD_SYMBOLS
-                        R.xml.keys_symbols
-                    } else {
-                        keyboardMode = Companion.KEYBOARD_LETTERS
-                        getKeyboardLayoutXML()
-                    }
-                keyboard = MyKeyboard(this, keyboardXml, enterKeyType)
-                keyboardView!!.setKeyboard(keyboard!!)
-            }
-            else -> {
-                var codeChar = code.toChar()
-                if (Character.isLetter(codeChar) && keyboard!!.mShiftState > SHIFT_OFF) {
-                    codeChar = Character.toUpperCase(codeChar)
-                }
-
-                // If the keyboard is set to symbols and the user presses space, we usually should switch back to the letters keyboard.
-                // However, avoid doing that in cases when the EditText for example requires numbers as the input.
-                // We can detect that by the text not changing on pressing Space.
-                if (keyboardMode != Companion.KEYBOARD_LETTERS && code == MyKeyboard.KEYCODE_SPACE) {
-                    val originalText = inputConnection.getExtractedText(ExtractedTextRequest(), 0).text
-                    inputConnection.commitText(codeChar.toString(), 1)
-                    val newText = inputConnection.getExtractedText(ExtractedTextRequest(), 0).text
-                    switchToLetters = originalText != newText
-                } else {
-                    inputConnection.commitText(codeChar.toString(), 1)
-                }
-
-                if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR && keyboardMode == Companion.KEYBOARD_LETTERS) {
-                    keyboard!!.mShiftState = SHIFT_OFF
-                    keyboardView!!.invalidateAllKeys()
-                }
-            }
-        }
-
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
-            updateShiftKeyState()
-        }
-    }
-
     override fun onActionUp() {
         if (switchToLetters) {
-            keyboardMode = Companion.KEYBOARD_LETTERS
+            keyboardMode = keyboardLetters
             keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
 
             val editorInfo = currentInputEditorInfo
@@ -365,10 +172,103 @@ abstract class SimpleKeyboardIME :
             currentInputEditorInfo.imeOptions and IME_MASK_ACTION
         }
 
-    companion object {
-        private const val SHIFT_PERM_TOGGLE_SPEED = 500 // how quickly do we have to doubletap shift to enable permanent caps lock
-        private const val KEYBOARD_LETTERS = 0
-        private const val KEYBOARD_SYMBOLS = 1
-        private const val KEYBOARD_SYMBOLS_SHIFT = 2
+    fun handleKeycodeEnter() {
+        val inputConnection = currentInputConnection
+        val imeOptionsActionId = getImeOptionsActionId()
+        if (imeOptionsActionId != IME_ACTION_NONE) {
+            inputConnection.performEditorAction(imeOptionsActionId)
+        } else {
+            inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+            inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
+        }
+    }
+
+    fun handleModeChange(
+        keyboardMode: Int,
+        keyboardView: MyKeyboardView?,
+        context: Context,
+    ) {
+        val keyboardXml =
+            if (keyboardMode == keyboardLetters) {
+                this.keyboardMode = keyboardSymbols
+                R.xml.keys_symbols
+            } else {
+                this.keyboardMode = keyboardLetters
+                getKeyboardLayoutXML()
+            }
+        keyboard = MyKeyboard(context, keyboardXml, enterKeyType)
+        keyboardView?.invalidateAllKeys()
+        keyboardView?.setKeyboard(keyboard!!)
+    }
+
+    fun handleKeyboardLetters(
+        keyboardMode: Int,
+        keyboardView: MyKeyboardView?,
+        context: Context,
+    ) {
+        if (keyboardMode == keyboardLetters) {
+            when {
+                keyboard!!.mShiftState == SHIFT_ON_PERMANENT -> keyboard!!.mShiftState = SHIFT_OFF
+                System.currentTimeMillis() - lastShiftPressTS < shiftPermToggleSpeed -> keyboard!!.mShiftState = SHIFT_ON_PERMANENT
+                keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR -> keyboard!!.mShiftState = SHIFT_OFF
+                keyboard!!.mShiftState == SHIFT_OFF -> keyboard!!.mShiftState = SHIFT_ON_ONE_CHAR
+            }
+
+            lastShiftPressTS = System.currentTimeMillis()
+        } else {
+            val keyboardXml =
+                if (keyboardMode == keyboardSymbols) {
+                    this.keyboardMode = keyboardSymbolShift
+                    R.xml.keys_symbols_shift
+                } else {
+                    this.keyboardMode = keyboardSymbols
+                    R.xml.keys_symbols
+                }
+            keyboard = MyKeyboard(this, keyboardXml, enterKeyType)
+            keyboardView!!.setKeyboard(keyboard!!)
+        }
+    }
+
+    fun handleDelete() {
+        val inputConnection = currentInputConnection
+        if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR) {
+            keyboard!!.mShiftState = SHIFT_OFF
+            Log.i("MY-TAG", "From English Keyboard IME")
+        }
+
+        val selectedText = inputConnection.getSelectedText(0)
+        if (TextUtils.isEmpty(selectedText)) {
+            inputConnection.deleteSurroundingText(1, 0)
+        } else {
+            inputConnection.commitText("", 1)
+        }
+    }
+
+    fun handleElseCondition(
+        code: Int,
+        keyboardMode: Int,
+    ) {
+        val inputConnection = currentInputConnection
+        var codeChar = code.toChar()
+        if (Character.isLetter(codeChar) && keyboard!!.mShiftState > SHIFT_OFF) {
+            codeChar = Character.toUpperCase(codeChar)
+        }
+
+        // If the keyboard is set to symbols and the user presses space, we usually should switch back to the letters keyboard.
+        // However, avoid doing that in cases when the EditText for example requires numbers as the input.
+        // We can detect that by the text not changing on pressing Space.
+        if (keyboardMode != keyboardLetters && code == MyKeyboard.KEYCODE_SPACE) {
+            val originalText = inputConnection.getExtractedText(ExtractedTextRequest(), 0).text
+            inputConnection.commitText(codeChar.toString(), 1)
+            val newText = inputConnection.getExtractedText(ExtractedTextRequest(), 0).text
+            switchToLetters = originalText != newText
+        } else {
+            inputConnection.commitText(codeChar.toString(), 1)
+        }
+
+        if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR && keyboardMode == keyboardLetters) {
+            keyboard!!.mShiftState = SHIFT_OFF
+            keyboardView!!.invalidateAllKeys()
+        }
     }
 }

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -1,6 +1,7 @@
 package be.scri.services
 
 import android.content.Context
+import android.text.InputType
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
@@ -8,7 +9,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SpanishKeyboardIME : SimpleKeyboardIME() {
@@ -30,10 +30,19 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
     private var currentState: ScribeState = ScribeState.IDLE
     private lateinit var keyboardBinding: KeyboardViewKeyboardBinding
     private lateinit var commandBinding: KeyboardViewCommandOptionsBinding
-    private lateinit var binding: KeyboardViewCommandOptionsBinding
-    private var keyboardView: MyKeyboardView? = null
-    private var keyboard: MyKeyboard? = null
-    private var enterKeyType = IME_ACTION_NONE
+    override lateinit var binding: KeyboardViewCommandOptionsBinding
+    override var keyboardView: MyKeyboardView? = null
+    override var keyboard: MyKeyboard? = null
+    override var enterKeyType = IME_ACTION_NONE
+    override var shiftPermToggleSpeed = 500
+    override val keyboardLetters = 0
+    override val keyboardSymbols = 1
+    override val keyboardSymbolShift = 2
+    override var lastShiftPressTS = 0L
+    override var keyboardMode = keyboardLetters
+    override var inputTypeClass = InputType.TYPE_CLASS_TEXT
+    override var switchToLetters = false
+    override var hasTextBeforeCursor = false
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
@@ -77,6 +86,41 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
             Log.i("MY-TAG", "SELECT COMMAND STATE")
             binding.scribeKey.foreground = getDrawable(R.drawable.close)
             updateUI()
+        }
+    }
+
+    override fun onKey(code: Int) {
+        val inputConnection = currentInputConnection
+        if (keyboard == null || inputConnection == null) {
+            return
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            lastShiftPressTS = 0
+        }
+
+        when (code) {
+            MyKeyboard.KEYCODE_DELETE -> {
+                super.handleDelete()
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_SHIFT -> {
+                super.handleKeyboardLetters(keyboardMode, keyboardView, this)
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_ENTER -> {
+                super.handleKeycodeEnter()
+            }
+            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+                handleModeChange(keyboardMode, keyboardView, this)
+            }
+            else -> {
+                super.handleElseCondition(code, keyboardMode)
+            }
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            super.updateShiftKeyState()
         }
     }
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -1,6 +1,7 @@
 package be.scri.services
 
 import android.content.Context
+import android.text.InputType
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
@@ -8,7 +9,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SwedishKeyboardIME : SimpleKeyboardIME() {
@@ -30,10 +30,19 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
     private var currentState: ScribeState = ScribeState.IDLE
     private lateinit var keyboardBinding: KeyboardViewKeyboardBinding
     private lateinit var commandBinding: KeyboardViewCommandOptionsBinding
-    private lateinit var binding: KeyboardViewCommandOptionsBinding
-    private var keyboardView: MyKeyboardView? = null
-    private var keyboard: MyKeyboard? = null
-    private var enterKeyType = IME_ACTION_NONE
+    override lateinit var binding: KeyboardViewCommandOptionsBinding
+    override var keyboardView: MyKeyboardView? = null
+    override var keyboard: MyKeyboard? = null
+    override var enterKeyType = IME_ACTION_NONE
+    override var shiftPermToggleSpeed = 500
+    override val keyboardLetters = 0
+    override val keyboardSymbols = 1
+    override val keyboardSymbolShift = 2
+    override var lastShiftPressTS = 0L
+    override var keyboardMode = keyboardLetters
+    override var inputTypeClass = InputType.TYPE_CLASS_TEXT
+    override var switchToLetters = false
+    override var hasTextBeforeCursor = false
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
@@ -50,6 +59,41 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
             val inputConnection = currentInputConnection ?: return
             inputConnection.deleteSurroundingText(1, 0)
             inputConnection.commitText(". ", 1)
+        }
+    }
+
+    override fun onKey(code: Int) {
+        val inputConnection = currentInputConnection
+        if (keyboard == null || inputConnection == null) {
+            return
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            lastShiftPressTS = 0
+        }
+
+        when (code) {
+            MyKeyboard.KEYCODE_DELETE -> {
+                super.handleDelete()
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_SHIFT -> {
+                super.handleKeyboardLetters(keyboardMode, keyboardView, this)
+                keyboardView!!.invalidateAllKeys()
+            }
+            MyKeyboard.KEYCODE_ENTER -> {
+                super.handleKeycodeEnter()
+            }
+            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+                handleModeChange(keyboardMode, keyboardView, this)
+            }
+            else -> {
+                super.handleElseCondition(code, keyboardMode)
+            }
+        }
+
+        if (code != MyKeyboard.KEYCODE_SHIFT) {
+            super.updateShiftKeyState()
         }
     }
 

--- a/app/src/main/res/xml/keys_letters_german.xml
+++ b/app/src/main/res/xml/keys_letters_german.xml
@@ -119,9 +119,6 @@
         Not having these causes the ?123 key to instead trigger a space instead of switching the view.
         -->
         <Key
-            app:keyLabel=""
-            app:keyWidth="0%p" />
-        <Key
             app:horizontalGap="3.325%"
             app:keyLabel="y"
             app:keyWidth="9.05%p" />
@@ -145,9 +142,6 @@
         <Key
             app:keyLabel="m"
             app:keyWidth="9.05%p" />
-        <Key
-            app:keyLabel=""
-            app:keyWidth="0%p" />
         <Key
             app:code="-5"
             app:horizontalGap="3.325%"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.5.2")
+        classpath("com.android.tools.build:gradle:8.6.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:12.1.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,5 @@ android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx4g -Xms1g -XX:MaxPermSize=1g
+org.gradle.jvmargs=-Xmx4g -Xms1g
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4g -Xms1g -XX:MaxPermSize=1g


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

- This pull request addresses a critical issue where the keyboard would crash either when the delete key was used or when switching to the numbers view. The  problem was that translate method and the various ScribeStates changing the toolbar. Specifically, the abstract class code responsible for managing these interactions was  causing a NullPointerException. For fixing it I have made the function for changing in the individual language keyboards and the individual implementation of the functions for changing in the abstract class. 
- I have also upgraded the Gradle to 8.6.0 



### Related issue
-   #123 
