### PR TITLE
fix:Corrected the keyboard color and keys colors based on condtions

### DIFF
--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -57,6 +57,10 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -76,7 +80,7 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         when (currentState) {
-            ScribeState.IDLE -> keyboardView!!.setEnterKeyColor(0)
+            ScribeState.IDLE -> keyboardView!!.setEnterKeyColor(null)
             else -> keyboardView!!.setEnterKeyColor(R.color.dark_scribe_blue)
         }
 
@@ -94,18 +98,24 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
 
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE FROM English IME")
@@ -126,7 +136,6 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")
             binding.scribeKey.foreground = getDrawable(R.drawable.ic_scribe_icon_vector)
-
             updateUI()
         }
         binding.translateBtn.setOnClickListener {
@@ -146,10 +155,10 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
         }
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -194,6 +203,16 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
         this.keyboardBinding = keyboardBinding
         val keyboardHolder = keyboardBinding.root
         super.setupToolBarTheme(keyboardBinding)
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(R.color.special_key_dark))
+            }
+            false -> {
+                keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(R.color.special_key_light))
+            }
+        }
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -230,11 +249,13 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun updateUI() {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -1,14 +1,17 @@
 package be.scri.services
 
 import android.content.Context
+import android.graphics.Color
 import android.text.InputType
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class FrenchKeyboardIME : SimpleKeyboardIME() {
@@ -61,6 +64,14 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         }
     }
 
+    override fun onStartInputView(
+        editorInfo: EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(editorInfo, restarting)
+        setupCommandBarTheme(binding)
+    }
+
     override fun onKey(code: Int) {
         val inputConnection = currentInputConnection
         if (keyboard == null || inputConnection == null) {
@@ -102,6 +113,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         Log.i("MY-TAG", "From French Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
         updateUI()
@@ -109,9 +121,22 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+            else -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = ""
         binding.conjugateBtn.text = ""
         binding.pluralBtn.text = ""
@@ -127,6 +152,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
@@ -159,6 +185,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        super.setupToolBarTheme(keyboardBinding)
         keyboardView!!.mOnKeyboardActionListener = this
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
@@ -172,6 +199,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
         this.binding = binding
         val keyboardHolder = binding.root
+        setupCommandBarTheme(binding)
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -183,11 +211,27 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    private fun updateEnterKeyColor() {
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateUI() {
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
+        updateEnterKeyColor()
     }
 }

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -11,7 +11,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class FrenchKeyboardIME : SimpleKeyboardIME() {
@@ -68,6 +67,10 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -128,18 +131,24 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
 
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -211,10 +220,10 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -232,6 +241,8 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -11,7 +11,6 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class GermanKeyboardIME : SimpleKeyboardIME() {
@@ -55,6 +54,10 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -93,18 +96,24 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
 
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -211,10 +220,10 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -232,6 +241,8 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -1,14 +1,17 @@
 package be.scri.services
 
 import android.content.Context
+import android.graphics.Color
 import android.text.InputType
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class GermanKeyboardIME : SimpleKeyboardIME() {
@@ -48,6 +51,14 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
     }
 
+    override fun onStartInputView(
+        editorInfo: EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(editorInfo, restarting)
+        setupCommandBarTheme(binding)
+    }
+
     private fun shouldCommitPeriodAfterSpace(language: String): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         return sharedPref.getBoolean("period_on_double_tap_$language", false)
@@ -67,6 +78,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         Log.i("MY-TAG", "From German Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
         updateUI()
@@ -74,9 +86,22 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+            else -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = ""
         binding.conjugateBtn.text = ""
         binding.pluralBtn.text = ""
@@ -127,6 +152,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
@@ -159,6 +185,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        super.setupToolBarTheme(keyboardBinding)
         keyboardView!!.mOnKeyboardActionListener = this
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
@@ -172,6 +199,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
         this.binding = binding
         val keyboardHolder = binding.root
+        setupCommandBarTheme(binding)
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -183,11 +211,27 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    private fun updateEnterKeyColor() {
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateUI() {
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
+        updateEnterKeyColor()
     }
 }

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -55,6 +55,10 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -93,18 +97,24 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
 
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -211,10 +221,10 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -232,6 +242,8 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -1,14 +1,17 @@
 package be.scri.services
 
 import android.content.Context
+import android.graphics.Color
 import android.text.InputType
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class ItalianKeyboardIME : SimpleKeyboardIME() {
@@ -48,6 +51,14 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
     }
 
+    override fun onStartInputView(
+        editorInfo: EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(editorInfo, restarting)
+        setupCommandBarTheme(binding)
+    }
+
     private fun shouldCommitPeriodAfterSpace(language: String): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         return sharedPref.getBoolean("period_on_double_tap_$language", false)
@@ -68,15 +79,29 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
+        setupCommandBarTheme(binding)
         keyboardView!!.mOnKeyboardActionListener = this
         updateUI()
         return keyboardHolder
     }
 
     private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+            else -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = ""
         binding.conjugateBtn.text = ""
         binding.pluralBtn.text = ""
@@ -127,6 +152,7 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
@@ -159,6 +185,7 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        super.setupToolBarTheme(keyboardBinding)
         keyboardView!!.mOnKeyboardActionListener = this
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
@@ -172,6 +199,7 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
         this.binding = binding
         val keyboardHolder = binding.root
+        setupCommandBarTheme(binding)
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -183,11 +211,27 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    private fun updateEnterKeyColor() {
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateUI() {
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
+        updateEnterKeyColor()
     }
 }

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -60,6 +60,10 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -93,18 +97,24 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
 
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -211,10 +221,10 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -232,6 +242,8 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -1,14 +1,17 @@
 package be.scri.services
 
 import android.content.Context
+import android.graphics.Color
 import android.text.InputType
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class PortugueseKeyboardIME : SimpleKeyboardIME() {
@@ -53,6 +56,14 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         return sharedPref.getBoolean("period_on_double_tap_$language", false)
     }
 
+    override fun onStartInputView(
+        editorInfo: EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(editorInfo, restarting)
+        setupCommandBarTheme(binding)
+    }
+
     override fun commitPeriodAfterSpace() {
         if (shouldCommitPeriodAfterSpace("Portuguese")) {
             val inputConnection = currentInputConnection ?: return
@@ -67,6 +78,7 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         Log.i("MY-TAG", "From Portuguese Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
         updateUI()
@@ -74,9 +86,22 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+            else -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = ""
         binding.conjugateBtn.text = ""
         binding.pluralBtn.text = ""
@@ -92,6 +117,7 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
@@ -159,6 +185,7 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        super.setupToolBarTheme(keyboardBinding)
         keyboardView!!.mOnKeyboardActionListener = this
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
@@ -172,6 +199,7 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
         this.binding = binding
         val keyboardHolder = binding.root
+        setupCommandBarTheme(binding)
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -183,11 +211,27 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    private fun updateEnterKeyColor() {
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateUI() {
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
+        updateEnterKeyColor()
     }
 }

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -55,6 +55,10 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -93,18 +97,23 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
-
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -211,10 +220,10 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -232,6 +241,8 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -1,14 +1,17 @@
 package be.scri.services
 
 import android.content.Context
+import android.graphics.Color
 import android.text.InputType
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class RussianKeyboardIME : SimpleKeyboardIME() {
@@ -48,6 +51,14 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
     }
 
+    override fun onStartInputView(
+        editorInfo: EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(editorInfo, restarting)
+        setupCommandBarTheme(binding)
+    }
+
     private fun shouldCommitPeriodAfterSpace(language: String): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         return sharedPref.getBoolean("period_on_double_tap_$language", false)
@@ -67,6 +78,7 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         Log.i("MY-TAG", "From Russian Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
         updateUI()
@@ -74,9 +86,22 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+            else -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = ""
         binding.conjugateBtn.text = ""
         binding.pluralBtn.text = ""
@@ -127,6 +152,7 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
@@ -159,6 +185,7 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        super.setupToolBarTheme(keyboardBinding)
         keyboardView!!.mOnKeyboardActionListener = this
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
@@ -172,6 +199,7 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
         this.binding = binding
         val keyboardHolder = binding.root
+        setupCommandBarTheme(binding)
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -183,11 +211,27 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    private fun updateEnterKeyColor() {
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateUI() {
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
+        updateEnterKeyColor()
     }
 }

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -18,12 +18,12 @@ import android.view.inputmethod.EditorInfo.IME_MASK_ACTION
 import android.view.inputmethod.ExtractedTextRequest
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
+import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
 import be.scri.helpers.SHIFT_ON_PERMANENT
 import be.scri.views.MyKeyboardView
-
 // based on https://www.androidauthority.com/lets-build-custom-keyboard-android-832362/
 
 abstract class SimpleKeyboardIME :
@@ -75,7 +75,7 @@ abstract class SimpleKeyboardIME :
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
-        return keyboardHolder!!
+        return keyboardHolder
     }
 
     override fun onPress(primaryCode: Int) {
@@ -89,6 +89,7 @@ abstract class SimpleKeyboardIME :
         restarting: Boolean,
     ) {
         super.onStartInput(attribute, restarting)
+
         inputTypeClass = attribute!!.inputType and TYPE_MASK_CLASS
         enterKeyType = attribute.imeOptions and (IME_MASK_ACTION or IME_FLAG_NO_ENTER_ACTION)
         val inputConnection = currentInputConnection
@@ -108,7 +109,6 @@ abstract class SimpleKeyboardIME :
 
         keyboard = MyKeyboard(this, keyboardXml, enterKeyType)
         keyboardView?.setKeyboard(keyboard!!)
-        updateShiftKeyState()
     }
 
     fun updateShiftKeyState() {
@@ -168,8 +168,10 @@ abstract class SimpleKeyboardIME :
     private fun getImeOptionsActionId(): Int =
         if (currentInputEditorInfo.imeOptions and IME_FLAG_NO_ENTER_ACTION != 0) {
             IME_ACTION_NONE
+            Log.i("MYT-TAG", "Hello from ime")
         } else {
             currentInputEditorInfo.imeOptions and IME_MASK_ACTION
+            Log.i("MYT-TAG", "Hello from ime")
         }
 
     fun handleKeycodeEnter() {
@@ -233,7 +235,6 @@ abstract class SimpleKeyboardIME :
         val inputConnection = currentInputConnection
         if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR) {
             keyboard!!.mShiftState = SHIFT_OFF
-            Log.i("MY-TAG", "From English Keyboard IME")
         }
 
         val selectedText = inputConnection.getSelectedText(0)
@@ -269,6 +270,32 @@ abstract class SimpleKeyboardIME :
         if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR && keyboardMode == keyboardLetters) {
             keyboard!!.mShiftState = SHIFT_OFF
             keyboardView!!.invalidateAllKeys()
+        }
+    }
+
+    fun setupToolBarTheme(binding: KeyboardViewKeyboardBinding) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.commandField.setBackgroundColor(getColor(R.color.md_grey_black_dark))
+            }
+            else -> {
+                binding.commandField.setBackgroundColor(getColor(R.color.light_cmd_bar_border_color))
+            }
+        }
+    }
+
+    fun setupCommandBarTheme(binding: KeyboardViewCommandOptionsBinding) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.commandField.setBackgroundColor(getColor(R.color.md_grey_black_dark))
+            }
+            else -> {
+                binding.commandField.setBackgroundColor(getColor(R.color.light_cmd_bar_border_color))
+            }
         }
     }
 }

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -60,6 +60,10 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -93,18 +97,24 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
 
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -179,10 +189,10 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         }
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -232,6 +242,8 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -1,14 +1,17 @@
 package be.scri.services
 
 import android.content.Context
+import android.graphics.Color
 import android.text.InputType
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SpanishKeyboardIME : SimpleKeyboardIME() {
@@ -53,6 +56,14 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         return sharedPref.getBoolean("period_on_double_tap_$language", false)
     }
 
+    override fun onStartInputView(
+        editorInfo: EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(editorInfo, restarting)
+        setupCommandBarTheme(binding)
+    }
+
     override fun commitPeriodAfterSpace() {
         if (shouldCommitPeriodAfterSpace("Spanish")) {
             val inputConnection = currentInputConnection ?: return
@@ -67,6 +78,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         Log.i("MY-TAG", "From Spanish Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
         updateUI()
@@ -74,9 +86,22 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+            else -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = ""
         binding.conjugateBtn.text = ""
         binding.pluralBtn.text = ""
@@ -127,6 +152,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
@@ -153,11 +179,20 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         }
     }
 
+    private fun updateEnterKeyColor() {
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+        }
+    }
+
     private fun switchToToolBar() {
         val keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
         this.keyboardBinding = keyboardBinding
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
+        super.setupToolBarTheme(keyboardBinding)
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
         keyboardBinding.scribeKey.setOnClickListener {
@@ -172,6 +207,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
         this.binding = binding
         val keyboardHolder = binding.root
+        setupCommandBarTheme(binding)
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -183,11 +219,19 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    override fun onCreate() {
+        super.onCreate()
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateUI() {
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
+        updateEnterKeyColor()
     }
 }

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -1,14 +1,17 @@
 package be.scri.services
 
 import android.content.Context
+import android.graphics.Color
 import android.text.InputType
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SwedishKeyboardIME : SimpleKeyboardIME() {
@@ -51,6 +54,14 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
     private fun shouldCommitPeriodAfterSpace(language: String): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         return sharedPref.getBoolean("period_on_double_tap_$language", false)
+    }
+
+    override fun onStartInputView(
+        editorInfo: EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(editorInfo, restarting)
+        setupCommandBarTheme(binding)
     }
 
     override fun commitPeriodAfterSpace() {
@@ -102,6 +113,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         Log.i("MY-TAG", "From Swedish Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder(binding.keyboardHolder)
         keyboardView!!.mOnKeyboardActionListener = this
         updateUI()
@@ -109,9 +121,22 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun setupIdleView() {
-        binding.translateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.conjugateBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
-        binding.pluralBtn.setBackgroundColor(getColor(R.color.you_keyboard_background_color))
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        when (isUserDarkMode) {
+            true -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+            else -> {
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = ""
         binding.conjugateBtn.text = ""
         binding.pluralBtn.text = ""
@@ -127,6 +152,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.conjugateBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
         binding.pluralBtn.setBackgroundDrawable(getDrawable(R.drawable.button_background_rounded))
+        setupCommandBarTheme(binding)
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
@@ -158,6 +184,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         this.keyboardBinding = keyboardBinding
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
+        super.setupToolBarTheme(keyboardBinding)
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
         keyboardBinding.scribeKey.setOnClickListener {
@@ -168,10 +195,19 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    private fun updateEnterKeyColor() {
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+        }
+    }
+
     private fun switchToCommandToolBar() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
         this.binding = binding
         val keyboardHolder = binding.root
+        setupCommandBarTheme(binding)
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
@@ -183,11 +219,19 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
+    override fun onCreate() {
+        super.onCreate()
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateUI() {
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
+        updateEnterKeyColor()
     }
 }

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -60,6 +60,10 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         editorInfo: EditorInfo?,
         restarting: Boolean,
     ) {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
+        setupIdleView()
         super.onStartInputView(editorInfo, restarting)
         setupCommandBarTheme(binding)
     }
@@ -128,18 +132,23 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.WHITE)
+                binding.conjugateBtn.setTextColor(Color.WHITE)
+                binding.pluralBtn.setTextColor(Color.WHITE)
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
                 binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
+                binding.translateBtn.setTextColor(Color.BLACK)
+                binding.conjugateBtn.setTextColor(Color.BLACK)
+                binding.pluralBtn.setTextColor(Color.BLACK)
             }
         }
-
         setupCommandBarTheme(binding)
-        binding.translateBtn.text = ""
-        binding.conjugateBtn.text = ""
-        binding.pluralBtn.text = ""
+        binding.translateBtn.text = "Suggestion"
+        binding.conjugateBtn.text = "Suggestion"
+        binding.pluralBtn.text = "Suggestion"
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -195,10 +204,10 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         setInputView(keyboardHolder)
     }
 
-    private fun updateEnterKeyColor() {
+    private fun updateEnterKeyColor(isDarkMode: Boolean? = null) {
         when (currentState) {
-            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
-            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(Color.TRANSPARENT)
+            ScribeState.IDLE -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
+            ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
     }
@@ -232,6 +241,8 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        updateEnterKeyColor()
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
+        updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/views/MyKeyboardView.kt
+++ b/app/src/main/java/be/scri/views/MyKeyboardView.kt
@@ -198,6 +198,17 @@ class MyKeyboardView
 
         private var mKeyboardBackgroundColor = 0
 
+        val alpha = 255
+        private val redDark = (0.180 * 255).toInt()
+        private val greenDark = (0.180 * 255).toInt()
+        private val blueDark = (0.180 * 255).toInt()
+        private val darkSpecialKey = Color.argb(alpha, redDark, greenDark, blueDark)
+
+        private val red = (0.682 * 255).toInt()
+        private val green = (0.702 * 255).toInt()
+        private val blue = (0.745 * 255).toInt()
+        private val lightSpecialKey = Color.argb(alpha, red, green, blue)
+
         companion object {
             private const val NOT_A_KEY = -1
             private val LONG_PRESSABLE_STATE_SET = intArrayOf(R.attr.state_long_pressable)
@@ -229,9 +240,25 @@ class MyKeyboardView
                 return _popupBinding!!
             }
 
-        fun setEnterKeyColor(color: Int) {
-            mEnterKeyColor = color
-            invalidateAllKeys()
+        fun setEnterKeyColor(
+            color: Int? = null,
+            isDarkMode: Boolean? = null,
+        ) {
+            if (color != null) {
+                mEnterKeyColor = color
+                invalidateAllKeys()
+            } else {
+                when (isDarkMode) {
+                    true -> {
+                        mEnterKeyColor = darkSpecialKey
+                        invalidateAllKeys()
+                    }
+                    else -> {
+                        mEnterKeyColor = lightSpecialKey
+                        invalidateAllKeys()
+                    }
+                }
+            }
         }
 
         private var _keyboardBinding: KeyboardViewKeyboardBinding? = null
@@ -604,6 +631,8 @@ class MyKeyboardView
                 val label = adjustCase(key.label)?.toString()
 
                 if (key.focused || code == KEYCODE_ENTER) {
+                    keyBackgroundPaint.color = Color.DKGRAY
+                    canvas.drawRoundRect(keyRect, rectRadius, rectRadius, keyBackgroundPaint)
                     keyBackgroundPaint.color = mEnterKeyColor
                     canvas.drawRoundRect(keyRect, rectRadius, rectRadius, keyBackgroundPaint)
                     keyBackgroundPaint.color = keyBackgroundColor

--- a/app/src/main/res/layout/keyboard_view_command_options.xml
+++ b/app/src/main/res/layout/keyboard_view_command_options.xml
@@ -11,8 +11,7 @@
         android:layout_above="@+id/keyboard_view"
         app:layout_constraintBottom_toTopOf="@+id/keyboard_view"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:background="@color/you_keyboard_background_color">
+        app:layout_constraintStart_toStartOf="parent">
 
         <Button
             android:id="@+id/scribe_key"
@@ -97,7 +96,6 @@
             app:layout_constraintHorizontal_weight="27"
             app:layout_constraintStart_toEndOf="@+id/separator_3"
             app:layout_constraintTop_toTopOf="@+id/command_field" />
-
 
 
         <ImageView

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -6,13 +6,14 @@
     <color name="nav_bar_color">#000</color>">
     <color name="nav_bar_focus_color">#FFF</color>
     <color name="nav_bar_selected_color">@color/you_background_color</color>
-    <color name = "you_border_color">#FFFFFFFF</color>
+    <color name="you_border_color">#FFFFFFFF</color>
     <color name="background_color">#235270</color>">
     <color name="text_color">#FFF</color>
     <color name="icon_color">#FFF</color>
-    <color name = "card_view_color">#000</color>
-    <color name = "menu_option_color">#878472</color>
-    <color name = "corner_polygon_color">@color/dark_tutorial_button_color</color>
+    <color name="card_view_color">#000</color>
+    <color name="menu_option_color">#878472</color>
+    <color name="corner_polygon_color">@color/dark_tutorial_button_color</color>
+
     <!-- Commons colors -->
     <color name="you_status_bar_color">@android:color/system_accent2_800</color>
     <color name="you_contextual_status_bar_color">@android:color/system_accent1_700</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,10 @@
     <color name="light_scribe_blue">#FF75CEFA</color>
     <color name="dark_scribe_blue">#FF4CADE6</color>
     <color name= "white">#ffffff</color>
+    <color name= "light_keyboard">#99FFFFFF</color>
+    <color name = "transparent">@android:color/transparent</color>
+    <color name="special_key_light">#B0B2BD</color>
+    <color name="special_key_dark">#2D2D2D</color>
 
 
     <!-- Light theme -->


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

- The pull request corrects the color of the toolbar and command icons and accordingly changes the color of the enter key when in other modes except idle mode. 

### Related issue

-   #121 
