### PR TITLE
Fix #116: Switch highlight color of tab bar

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name = "dark_scribe_color">#235270</color>
-    <color name = "light_scribe_color">#5EB5E8</color>
-    <color name = "dark_text_color">#FFF</color>
-    <color name ="light_text_color">#000</color>
-    <color name = "light_tutorial_button_color">#FDAD0D</color>
-    <color name = "dark_tutorial_button_color">#D17B0F</color>
-    <color name = "dark_icon_color">#fff</color>
-    <color name = "light_icon_color">#000</color>
+    <color name="dark_scribe_color">#5EB5E8</color>
+    <color name="light_scribe_color">#235270</color>
+    <color name="dark_text_color">#FFF</color>
+    <color name="light_text_color">#000</color>
+    <color name="light_tutorial_button_color">#FDAD0D</color>
+    <color name="dark_tutorial_button_color">#D17B0F</color>
+    <color name="dark_icon_color">#fff</color>
+    <color name="light_icon_color">#000</color>
     <color name="light_scribe_blue">#FF75CEFA</color>
     <color name="dark_scribe_blue">#FF4CADE6</color>
-    <color name= "white">#ffffff</color>
+    <color name="white">#ffffff</color>
 
 
     <!-- Light theme -->


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This pull request changes the highlight color of the tab bar options as described in issue #116. I switched the highlight color for light mode to the dark mode Scribe blue, and for dark mode to the light mode Scribe blue. I tested the changes in both light and dark modes, and they work as expected.

### Related issue

-   #116 