### PR TITLE
Implement switch text proxy to the command bar when shown 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     id("com.google.devtools.ksp") version "2.0.0-1.0.22" apply true
 }
-val kotlin_version by extra("2.0.0")
+val kotlinVersion by extra("2.0.0")
 
 android {
     compileSdk = 34

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -211,10 +211,8 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }
-                }
-
             }
-
+        }
 
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
@@ -222,7 +220,6 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun switchToToolBar() {
-
         this.keyboardBinding = initializeKeyboardBinding()
         val keyboardHolder = keyboardBinding.root
         super.setupToolBarTheme(keyboardBinding)
@@ -285,6 +282,7 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
         }
         updateEnterKeyColor(isUserDarkMode)
     }
+
     private fun initializeKeyboardBinding(): KeyboardViewKeyboardBinding {
         val keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
         return keyboardBinding

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -90,7 +90,11 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
 
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
-                super.handleDelete()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleDelete(false, keyboardBinding)
+                } else {
+                    handleDelete(true, keyboardBinding)
+                }
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_SHIFT -> {
@@ -98,13 +102,24 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_ENTER -> {
-                super.handleKeycodeEnter()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleKeycodeEnter(keyboardBinding, false)
+                } else {
+                    handleKeycodeEnter(keyboardBinding, true)
+                    currentState = ScribeState.IDLE
+                    switchToCommandToolBar()
+                    updateUI()
+                }
             }
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
             }
             else -> {
-                super.handleElseCondition(code, keyboardMode)
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, binding = null)
+                } else {
+                    handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                }
             }
         }
 

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -137,7 +137,11 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
 
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
-                super.handleDelete()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleDelete(false, keyboardBinding)
+                } else {
+                    handleDelete(true, keyboardBinding)
+                }
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_SHIFT -> {
@@ -145,13 +149,24 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_ENTER -> {
-                super.handleKeycodeEnter()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleKeycodeEnter(keyboardBinding, false)
+                } else {
+                    handleKeycodeEnter(keyboardBinding, true)
+                    currentState = ScribeState.IDLE
+                    switchToCommandToolBar()
+                    updateUI()
+                }
             }
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
             }
             else -> {
-                super.handleElseCondition(code, keyboardMode)
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, binding = null)
+                } else {
+                    handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                }
             }
         }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -140,7 +140,11 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
 
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
-                super.handleDelete()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleDelete(false, keyboardBinding)
+                } else {
+                    handleDelete(true, keyboardBinding)
+                }
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_SHIFT -> {
@@ -148,13 +152,24 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_ENTER -> {
-                super.handleKeycodeEnter()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleKeycodeEnter(keyboardBinding, false)
+                } else {
+                    handleKeycodeEnter(keyboardBinding, true)
+                    currentState = ScribeState.IDLE
+                    switchToCommandToolBar()
+                    updateUI()
+                }
             }
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
             }
             else -> {
-                super.handleElseCondition(code, keyboardMode)
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, binding = null)
+                } else {
+                    handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                }
             }
         }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -171,7 +171,11 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
 
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
-                super.handleDelete()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleDelete(false, keyboardBinding)
+                } else {
+                    handleDelete(true, keyboardBinding)
+                }
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_SHIFT -> {
@@ -179,13 +183,24 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_ENTER -> {
-                super.handleKeycodeEnter()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleKeycodeEnter(keyboardBinding, false)
+                } else {
+                    handleKeycodeEnter(keyboardBinding, true)
+                    currentState = ScribeState.IDLE
+                    switchToCommandToolBar()
+                    updateUI()
+                }
             }
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
             }
             else -> {
-                super.handleElseCondition(code, keyboardMode)
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, binding = null)
+                } else {
+                    handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                }
             }
         }
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -139,7 +139,11 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
 
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
-                super.handleDelete()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleDelete(false, keyboardBinding)
+                } else {
+                    handleDelete(true, keyboardBinding)
+                }
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_SHIFT -> {
@@ -147,13 +151,24 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_ENTER -> {
-                super.handleKeycodeEnter()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleKeycodeEnter(keyboardBinding, false)
+                } else {
+                    handleKeycodeEnter(keyboardBinding, true)
+                    currentState = ScribeState.IDLE
+                    switchToCommandToolBar()
+                    updateUI()
+                }
             }
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
             }
             else -> {
-                super.handleElseCondition(code, keyboardMode)
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, binding = null)
+                } else {
+                    handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                }
             }
         }
 

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -140,7 +140,11 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
 
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
-                super.handleDelete()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleDelete(false, keyboardBinding)
+                } else {
+                    handleDelete(true, keyboardBinding)
+                }
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_SHIFT -> {
@@ -148,13 +152,24 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_ENTER -> {
-                super.handleKeycodeEnter()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, binding = null)
+                } else {
+                    handleKeycodeEnter(keyboardBinding, true)
+                    currentState = ScribeState.IDLE
+                    switchToCommandToolBar()
+                    updateUI()
+                }
             }
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
             }
             else -> {
-                super.handleElseCondition(code, keyboardMode)
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, keyboardBinding)
+                } else {
+                    handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                }
             }
         }
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -91,7 +91,11 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
 
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
-                super.handleDelete()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleDelete(false, keyboardBinding)
+                } else {
+                    handleDelete(true, keyboardBinding)
+                }
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_SHIFT -> {
@@ -99,13 +103,24 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
                 keyboardView!!.invalidateAllKeys()
             }
             MyKeyboard.KEYCODE_ENTER -> {
-                super.handleKeycodeEnter()
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, binding = null)
+                } else {
+                    handleKeycodeEnter(keyboardBinding, true)
+                    currentState = ScribeState.IDLE
+                    switchToCommandToolBar()
+                    updateUI()
+                }
             }
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
             }
             else -> {
-                super.handleElseCondition(code, keyboardMode)
+                if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+                    handleElseCondition(code, keyboardMode, keyboardBinding)
+                } else {
+                    handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                }
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    val kotlin_version = "2.0.0"
+    val kotlinVersion = "2.0.0"
 
     repositories {
         google()
@@ -12,7 +12,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.6.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:12.1.1")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

The pull request implements switching the text proxy to the command bar when it is shown. In specific there is a switch for all states except the select command state and idle state.

### Related issue

-   #137 
