### PR TITLE
Growabeard fix darkmode coloration

### DIFF
--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -114,11 +114,12 @@
             android:alpha="0.9"
             android:src="@drawable/corner_polygon" />
         <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="26dp"
+            android:layout_height="25dp"
             android:layout_gravity="top|end"
             android:layout_margin="8dp"
-            android:src="@drawable/cog" />
+            android:src="@drawable/cog"
+            app:tint="@color/button_text_color" />
     </androidx.cardview.widget.CardView>
     <TextView
         android:id="@+id/textView2"
@@ -176,7 +177,7 @@
                 android:textSize="12sp" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:id="@+id/cardView3"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -185,8 +186,9 @@
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:background="@color/corner_polygon_color"
         app:cardBackgroundColor="@color/corner_polygon_color"
+        app:strokeColor="@color/button_outline_color"
+        app:strokeWidth="@dimen/tiny_margin"
         app:cardCornerRadius="20dp">
         <TextView
             android:layout_width="wrap_content"
@@ -195,6 +197,7 @@
             android:paddingVertical="20sp"
             android:text="@string/app.installation.button_quick_tutorial"
             android:textStyle="bold"
-            android:textSize="20sp" />
-    </androidx.cardview.widget.CardView>
+            android:textSize="20sp"
+            android:textColor="@color/button_text_color"/>
+    </com.google.android.material.card.MaterialCardView>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_privacy_policy.xml
+++ b/app/src/main/res/layout/fragment_privacy_policy.xml
@@ -66,6 +66,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="top|end"
                         android:layout_margin="8dp"
+                        app:tint="@color/button_text_color"
                         android:contentDescription="@string/app.about.legal.privacy_policy"
                         android:src="@drawable/shield_check" />
                 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_third_party.xml
+++ b/app/src/main/res/layout/fragment_third_party.xml
@@ -68,7 +68,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="top|end"
                         android:layout_margin="8dp"
-
+                        app:tint="@color/button_text_color"
                         android:contentDescription="@string/app.about.legal.third_party"
                         android:src="@drawable/doc" />
                 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_wikimedia_scribe.xml
+++ b/app/src/main/res/layout/fragment_wikimedia_scribe.xml
@@ -93,9 +93,9 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="top|end"
                         android:layout_margin="8dp"
-
                         android:contentDescription="@string/app.about.community.wikimedia"
-                        android:src="@drawable/wikimedia_logo_black" />
+                        android:src="@drawable/wikimedia_logo_black"
+                        app:tint="@color/button_text_color" />
                 </androidx.cardview.widget.CardView>
                 <View
                     android:layout_width="100dp"

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -13,6 +13,8 @@
     <color name="card_view_color">#000</color>
     <color name="menu_option_color">#878472</color>
     <color name="corner_polygon_color">@color/dark_tutorial_button_color</color>
+    <color name="button_outline_color">@color/dark_button_outline_color</color>
+    <color name="button_text_color">#D17B0F</color>
     <!-- Commons colors -->
     <color name="you_status_bar_color">@android:color/system_accent2_800</color>
     <color name="you_contextual_status_bar_color">@android:color/system_accent1_700</color>

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -13,6 +13,8 @@
     <color name="card_view_color">#FFF</color>
     <color name="menu_option_color">#878472</color>
     <color name="corner_polygon_color">@color/light_tutorial_button_color</color>
+    <color name="button_outline_color">@color/light_tutorial_button_color</color>
+    <color name="button_text_color">#000000</color>
 
     <!-- Commons colors -->
     <color name="you_status_bar_color">@android:color/system_accent2_50</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,7 +5,8 @@
     <color name="dark_text_color">#FFF</color>
     <color name="light_text_color">#000</color>
     <color name="light_tutorial_button_color">#FDAD0D</color>
-    <color name="dark_tutorial_button_color">#D17B0F</color>
+    <color name="dark_tutorial_button_color">#2A1903</color>
+    <color name="dark_button_outline_color">#D17B0F</color>"
     <color name="dark_icon_color">#fff</color>
     <color name="light_icon_color">#000</color>
     <color name="light_scribe_blue">#FF75CEFA</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar"/>
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge" />
 
     <style name="MyKeyboard">
         <item name="itemTextAppearance">?attr/itemTextAppearance</item>
@@ -40,7 +40,7 @@
         <item name="android:visibility">invisible</item>
     </style>
 
-    <style name="AppTheme.Base" parent="Theme.MaterialComponents">
+    <style name="AppTheme.Base" parent="Theme.MaterialComponents.DayNight.DarkActionBar.Bridge">
         <item name="colorPrimary">@color/color_primary</item>
         <item name="colorPrimaryDark">@color/color_primary_dark</item>
         <item name="colorAccent">@color/color_accent</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AppTheme" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar"/>
 
     <style name="MyKeyboard">
         <item name="itemTextAppearance">?attr/itemTextAppearance</item>
@@ -40,7 +40,7 @@
         <item name="android:visibility">invisible</item>
     </style>
 
-    <style name="AppTheme.Base" parent="Theme.AppCompat">
+    <style name="AppTheme.Base" parent="Theme.MaterialComponents">
         <item name="colorPrimary">@color/color_primary</item>
         <item name="colorPrimaryDark">@color/color_primary_dark</item>
         <item name="colorAccent">@color/color_accent</item>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR fixes dark mode coloring for the main screen button as well as corner polygons on a few screens according to the [figma design](https://www.figma.com/design/c8945w2iyoPYVhsqW7vRn6/scribe_public_designs?node-id=581-1539&t=wP5sMYaHXkKslhGE-4).

Apologies apparently the color coming across is not what I see in the app running on my phone.. It's the same as figma I assure you.
![scribe_privacy_policy](https://github.com/user-attachments/assets/448fd0f1-4bfa-4a8e-8b9d-1798da0708ff)
![scribe_licenses](https://github.com/user-attachments/assets/b7c9de3f-1727-4faf-b9d7-d700ed22477a)
![scribe_wikipedia](https://github.com/user-attachments/assets/2a8edee3-1c0f-4ef7-bb70-abe64ced3971)
![scribe_main](https://github.com/user-attachments/assets/b3bdb2ba-be45-4005-b577-e5e48dc34650)


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #164
