### PR TITLE
Implement disable and enable of  accent characters

### DIFF
--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -100,39 +100,44 @@ class LanguageSettingsFragment : Fragment() {
     private fun setupRecyclerView(language: String) {
         binding.recyclerView.layoutManager = LinearLayoutManager(context)
         binding.recyclerView.adapter = CustomAdapter(getRecyclerViewData(language), requireContext())
-
     }
 
     private fun getRecyclerViewData(language: String): List<SwitchItem> {
         val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val list = mutableListOf<SwitchItem>()
-        when(language) {
+        when (language) {
             "German" -> {
-                list.add(SwitchItem(
-                    isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
-                    title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
-                    description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { enableAccentCharacters(language) },
-                    action2 = { disableAccentCharacter(language) },
-                ))
+                list.add(
+                    SwitchItem(
+                        isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
+                        title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
+                        description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
+                        action = { disableAccentCharacter(language) },
+                        action2 = { enableAccentCharacters(language) },
+                    ),
+                )
             }
             "Swedish" -> {
-                 list.add(SwitchItem(
-                    isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
-                    title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
-                    description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { enableAccentCharacters(language) },
-                    action2 = { disableAccentCharacters(language) },
-                ))
+                list.add(
+                    SwitchItem(
+                        isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
+                        title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
+                        description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
+                        action = { disableAccentCharacter(language) },
+                        action2 = { enableAccentCharacters(language) },
+                    ),
+                )
             }
             "Spanish" -> {
-                 list.add(SwitchItem(
-                    isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
-                    title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
-                    description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { enableAccentCharacters(language) },
-                    action2 = { disableAccentCharacter(language) },
-                ))
+                list.add(
+                    SwitchItem(
+                        isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
+                        title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
+                        description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
+                        action = { disableAccentCharacter(language) },
+                        action2 = { enableAccentCharacters(language) },
+                    ),
+                )
             }
         }
         list.add(
@@ -142,16 +147,17 @@ class LanguageSettingsFragment : Fragment() {
                 description = getString(R.string.app_settings_keyboard_functionality_double_space_period_description),
                 action = { enablePeriodOnSpaceBarDoubleTap(language) },
                 action2 = { disablePeriodOnSpaceBarDoubleTap(language) },
-            )
-
+            ),
         )
-        list.add(SwitchItem(
-            isChecked = sharedPref.getBoolean("autosuggest_emojis_$language", true),
-            title = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji),
-            description = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description),
-            action = { enableEmojiAutosuggestions(language) },
-            action2 = { disableEmojiAutosuggestions(language) },
-        ),)
+        list.add(
+            SwitchItem(
+                isChecked = sharedPref.getBoolean("autosuggest_emojis_$language", true),
+                title = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji),
+                description = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description),
+                action = { enableEmojiAutosuggestions(language) },
+                action2 = { disableEmojiAutosuggestions(language) },
+            ),
+        )
         return list
     }
 
@@ -161,14 +167,6 @@ class LanguageSettingsFragment : Fragment() {
         editor.putBoolean("disable_accent_character_$language", true)
         editor.apply()
         Toast.makeText(requireContext(), "$language Accent Character Enabled", Toast.LENGTH_SHORT).show()
-    }
-
-    private fun disableAccentCharacters(language: String) {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("disable_accent_character_$language", false)
-        editor.apply()
-        Toast.makeText(requireContext(), "$language Accent Character Disabled", Toast.LENGTH_SHORT).show()
     }
 
     private fun enablePeriodOnSpaceBarDoubleTap(language: String) {
@@ -186,7 +184,6 @@ class LanguageSettingsFragment : Fragment() {
         editor.apply()
         Toast.makeText(requireContext(), "$language Period on Double Tap of Space Bar on ", Toast.LENGTH_SHORT).show()
     }
-
 
     private fun disableAccentCharacter(language: String) {
         val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -25,7 +25,6 @@ class LanguageSettingsFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val viewpager = requireActivity().findViewById<ViewPager2>(R.id.view_pager)
-        val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
         (requireActivity() as MainActivity).setActionBarButtonFunction(3, R.string.app_settings_title)
         val callback =
             requireActivity().onBackPressedDispatcher.addCallback(this) {
@@ -113,8 +112,8 @@ class LanguageSettingsFragment : Fragment() {
                     isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
                     title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
                     description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { enableAccentCharacters(language) },
-                    action2 = { disableAccentCharacter(language) },
+                    action = { disableAccentCharacter(language)},
+                    action2 = { enableAccentCharacters(language) },
                 ))
             }
             "Swedish" -> {
@@ -122,8 +121,8 @@ class LanguageSettingsFragment : Fragment() {
                     isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
                     title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
                     description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { enableAccentCharacters(language) },
-                    action2 = { disableAccentCharacters(language) },
+                     action = { disableAccentCharacter(language)},
+                     action2 = { enableAccentCharacters(language) },
                 ))
             }
             "Spanish" -> {
@@ -131,8 +130,8 @@ class LanguageSettingsFragment : Fragment() {
                     isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
                     title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
                     description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { enableAccentCharacters(language) },
-                    action2 = { disableAccentCharacter(language) },
+                    action = { disableAccentCharacter(language)},
+                    action2 = { enableAccentCharacters(language) },
                 ))
             }
         }

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -101,26 +101,75 @@ class LanguageSettingsFragment : Fragment() {
     private fun setupRecyclerView(language: String) {
         binding.recyclerView.layoutManager = LinearLayoutManager(context)
         binding.recyclerView.adapter = CustomAdapter(getRecyclerViewData(language), requireContext())
+
     }
 
     private fun getRecyclerViewData(language: String): List<SwitchItem> {
         val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        return listOf(
+        val list = mutableListOf<SwitchItem>()
+        when(language) {
+            "German" -> {
+                list.add(SwitchItem(
+                    isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
+                    title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
+                    description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
+                    action = { enableAccentCharacters(language) },
+                    action2 = { disableAccentCharacter(language) },
+                ))
+            }
+            "Swedish" -> {
+                 list.add(SwitchItem(
+                    isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
+                    title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
+                    description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
+                    action = { enableAccentCharacters(language) },
+                    action2 = { disableAccentCharacters(language) },
+                ))
+            }
+            "Spanish" -> {
+                 list.add(SwitchItem(
+                    isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
+                    title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
+                    description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
+                    action = { enableAccentCharacters(language) },
+                    action2 = { disableAccentCharacter(language) },
+                ))
+            }
+        }
+        list.add(
             SwitchItem(
                 isChecked = sharedPref.getBoolean("period_on_double_tap_$language", false),
                 title = getString(R.string.app_settings_keyboard_functionality_double_space_period),
                 description = getString(R.string.app_settings_keyboard_functionality_double_space_period_description),
                 action = { enablePeriodOnSpaceBarDoubleTap(language) },
                 action2 = { disablePeriodOnSpaceBarDoubleTap(language) },
-            ),
-            SwitchItem(
-                isChecked = sharedPref.getBoolean("autosuggest_emojis_$language", true),
-                title = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji),
-                description = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description),
-                action = { enableEmojiAutosuggestions(language) },
-                action2 = { disableEmojiAutosuggestions(language) },
-            ),
+            )
+
         )
+        list.add(SwitchItem(
+            isChecked = sharedPref.getBoolean("autosuggest_emojis_$language", true),
+            title = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji),
+            description = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description),
+            action = { enableEmojiAutosuggestions(language) },
+            action2 = { disableEmojiAutosuggestions(language) },
+        ),)
+        return list
+    }
+
+    private fun enableAccentCharacters(language: String) {
+        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val editor = sharedPref.edit()
+        editor.putBoolean("disable_accent_character_$language", true)
+        editor.apply()
+        Toast.makeText(requireContext(), "$language Accent Character Enabled", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun disableAccentCharacters(language: String) {
+        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val editor = sharedPref.edit()
+        editor.putBoolean("disable_accent_character_$language", false)
+        editor.apply()
+        Toast.makeText(requireContext(), "$language Accent Character Disabled", Toast.LENGTH_SHORT).show()
     }
 
     private fun enablePeriodOnSpaceBarDoubleTap(language: String) {
@@ -137,6 +186,15 @@ class LanguageSettingsFragment : Fragment() {
         editor.putBoolean("period_on_double_tap_$language", false)
         editor.apply()
         Toast.makeText(requireContext(), "$language Period on Double Tap of Space Bar on ", Toast.LENGTH_SHORT).show()
+    }
+
+
+    private fun disableAccentCharacter(language: String) {
+        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val editor = sharedPref.edit()
+        editor.putBoolean("disable_accent_character_$language", false)
+        editor.apply()
+        Toast.makeText(requireContext(), "$language Accent Characters Disabled", Toast.LENGTH_SHORT).show()
     }
 
     private fun enableEmojiAutosuggestions(language: String) {

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -112,8 +112,8 @@ class LanguageSettingsFragment : Fragment() {
                     isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
                     title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
                     description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { disableAccentCharacter(language)},
-                    action2 = { enableAccentCharacters(language) },
+                    action = { enableAccentCharacters(language) },
+                    action2 = { disableAccentCharacter(language) },
                 ))
             }
             "Swedish" -> {
@@ -121,8 +121,8 @@ class LanguageSettingsFragment : Fragment() {
                     isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
                     title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
                     description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                     action = { disableAccentCharacter(language)},
-                     action2 = { enableAccentCharacters(language) },
+                    action = { enableAccentCharacters(language) },
+                    action2 = { disableAccentCharacters(language) },
                 ))
             }
             "Spanish" -> {
@@ -130,8 +130,8 @@ class LanguageSettingsFragment : Fragment() {
                     isChecked = sharedPref.getBoolean("disable_accent_character_$language", false),
                     title = getString(R.string.app_settings_keyboard_layout_disable_accent_characters),
                     description = getString(R.string.app_settings_keyboard_layout_disable_accent_characters_description),
-                    action = { disableAccentCharacter(language)},
-                    action2 = { enableAccentCharacters(language) },
+                    action = { enableAccentCharacters(language) },
+                    action2 = { disableAccentCharacter(language) },
                 ))
             }
         }

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -46,7 +46,7 @@ class LanguageSettingsFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
+    ): View {
         requireActivity().onBackPressedDispatcher.addCallback(
             viewLifecycleOwner,
             object : OnBackPressedCallback(true) {

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -164,7 +164,7 @@ class LanguageSettingsFragment : Fragment() {
     private fun enableAccentCharacters(language: String) {
         val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val editor = sharedPref.edit()
-        editor.putBoolean("disable_accent_character_$language", true)
+        editor.putBoolean("disable_accent_character_$language", false)
         editor.apply()
         Toast.makeText(requireContext(), "$language Accent Character Enabled", Toast.LENGTH_SHORT).show()
     }
@@ -188,7 +188,7 @@ class LanguageSettingsFragment : Fragment() {
     private fun disableAccentCharacter(language: String) {
         val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val editor = sharedPref.edit()
-        editor.putBoolean("disable_accent_character_$language", false)
+        editor.putBoolean("disable_accent_character_$language", true)
         editor.apply()
         Toast.makeText(requireContext(), "$language Accent Characters Disabled", Toast.LENGTH_SHORT).show()
     }

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
 import android.provider.Settings.ACTION_APP_LOCALE_SETTINGS
 import android.provider.Settings.ACTION_INPUT_METHOD_SETTINGS
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -154,6 +155,7 @@ class SettingsFragment : Fragment() {
                     "Spanish" -> R.string.app__global_spanish
                     "Italian" -> R.string.app__global_italian
                     "Portuguese" -> R.string.app__global_portuguese
+                    "Swedish" -> R.string.app__global_swedish
                     else -> 0
                 }
             list.add(
@@ -188,6 +190,7 @@ class SettingsFragment : Fragment() {
         val result = mutableListOf<String>()
 
         for (inputMethod in enabledInputMethods) {
+            Log.i("MY-TAG", inputMethod.serviceName)
             when (inputMethod.serviceName) {
                 "be.scri.services.EnglishKeyboardIME" -> result.add("English")
                 "be.scri.services.GermanKeyboardIME" -> result.add("German")
@@ -196,6 +199,7 @@ class SettingsFragment : Fragment() {
                 "be.scri.services.FrenchKeyboardIME" -> result.add("French")
                 "be.scri.services.ItalianKeyboardIME" -> result.add("Italian")
                 "be.scri.services.PortugueseKeyboardIME" -> result.add("Portuguese")
+                "be.scri.services.SwedishKeyboardIME" -> result.add("Swedish")
             }
         }
         return result

--- a/app/src/main/java/be/scri/helpers/CustomAdapter.kt
+++ b/app/src/main/java/be/scri/helpers/CustomAdapter.kt
@@ -82,6 +82,7 @@ class CustomAdapter(
         position: Int,
     ) {
         val item = mList[position] as ItemsViewModel
+
         holder.imageView.setImageResource(item.image)
         holder.textView.text =
             with(item.text) {
@@ -128,8 +129,13 @@ class CustomAdapter(
         holder: SwitchViewHolder,
         position: Int,
     ) {
-        val item = mList[position] as SwitchItem
-        holder.switchView.isChecked = item.isChecked
+
+
+
+
+        val item = mList[position] as? SwitchItem
+
+        holder.switchView.isChecked = item!!.isChecked
         holder.switchView.setOnCheckedChangeListener(null)
         holder.textView.text = item.title
         if (item.description.isNullOrEmpty()) {
@@ -152,13 +158,14 @@ class CustomAdapter(
 
     override fun getItemCount(): Int = mList.size
 
-    override fun getItemViewType(position: Int): Int =
-        when (mList[position]) {
+    override fun getItemViewType(position: Int): Int {
+        return when (mList[position])  {
             is ItemsViewModel -> VIEW_TYPE_IMAGE
             is SwitchItem -> VIEW_TYPE_SWITCH
             is TextItem -> VIEW_TYPE_TEXT
             else -> throw IllegalArgumentException("Invalid item type")
         }
+    }
 
     class ImageViewHolder(
         itemView: View,

--- a/app/src/main/java/be/scri/helpers/CustomAdapter.kt
+++ b/app/src/main/java/be/scri/helpers/CustomAdapter.kt
@@ -129,10 +129,6 @@ class CustomAdapter(
         holder: SwitchViewHolder,
         position: Int,
     ) {
-
-
-
-
         val item = mList[position] as? SwitchItem
 
         holder.switchView.isChecked = item!!.isChecked
@@ -158,14 +154,13 @@ class CustomAdapter(
 
     override fun getItemCount(): Int = mList.size
 
-    override fun getItemViewType(position: Int): Int {
-        return when (mList[position])  {
+    override fun getItemViewType(position: Int): Int =
+        when (mList[position]) {
             is ItemsViewModel -> VIEW_TYPE_IMAGE
             is SwitchItem -> VIEW_TYPE_SWITCH
             is TextItem -> VIEW_TYPE_TEXT
             else -> throw IllegalArgumentException("Invalid item type")
         }
-    }
 
     class ImageViewHolder(
         itemView: View,

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -12,6 +12,7 @@ import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.MyKeyboard
+import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class GermanKeyboardIME : SimpleKeyboardIME() {
@@ -64,15 +65,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
-        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", true)
-
-        if (isAccentCharacter) {
-            Log.i("MY-TAG", "I am in onInitializeInterface() inside Accent Character")
-            keyboard = MyKeyboard(this, R.xml.keys_letters_german, enterKeyType)
-        } else {
-            keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
-        }
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
     }
 
     override fun onStartInputView(
@@ -109,6 +102,10 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         Log.i("MY-TAG", "From German Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        when (currentState) {
+            ScribeState.IDLE -> keyboardView!!.setEnterKeyColor(null)
+            else -> keyboardView!!.setEnterKeyColor(R.color.dark_scribe_blue)
+        }
         setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this
@@ -273,28 +270,22 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
 
     override fun onCreate() {
         super.onCreate()
-        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", false)
-        if (isAccentCharacter) {
-            Log.i("MY-TAG", "I am in OnCreate inside Accent Character")
-            keyboard = MyKeyboard(this, R.xml.keys_letters_german, enterKeyType)
-        } else {
-            keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
-        }
-
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }
 
 
     private fun updateUI() {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val isSystemDarkMode = currentNightMode == Configuration.UI_MODE_NIGHT_YES
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkMode)
         when (currentState) {
             ScribeState.IDLE -> setupIdleView()
             ScribeState.SELECT_COMMAND -> setupSelectCommandView()
             else -> switchToToolBar()
         }
-        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isUserDarkMode = sharedPref.getBoolean("dark_mode", true)
         updateEnterKeyColor(isUserDarkMode)
     }
 }

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -17,9 +17,9 @@ import be.scri.views.MyKeyboardView
 class GermanKeyboardIME : SimpleKeyboardIME() {
     override fun getKeyboardLayoutXML(): Int =
         if (getIsAccentCharacter()) {
-            R.xml.keys_letters_german
-        } else {
             R.xml.keys_letter_german_without_accent_character
+        } else {
+            R.xml.keys_letters_german
         }
 
     private fun getIsAccentCharacter(): Boolean {

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -29,11 +29,6 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         return isAccentCharacter
     }
 
-    private fun getIsAccentCharacter(): Boolean{
-        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", true)
-        return isAccentCharacter
-    }
     enum class ScribeState {
         IDLE,
         SELECT_COMMAND,
@@ -274,7 +269,6 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         onCreateInputView()
         setupCommandBarTheme(binding)
     }
-
 
     private fun updateUI() {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -15,8 +15,17 @@ import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
 class GermanKeyboardIME : SimpleKeyboardIME() {
-    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_german
+    override fun getKeyboardLayoutXML(): Int = if (getIsAccentCharacter()) {
+        R.xml.keys_letters_german
+    } else {
+        R.xml.keys_letter_german_without_accent_character
+    }
 
+    private fun getIsAccentCharacter(): Boolean{
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", true)
+        return isAccentCharacter
+    }
     enum class ScribeState {
         IDLE,
         SELECT_COMMAND,
@@ -48,7 +57,17 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", true)
+
+        if (isAccentCharacter) {
+            Log.i("MY-TAG","I am in onInitializeInterface() inside Accent Character")
+            keyboard = MyKeyboard(this, R.xml.keys_letters_german, enterKeyType)
+        }
+        else {
+            keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        }
+
     }
 
     override fun onStartInputView(
@@ -62,6 +81,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         updateEnterKeyColor(isUserDarkMode)
         setupIdleView()
         super.onStartInputView(editorInfo, restarting)
+        onInitializeInterface()
         setupCommandBarTheme(binding)
     }
 
@@ -138,7 +158,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
-                    handleDelete(false, keyboardBinding)
+                    handleDelete(false, binding = null)
                 } else {
                     handleDelete(true, keyboardBinding)
                 }
@@ -150,7 +170,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
             }
             MyKeyboard.KEYCODE_ENTER -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
-                    handleKeycodeEnter(keyboardBinding, false)
+                    handleKeycodeEnter(binding = null, false)
                 } else {
                     handleKeycodeEnter(keyboardBinding, true)
                     currentState = ScribeState.IDLE
@@ -248,10 +268,20 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", false)
+        if (isAccentCharacter) {
+            Log.i("MY-TAG","I am in OnCreate inside Accent Character")
+            keyboard = MyKeyboard(this, R.xml.keys_letters_german, enterKeyType)
+        }
+        else {
+            keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        }
+
         onCreateInputView()
         setupCommandBarTheme(binding)
     }
+
 
     private fun updateUI() {
         when (currentState) {

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -15,10 +15,17 @@ import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
 class GermanKeyboardIME : SimpleKeyboardIME() {
-    override fun getKeyboardLayoutXML(): Int = if (getIsAccentCharacter()) {
-        R.xml.keys_letters_german
-    } else {
-        R.xml.keys_letter_german_without_accent_character
+    override fun getKeyboardLayoutXML(): Int =
+        if (getIsAccentCharacter()) {
+            R.xml.keys_letters_german
+        } else {
+            R.xml.keys_letter_german_without_accent_character
+        }
+
+    private fun getIsAccentCharacter(): Boolean {
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", true)
+        return isAccentCharacter
     }
 
     private fun getIsAccentCharacter(): Boolean{
@@ -61,13 +68,11 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", true)
 
         if (isAccentCharacter) {
-            Log.i("MY-TAG","I am in onInitializeInterface() inside Accent Character")
+            Log.i("MY-TAG", "I am in onInitializeInterface() inside Accent Character")
             keyboard = MyKeyboard(this, R.xml.keys_letters_german, enterKeyType)
-        }
-        else {
+        } else {
             keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
         }
-
     }
 
     override fun onStartInputView(
@@ -271,10 +276,9 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", false)
         if (isAccentCharacter) {
-            Log.i("MY-TAG","I am in OnCreate inside Accent Character")
+            Log.i("MY-TAG", "I am in OnCreate inside Accent Character")
             keyboard = MyKeyboard(this, R.xml.keys_letters_german, enterKeyType)
-        }
-        else {
+        } else {
             keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
         }
 

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -24,7 +24,7 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
 
     private fun getIsAccentCharacter(): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", true)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_German", false)
         return isAccentCharacter
     }
 

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -25,7 +25,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
 
     private fun getIsAccentCharacter(): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Spanish", true)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Spanish", false)
         return isAccentCharacter
     }
 
@@ -152,7 +152,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
-                    handleDelete(false, keyboardBinding)
+                    handleDelete(false, binding = null)
                 } else {
                     handleDelete(true, keyboardBinding)
                 }

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -16,20 +16,18 @@ import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SpanishKeyboardIME : SimpleKeyboardIME() {
+    override fun getKeyboardLayoutXML(): Int =
+        if (getIsAccentCharacter()) {
+            R.xml.keys_letters_spanish
+        } else {
+            R.xml.keys_letter_spanish_without_accent_character
+        }
 
-    override fun getKeyboardLayoutXML(): Int = if (getIsAccentCharacter()) {
-        R.xml.keys_letters_spanish
-    } else {
-        R.xml.keys_letter_spanish_without_accent_character
-    }
-
-
-    private fun getIsAccentCharacter(): Boolean{
+    private fun getIsAccentCharacter(): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Spanish", true)
         return isAccentCharacter
     }
-
 
     enum class ScribeState {
         IDLE,

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -16,7 +16,20 @@ import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SpanishKeyboardIME : SimpleKeyboardIME() {
-    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_spanish
+
+    override fun getKeyboardLayoutXML(): Int = if (getIsAccentCharacter()) {
+        R.xml.keys_letters_spanish
+    } else {
+        R.xml.keys_letter_spanish_without_accent_character
+    }
+
+
+    private fun getIsAccentCharacter(): Boolean{
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Spanish", true)
+        return isAccentCharacter
+    }
+
 
     enum class ScribeState {
         IDLE,
@@ -166,7 +179,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
             }
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
-                    handleElseCondition(code, keyboardMode, keyboardBinding)
+                    handleElseCondition(code, keyboardMode, binding = null)
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }
@@ -218,8 +231,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
     }
 
     private fun switchToToolBar() {
-        val keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
-        this.keyboardBinding = keyboardBinding
+        val keyboardBinding = initializeKeyboardBinding()
         val keyboardHolder = keyboardBinding.root
         keyboardView = keyboardBinding.keyboardView
         super.setupToolBarTheme(keyboardBinding)
@@ -267,5 +279,10 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         val isSystemDarkMode = currentNightMode == Configuration.UI_MODE_NIGHT_YES
         val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkMode)
         updateEnterKeyColor(isUserDarkMode)
+    }
+
+    private fun initializeKeyboardBinding(): KeyboardViewKeyboardBinding {
+        val keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
+        return keyboardBinding
     }
 }

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -18,9 +18,9 @@ import be.scri.views.MyKeyboardView
 class SpanishKeyboardIME : SimpleKeyboardIME() {
     override fun getKeyboardLayoutXML(): Int =
         if (getIsAccentCharacter()) {
-            R.xml.keys_letters_spanish
-        } else {
             R.xml.keys_letter_spanish_without_accent_character
+        } else {
+            R.xml.keys_letters_spanish
         }
 
     private fun getIsAccentCharacter(): Boolean {

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -18,9 +18,11 @@ import be.scri.views.MyKeyboardView
 class SwedishKeyboardIME : SimpleKeyboardIME() {
     override fun getKeyboardLayoutXML(): Int =
         if (getIsAccentCharacter()) {
-            R.xml.keys_letters_swedish
-        } else {
+            Log.i("MY-TAG",getIsAccentCharacter().toString())
             R.xml.keys_letter_swedish_without_accent_characters
+        } else {
+            Log.i("MY-TAG",getIsAccentCharacter().toString())
+            R.xml.keys_letters_swedish
         }
 
     private fun getIsAccentCharacter(): Boolean {

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -16,19 +16,18 @@ import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SwedishKeyboardIME : SimpleKeyboardIME() {
-    override fun getKeyboardLayoutXML(): Int = if (getIsAccentCharacter()) {
-        R.xml.keys_letters_swedish
-    } else {
-        R.xml.keys_letter_swedish_without_accent_characters
-    }
+    override fun getKeyboardLayoutXML(): Int =
+        if (getIsAccentCharacter()) {
+            R.xml.keys_letters_swedish
+        } else {
+            R.xml.keys_letter_swedish_without_accent_characters
+        }
 
-
-    private fun getIsAccentCharacter(): Boolean{
+    private fun getIsAccentCharacter(): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Swedish", true)
         return isAccentCharacter
     }
-
 
     enum class ScribeState {
         IDLE,
@@ -129,7 +128,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
             }
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
-                    handleElseCondition(code, keyboardMode,  binding = null)
+                    handleElseCondition(code, keyboardMode, binding = null)
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -18,10 +18,10 @@ import be.scri.views.MyKeyboardView
 class SwedishKeyboardIME : SimpleKeyboardIME() {
     override fun getKeyboardLayoutXML(): Int =
         if (getIsAccentCharacter()) {
-            Log.i("MY-TAG",getIsAccentCharacter().toString())
+            Log.i("MY-TAG", getIsAccentCharacter().toString())
             R.xml.keys_letter_swedish_without_accent_characters
         } else {
-            Log.i("MY-TAG",getIsAccentCharacter().toString())
+            Log.i("MY-TAG", getIsAccentCharacter().toString())
             R.xml.keys_letters_swedish
         }
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -25,7 +25,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
 
     private fun getIsAccentCharacter(): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Swedish", true)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Swedish", false)
         return isAccentCharacter
     }
 
@@ -103,7 +103,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
-                    handleDelete(false, keyboardBinding)
+                    handleDelete(false, binding = null)
                 } else {
                     handleDelete(true, keyboardBinding)
                 }

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -16,7 +16,19 @@ import be.scri.services.EnglishKeyboardIME.ScribeState
 import be.scri.views.MyKeyboardView
 
 class SwedishKeyboardIME : SimpleKeyboardIME() {
-    override fun getKeyboardLayoutXML(): Int = R.xml.keys_letters_spanish
+    override fun getKeyboardLayoutXML(): Int = if (getIsAccentCharacter()) {
+        R.xml.keys_letters_swedish
+    } else {
+        R.xml.keys_letter_swedish_without_accent_characters
+    }
+
+
+    private fun getIsAccentCharacter(): Boolean{
+        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val isAccentCharacter = sharedPref.getBoolean("disable_accent_character_Swedish", true)
+        return isAccentCharacter
+    }
+
 
     enum class ScribeState {
         IDLE,
@@ -117,7 +129,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
             }
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
-                    handleElseCondition(code, keyboardMode, keyboardBinding)
+                    handleElseCondition(code, keyboardMode,  binding = null)
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }

--- a/app/src/main/res/layout/fragment_third_party.xml
+++ b/app/src/main/res/layout/fragment_third_party.xml
@@ -42,6 +42,7 @@
                         android:layout_height="wrap_content"
                         android:orientation="vertical"
                         android:padding="16dp">
+
                         <TextView
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"

--- a/app/src/main/res/xml/keys_letter_german_without_accent_character.xml
+++ b/app/src/main/res/xml/keys_letter_german_without_accent_character.xml
@@ -1,120 +1,103 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <Row>
         <Key
             app:keyEdgeFlags="left"
+            app:horizontalGap = "1%"
             app:keyLabel="q"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="1"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="1" />
         <Key
             app:keyLabel="w"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="2"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="2" />
         <Key
             app:keyLabel="e"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="èé3ęêë"
+            app:keyWidth="9.85%p"
+            app:popupCharacters="èé3ėêë"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="3" />
         <Key
             app:keyLabel="r"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="4ř"
+            app:keyWidth="9.85%p"
+            app:popupCharacters="4"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="4" />
         <Key
             app:keyLabel="t"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="þ5ť"
+            app:keyWidth="9.85%p"
+            app:popupCharacters="5"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="5" />
         <Key
-            app:keyLabel="y"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ÿ6ý"
+            app:keyLabel="z"
+            app:keyWidth="9.85%p"
+            app:popupCharacters="6"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="6" />
         <Key
             app:keyLabel="u"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="úü7ūùû"
+            app:keyWidth="9.85%p"
+            app:popupCharacters="ûū7ùú"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
             app:keyLabel="i"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ïì8íî"
+            app:keyWidth="9.85%p"
+            app:popupCharacters="ìïîī8íį"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="8" />
         <Key
             app:keyLabel="o"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="óœøōõò9ô"
+            app:keyWidth="9.85%p"
+            app:popupCharacters="ōøœõóò9ô"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key
             app:keyLabel="p"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="0"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="0" />
-        <Key
-            app:keyEdgeFlags="right"
-            app:keyLabel="å"
-            app:keyWidth="9.05%p" />
     </Row>
     <Row>
         <Key
-            app:keyEdgeFlags="left"
             app:keyLabel="a"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="æáàâąã"
+            app:horizontalGap = "7%"
+            app:keyWidth="9.75%p"
+            app:popupCharacters="âàáæãåā"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key
             app:keyLabel="s"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="śšşß"
+            app:keyWidth="9.75%p"
+            app:popupCharacters="šßś"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key
             app:keyLabel="d"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ðď"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="f"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="g"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="h"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="j"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="k"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="l"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ł"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="ö"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="œø"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyEdgeFlags="right"
-            app:keyLabel="ä"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="æ"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
+            app:keyWidth="9.75%p" />
     </Row>
     <Row>
         <Key
@@ -128,18 +111,14 @@
         -->
         <Key
             app:horizontalGap="3.325%"
-            app:keyLabel="z"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="żźž"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
+            app:keyLabel="y"
+            app:keyWidth="9.05%p" />
         <Key
             app:keyLabel="x"
             app:keyWidth="9.05%p" />
         <Key
             app:keyLabel="c"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="čçć"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
+            app:keyWidth="9.05%p" />
         <Key
             app:keyLabel="v"
             app:keyWidth="9.05%p" />
@@ -149,7 +128,7 @@
         <Key
             app:keyLabel="n"
             app:keyWidth="9.05%p"
-            app:popupCharacters="ňńñ"
+            app:popupCharacters="ñń"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key
             app:keyLabel="m"

--- a/app/src/main/res/xml/keys_letter_spanish_without_accent_character.xml
+++ b/app/src/main/res/xml/keys_letter_spanish_without_accent_character.xml
@@ -4,116 +4,73 @@
         <Key
             app:keyEdgeFlags="left"
             app:keyLabel="q"
-            app:keyWidth="9.05%p"
             app:popupCharacters="1"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="1" />
         <Key
             app:keyLabel="w"
-            app:keyWidth="9.05%p"
             app:popupCharacters="2"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="2" />
         <Key
             app:keyLabel="e"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="èé3ęêë"
+            app:popupCharacters="èé3ëėêęē"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="3" />
         <Key
             app:keyLabel="r"
-            app:keyWidth="9.05%p"
             app:popupCharacters="4ř"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="4" />
         <Key
             app:keyLabel="t"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="þ5ť"
+            app:popupCharacters="5"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="5" />
         <Key
             app:keyLabel="y"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ÿ6ý"
+            app:popupCharacters="6"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="6" />
         <Key
             app:keyLabel="u"
-            app:keyWidth="9.05%p"
             app:popupCharacters="úü7ūùû"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
             app:keyLabel="i"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ïì8íî"
+            app:popupCharacters="ìïíīî8į"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="8" />
         <Key
             app:keyLabel="o"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="óœøōõò9ô"
+            app:popupCharacters="ôöòóōœõ9õ"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key
+            app:keyEdgeFlags="right"
             app:keyLabel="p"
-            app:keyWidth="9.05%p"
             app:popupCharacters="0"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="0" />
-        <Key
-            app:keyEdgeFlags="right"
-            app:keyLabel="å"
-            app:keyWidth="9.05%p" />
     </Row>
     <Row>
         <Key
             app:keyEdgeFlags="left"
+            app:horizontalGap = "5.545%"
             app:keyLabel="a"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="æáàâąã"
+            app:popupCharacters="áàäâãåąæā"
             app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="s"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="śšşß"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="d"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ðď"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="f"
-            app:keyWidth="9.05%p" />
-        <Key
-            app:keyLabel="g"
-            app:keyWidth="9.05%p" />
-        <Key
-            app:keyLabel="h"
-            app:keyWidth="9.05%p" />
-        <Key
-            app:keyLabel="j"
-            app:keyWidth="9.05%p" />
-        <Key
-            app:keyLabel="k"
-            app:keyWidth="9.05%p" />
+        <Key app:keyLabel="s" />
+        <Key app:keyLabel="d" />
+        <Key app:keyLabel="f" />
+        <Key app:keyLabel="g" />
+        <Key app:keyLabel="h" />
+        <Key app:keyLabel="j" />
+        <Key app:keyLabel="k" />
         <Key
             app:keyLabel="l"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ł"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="ö"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="œø"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyEdgeFlags="right"
-            app:keyLabel="ä"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="æ"
+            app:popupCharacters="ĺľł"
             app:popupKeyboard="@xml/keyboard_popup_template" />
     </Row>
     <Row>
@@ -122,41 +79,21 @@
             app:keyEdgeFlags="left"
             app:keyIcon="@drawable/ic_caps_outline_vector"
             app:keyWidth="15%p" />
-        <!--
-        This needs to have nine keys on the bottom row, hence once before and after the letter keys.
-        Not having these causes the ?123 key to instead trigger a space instead of switching the view.
-        -->
-        <Key
-            app:horizontalGap="3.325%"
-            app:keyLabel="z"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="żźž"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="x"
-            app:keyWidth="9.05%p" />
+        <Key app:keyLabel="z" />
+        <Key app:keyLabel="x" />
         <Key
             app:keyLabel="c"
-            app:keyWidth="9.05%p"
             app:popupCharacters="čçć"
             app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="v"
-            app:keyWidth="9.05%p" />
-        <Key
-            app:keyLabel="b"
-            app:keyWidth="9.05%p" />
+        <Key app:keyLabel="v" />
+        <Key app:keyLabel="b" />
         <Key
             app:keyLabel="n"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="ňńñ"
+            app:popupCharacters="ñń"
             app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="m"
-            app:keyWidth="9.05%p" />
+        <Key app:keyLabel="m" />
         <Key
             app:code="-5"
-            app:horizontalGap="3.325%"
             app:isRepeatable="true"
             app:keyEdgeFlags="right"
             app:keyIcon="@drawable/ic_clear_outline_vector"

--- a/app/src/main/res/xml/keys_letter_swedish_without_accent_characters.xml
+++ b/app/src/main/res/xml/keys_letter_swedish_without_accent_characters.xml
@@ -118,7 +118,7 @@
         Not having these causes the ?123 key to instead trigger a space instead of switching the view.
         -->
         <Key
-            app:horizontalGap="3.325%"
+            app:horizontalGap="1.725%"
             app:keyLabel="z"
             app:keyWidth="9.75%p"
             app:popupCharacters="żźž"
@@ -147,11 +147,11 @@
             app:keyWidth="9.75%p" />
         <Key
             app:code="-5"
-            app:horizontalGap="3.325%"
             app:isRepeatable="true"
             app:keyEdgeFlags="right"
             app:keyIcon="@drawable/ic_clear_outline_vector"
-            app:keyWidth="9.75%p" />
+            app:keyWidth="15%p"
+            />
     </Row>
     <Row>
         <Key

--- a/app/src/main/res/xml/keys_letter_swedish_without_accent_characters.xml
+++ b/app/src/main/res/xml/keys_letter_swedish_without_accent_characters.xml
@@ -3,72 +3,74 @@
     <Row>
         <Key
             app:keyEdgeFlags="left"
+            app:horizontalGap = "1%"
             app:keyLabel="q"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="1"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="1" />
         <Key
             app:keyLabel="w"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="2"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="2" />
         <Key
             app:keyLabel="e"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="èé3ęêë"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="3" />
         <Key
             app:keyLabel="r"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="4ř"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="4" />
         <Key
             app:keyLabel="t"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="þ5ť"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="5" />
         <Key
             app:keyLabel="y"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="ÿ6ý"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="6" />
         <Key
             app:keyLabel="u"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="úü7ūùû"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
             app:keyLabel="i"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="ïì8íî"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="8" />
         <Key
             app:keyLabel="o"
-            app:keyWidth="9.05%p"
+
             app:popupCharacters="óœøōõò9ô"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key
             app:keyLabel="p"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.85%p"
             app:popupCharacters="0"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="0" />
-        <Key
-            app:keyEdgeFlags="right"
-            app:keyLabel="å"
-            app:keyWidth="9.05%p" />
+        <!--        <Key-->
+        <!--            app:keyEdgeFlags="right"-->
+        <!--            app:keyLabel="å"-->
+        <!--            app:keyWidth="9.05%p" />-->
     </Row>
     <Row>
         <Key
+            app:horizontalGap= "8.854%"
             app:keyEdgeFlags="left"
             app:keyLabel="a"
             app:keyWidth="9.05%p"
@@ -104,17 +106,6 @@
             app:keyWidth="9.05%p"
             app:popupCharacters="ł"
             app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyLabel="ö"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="œø"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
-        <Key
-            app:keyEdgeFlags="right"
-            app:keyLabel="ä"
-            app:keyWidth="9.05%p"
-            app:popupCharacters="æ"
-            app:popupKeyboard="@xml/keyboard_popup_template" />
     </Row>
     <Row>
         <Key
@@ -129,38 +120,38 @@
         <Key
             app:horizontalGap="3.325%"
             app:keyLabel="z"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.75%p"
             app:popupCharacters="żźž"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key
             app:keyLabel="x"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="c"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.75%p"
             app:popupCharacters="čçć"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key
             app:keyLabel="v"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="b"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:keyLabel="n"
-            app:keyWidth="9.05%p"
+            app:keyWidth="9.75%p"
             app:popupCharacters="ňńñ"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key
             app:keyLabel="m"
-            app:keyWidth="9.05%p" />
+            app:keyWidth="9.75%p" />
         <Key
             app:code="-5"
             app:horizontalGap="3.325%"
             app:isRepeatable="true"
             app:keyEdgeFlags="right"
             app:keyIcon="@drawable/ic_clear_outline_vector"
-            app:keyWidth="15%p" />
+            app:keyWidth="9.75%p" />
     </Row>
     <Row>
         <Key

--- a/app/src/main/res/xml/keys_letters_german.xml
+++ b/app/src/main/res/xml/keys_letters_german.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <Row>
         <Key
             app:keyEdgeFlags="left"
@@ -63,13 +64,13 @@
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="0" />
         <Key
+
             app:keyEdgeFlags="right"
             app:keyLabel="ü"
             app:keyWidth="9.05%p" />
     </Row>
     <Row>
         <Key
-            app:keyEdgeFlags="left"
             app:keyLabel="a"
             app:keyWidth="9.05%p"
             app:popupCharacters="âàáæãåā"
@@ -101,9 +102,11 @@
             app:keyLabel="l"
             app:keyWidth="9.05%p" />
         <Key
+            app:code="1"
             app:keyLabel="ö"
             app:keyWidth="9.05%p" />
         <Key
+            app:code = "2"
             app:keyEdgeFlags="right"
             app:keyLabel="ä"
             app:keyWidth="9.05%p" />


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

- The pull request allows disabling and enabling accent characters in the German, Swedish, and Spanish keyboards. By default they are enabled. 

### Related issue

-   #67 
-   #65 
