### PR TITLE
Fixing title to fill full width so names don't get cut off.

### DIFF
--- a/app/src/main/res/layout/custom_action_bar_layout.xml
+++ b/app/src/main/res/layout/custom_action_bar_layout.xml
@@ -28,7 +28,7 @@
 
     <TextView
         android:id="@+id/name"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="10dp"
         android:layout_gravity="top|start"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR fixes the custom action bar so the title doesn't get cut off when changing themes.

Test steps:
1. Set device theme to dark theme.
2. Open app.
3. Navigate to Settings screen.
4. Change device theme to light theme.
5. Open app again.
6. Verify that the title is full "Settings"
7. Repeat steps 1-6 with opposite themes, for good measure.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #151
