### PR TITLE
add dividers between autosuggestion #122

### DIFF
--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -106,6 +106,8 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -114,6 +116,8 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
 

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -121,6 +121,8 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE FROM English IME")
@@ -136,6 +138,8 @@ class EnglishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         super.setupCommandBarTheme(binding)
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -169,6 +169,8 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -185,6 +187,8 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")
@@ -207,6 +211,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
             updateUI()
         }
     }
+
 
     private fun switchToToolBar() {
         val keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -154,6 +154,8 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -162,6 +164,8 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -212,7 +212,6 @@ class FrenchKeyboardIME : SimpleKeyboardIME() {
         }
     }
 
-
     private fun switchToToolBar() {
         val keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
         this.keyboardBinding = keyboardBinding

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -134,6 +134,8 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -200,6 +202,8 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -119,6 +119,8 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -127,6 +129,8 @@ class GermanKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -105,6 +105,8 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -113,6 +115,8 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -120,6 +120,8 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -186,6 +188,8 @@ class ItalianKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -105,6 +105,8 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -113,6 +115,8 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -120,6 +120,8 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -136,6 +138,8 @@ class PortugueseKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -119,6 +119,8 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -185,6 +187,8 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -105,6 +105,8 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -113,6 +115,8 @@ class RussianKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
         setupCommandBarTheme(binding)

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -131,6 +131,8 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -197,6 +199,8 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -116,6 +116,8 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -124,6 +126,8 @@ class SpanishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -168,6 +168,8 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.WHITE)
                 binding.conjugateBtn.setTextColor(Color.WHITE)
                 binding.pluralBtn.setTextColor(Color.WHITE)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
             }
             else -> {
                 binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
@@ -176,6 +178,8 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
                 binding.translateBtn.setTextColor(Color.BLACK)
                 binding.conjugateBtn.setTextColor(Color.BLACK)
                 binding.pluralBtn.setTextColor(Color.BLACK)
+                binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
         setupCommandBarTheme(binding)

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -182,6 +182,8 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Suggestion"
         binding.conjugateBtn.text = "Suggestion"
         binding.pluralBtn.text = "Suggestion"
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             Log.i("MY-TAG", "SELECT COMMAND STATE")
@@ -198,6 +200,8 @@ class SwedishKeyboardIME : SimpleKeyboardIME() {
         binding.translateBtn.text = "Translate"
         binding.conjugateBtn.text = "Conjugate"
         binding.pluralBtn.text = "Plural"
+        binding.separator2.visibility = View.GONE
+        binding.separator3.visibility = View.GONE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")

--- a/app/src/main/res/layout/keyboard_view_command_options.xml
+++ b/app/src/main/res/layout/keyboard_view_command_options.xml
@@ -43,6 +43,7 @@
             android:id="@+id/translate_btn"
             android:layout_width="0dp"
             android:layout_height="@dimen/toolbar_icon_height"
+            android:layout_marginEnd="@dimen/small_margin"
             android:background="@drawable/cmd_key_background_rounded"
             android:contentDescription="@string/command_bar"
             app:layout_constraintBottom_toBottomOf="@+id/command_field"
@@ -54,17 +55,24 @@
 
         <View
             android:id="@+id/separator_2"
-            android:layout_width="0dp"
-            android:layout_height="@dimen/toolbar_icon_height"
+            android:layout_width="1dp"
+            android:layout_height="0dp"
+            app:layout_constraintHeight_percent="0.8"
+            app:layout_constraintVertical_bias="0.5"
+            android:background="@color/special_key_light"
             app:layout_constraintBottom_toBottomOf="@+id/command_field"
+            app:layout_constraintTop_toTopOf="@+id/command_field"
             app:layout_constraintEnd_toStartOf="@+id/conjugate_btn"
             app:layout_constraintHorizontal_weight="1"
-            app:layout_constraintStart_toEndOf="@+id/translate_btn" />
+            app:layout_constraintStart_toEndOf="@+id/translate_btn"
+            android:visibility="gone" />
+
 
         <Button
             android:id="@+id/conjugate_btn"
             android:layout_width="0dp"
             android:layout_height="@dimen/toolbar_icon_height"
+            android:layout_marginEnd="@dimen/small_margin"
             android:background="@drawable/cmd_key_background_rounded"
             android:contentDescription="@string/command_bar"
             app:layout_constraintBottom_toBottomOf="@+id/command_field"
@@ -74,14 +82,19 @@
             app:layout_constraintStart_toEndOf="@+id/separator_2"
             app:layout_constraintTop_toTopOf="@+id/command_field" />
 
-        <View
+            <View
             android:id="@+id/separator_3"
-            android:layout_width="0dp"
-            android:layout_height="@dimen/toolbar_icon_height"
+            android:layout_width="1dp"
+            android:layout_height="0dp"
+            app:layout_constraintHeight_percent="0.8"
+            app:layout_constraintVertical_bias="0.5"
+            android:background="@color/special_key_light"
+            app:layout_constraintTop_toTopOf="@+id/command_field"
             app:layout_constraintBottom_toBottomOf="@+id/command_field"
             app:layout_constraintEnd_toStartOf="@+id/plural_btn"
             app:layout_constraintHorizontal_weight="1"
-            app:layout_constraintStart_toEndOf="@+id/conjugate_btn" />
+            app:layout_constraintStart_toEndOf="@+id/conjugate_btn"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/plural_btn"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR adds dividers between the autosuggestion buttons.
![divide](https://github.com/user-attachments/assets/3e8ffd07-28e1-4fdc-8303-b7989571d039)
 Since the separator already exists, I made minor adjustments to the [keyboard_view_command_options.xml](https://github.com/scribe-org/Scribe-Android/blob/main/app/src/main/res/layout/keyboard_view_command_options.xml) file.

Please let me know if this approach is incorrect or if there are other considerations I should keep in mind. I look forward to your feedback! :)

Thank you!


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #122
