### PR TITLE
Update detekt.yml to fix the large class lint issue

### DIFF
--- a/app/src/main/java/be/scri/views/MyKeyboardView.kt
+++ b/app/src/main/java/be/scri/views/MyKeyboardView.kt
@@ -57,6 +57,7 @@ import be.scri.helpers.SHIFT_ON_PERMANENT
 import java.util.Arrays
 
 @SuppressLint("UseCompatLoadingForDrawables")
+@Suppress("LargeClass")
 class MyKeyboardView
     @JvmOverloads
     constructor(

--- a/detekt.yml
+++ b/detekt.yml
@@ -29,8 +29,6 @@ complexity:
         active: false
     CyclomaticComplexMethod:
         active: false
-    LargeClass:
-        active: false
 
 potential-bugs:
     ImplicitDefaultLocale:


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR fixes linting issues due to Large Class Block by removing the line of code:
```
EmptyCatchBlock:
        active: true
```

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #125
