### PR TITLE
Feat: Add unit testing dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,12 @@ plugins {
     id("org.jmailen.kotlinter")
     id("io.gitlab.arturbosch.detekt")
     id("com.google.devtools.ksp") version "2.0.0-1.0.22" apply true
+    id("de.mannodermaus.android-junit5") version "1.11.2.0"
 }
+
 val kotlinVersion by extra("2.0.0")
+val junit5Version by extra("5.11.2")
+val mockkVersion by extra("1.13.13")
 
 android {
     compileSdk = 34
@@ -87,6 +91,7 @@ android {
         buildUponDefaultConfig = true
         allRules = false
         config = rootProject.files("detekt.yml")
+
     }
 
     kotlinter {
@@ -114,6 +119,10 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("androidx.viewpager2:viewpager2:1.1.0")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5Version")
+    testImplementation("io.mockk:mockk:$mockkVersion")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit5Version")
 
     api("joda-time:joda-time:2.10.13")
     api("com.github.tibbi:RecyclerView-FastScroller:e7d3e150c4")

--- a/app/src/test/kotlin/helpers/AlphanumericComparatorTest.kt
+++ b/app/src/test/kotlin/helpers/AlphanumericComparatorTest.kt
@@ -1,0 +1,18 @@
+package helpers
+
+import be.scri.helpers.AlphanumericComparator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AlphanumericComparatorTest {
+    private val subject = AlphanumericComparator()
+
+    @Test
+    fun testCompare() {
+        assertEquals(-1, subject.compare("IMG_10.png", "IMG_11.png"))
+
+        assertEquals(0, subject.compare("IMG_10.png", "IMG_10.png"))
+
+        assertEquals(1, subject.compare("IMG_11.png", "IMG_10.png"))
+    }
+}


### PR DESCRIPTION
Add Junit 5 and Mockk test dependencies with simple test

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This change adds dependencies to enable writing unit tests including JUnit 5, a dependency to support use of JUnit 5 for android tests, and MockK following details and discussion from #181 

I added a simple test for a utility class as an example.

I ran the following commands to test:
* `./gradlew test`
* `./gradlew check`

For each of these, I verified they fail when expected (set assertions to be incorrect) and pass otherwise.

Once this change is merged, there are a few follow ups needed - I can create issues for these so they can be done later:
* Test code conventions (naming, organization, etc.)
* Adding tests to automated PR checks
* Adding code coverage tooling and automated PR code coverage checks
* Adding example tests with mocking

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #181
