### PR TITLE
Fix back button not exiting app

### DIFF
--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -220,7 +220,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
-    
+
     override fun onBackPressed() {
         super.onBackPressed()
         if (viewPager.currentItem == 0) {

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -220,6 +220,19 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
+    
+    override fun onBackPressed() {
+        super.onBackPressed()
+        if (viewPager.currentItem == 0) {
+            if (binding.fragmentContainer.visibility == View.VISIBLE) {
+                binding.fragmentContainer.visibility = View.GONE
+            } else {
+                finish()
+            }
+        } else {
+            viewPager.currentItem = viewPager.currentItem - 1
+        }
+    }
 
     fun hideHint() {
         val hintLayout = findViewById<View>(R.id.hint_layout)


### PR DESCRIPTION
* Ensure the app exits on back press from the first page.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This pull request fixes the issue where the app did not exit when the back button was pressed on the first page. The updated logic now ensures that the app calls finish() to exit when the back button is pressed on the first page, enhancing the user experience.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #206 
