### PR TITLE
bugfix/Auto increase size of the select keyboard recycler view on page change

### DIFF
--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -24,8 +24,6 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private var englishKeyboardIME: EnglishKeyboardIME? = null
 
-    fun getEnglishKeyboardIME(): EnglishKeyboardIME? = englishKeyboardIME
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         supportActionBar?.displayOptions = androidx.appcompat.app.ActionBar.DISPLAY_SHOW_CUSTOM

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -133,9 +133,8 @@ class AboutFragment : Fragment() {
             ),
         )
 
-    private fun getSecondRecyclerViewData(): List<Any> {
-        val context = requireContext()
-        return listOf(
+    private fun getSecondRecyclerViewData(): List<Any> =
+        listOf(
             ItemsViewModel(
                 image = R.drawable.star,
                 text = ItemsViewModel.Text(R.string.app_about_feedback_rate_scribe),
@@ -177,7 +176,6 @@ class AboutFragment : Fragment() {
                 action = ::resetHints,
             ),
         )
-    }
 
     private fun getThirdRecyclerViewData(): List<ItemsViewModel> =
         listOf(

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -20,6 +20,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import be.scri.R
 import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentSettingsBinding
@@ -30,6 +31,7 @@ import be.scri.models.TextItem
 
 class SettingsFragment : Fragment() {
     private lateinit var binding: FragmentSettingsBinding
+    private var isDecorationSet: Boolean = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -141,22 +143,29 @@ class SettingsFragment : Fragment() {
                 setupItemVisibility()
             }
         }
-
         val recyclerView = binding.recyclerView2
         val adapter = CustomAdapter(getRecyclerViewElements(), requireContext())
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
         recyclerView.suppressLayout(true)
-        recyclerView.apply {
-            val itemDecoration =
-                CustomDividerItemDecoration(
-                    drawable = getDrawable(requireContext(), R.drawable.rv_divider)!!,
-                    width = 1,
-                    marginLeft = 50,
-                    marginRight = 50,
-                )
-            addItemDecoration(itemDecoration)
+
+        if (!isDecorationSet) {
+            isDecorationSet = true
+            recyclerView.apply {
+                addCustomItemDecoration()
+            }
         }
+    }
+
+    private fun RecyclerView.addCustomItemDecoration() {
+        val itemDecoration =
+            CustomDividerItemDecoration(
+                drawable = getDrawable(requireContext(), R.drawable.rv_divider)!!,
+                width = 1,
+                marginLeft = 50,
+                marginRight = 50,
+            )
+        addItemDecoration(itemDecoration)
     }
 
     private fun getRecyclerViewElements(): MutableList<TextItem> {

--- a/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
+++ b/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
@@ -20,7 +20,7 @@ class CustomDividerItemDecoration(
         val right = parent.width - parent.paddingRight - marginRight
 
         val childCount = parent.childCount
-        for (i in 0 until childCount - 1) { // Exclude the last item
+        for (i in 0 until childCount - 1) {
             val child = parent.getChildAt(i)
             val params = child.layoutParams as RecyclerView.LayoutParams
             val top = child.bottom + params.bottomMargin

--- a/app/src/main/res/drawable/rv_divider.xml
+++ b/app/src/main/res/drawable/rv_divider.xml
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <size android:height="1dp" />
-    <corners android:radius="10dp" />
-    <solid android:color="@color/rv_divider" />
-</shape>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="1023dp"
+    android:height="1dp"
+    android:viewportWidth="1023"
+    android:viewportHeight="1">
+  <path
+      android:pathData="M0,0h1023v1h-1023z"
+      android:fillColor="@color/rv_divider"
+      android:fillAlpha="0.5"/>
+</vector>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Could you describe briefly what your pull request proposes to change? Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe briefly how you tested that your change works.
-->

The pull request corrects the auto size increase of the select keyboard recycler view. It also **replaces the existing rv_divider to the one present in Figma** as I felt it to be more subtle compared to the existing rv_divider. Happy to revert back to earlier rv_divider in the PR on discussion. 
### Related issue

-   #205 
