### PR TITLE
feat:Added formating fixes in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,17 +9,17 @@ repos:
           - id: check-yaml
 
     - repo: local
-      hooks:        
+      hooks:
           - id: formatKotlin
             name: formatKotlin
-            entry: sh -c './gradlew formatKotlin' 
+            entry: sh -c './gradlew formatKotlin'
             language: system
             types: [kotlin]
             files: \.kt$
 
           - id: ktlint
             name: ktlint
-            entry: sh -c './gradlew lintKotlin' 
+            entry: sh -c './gradlew lintKotlin'
             language: system
             types: [kotlin]
             files: \.kt$
@@ -30,6 +30,3 @@ repos:
             language: system
             types: [kotlin]
             files: \.kt$
-            
-
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,33 @@ repos:
       rev: v4.5.0
       hooks:
           - id: trailing-whitespace
+            files: \.kt$
           - id: end-of-file-fixer
+            files: \.kt$
           - id: check-yaml
 
     - repo: local
-      hooks:
-          - id: ktlint
-            name: ktlint
-            entry: ./gradlew lintKotlin
+      hooks:        
+          - id: formatKotlin
+            name: formatKotlin
+            entry: sh -c './gradlew formatKotlin' 
             language: system
             types: [kotlin]
+            files: \.kt$
+
+          - id: ktlint
+            name: ktlint
+            entry: sh -c './gradlew lintKotlin' 
+            language: system
+            types: [kotlin]
+            files: \.kt$
 
           - id: detekt
             name: detekt
-            entry: ./gradlew detekt
+            entry: sh -c './gradlew detekt'
             language: system
             types: [kotlin]
+            files: \.kt$
+            
+
+


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

The PR adds auto-formatting during the pre-commit. Also, for some reason, the pre-commit was not working on my device and some of the other devices on which I tested it. I have added an sh to run the script. Currently, the thing fails if it has to auto format, as there must be changes to the codebase. I am happy to have suggestions so that it does not fail whether it makes changes and also on the changes on adding sh to run the command. 

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #215 
