### PR TITLE
Fix TooManyFunctions in Fragments and MainActivity.

### DIFF
--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -1,6 +1,5 @@
 package be.scri.activities
 
-import android.app.UiModeManager
 import android.content.Context
 import android.os.Bundle
 import android.util.Log
@@ -66,21 +65,21 @@ class MainActivity : AppCompatActivity() {
                             binding.fragmentContainer.visibility = View.GONE
                             setActionBarTitle(R.string.app_launcher_name)
                             setActionBarButtonInvisible()
-                            unsetActionBarLayoutMargin()
+                            setActionBarVisibility(false)
                         }
 
                         1 -> {
                             binding.fragmentContainer.visibility = View.GONE
                             setActionBarTitle(R.string.app_settings_title)
                             setActionBarButtonInvisible()
-                            unsetActionBarLayoutMargin()
+                            setActionBarVisibility(false)
                         }
 
                         2 -> {
                             binding.fragmentContainer.visibility = View.GONE
                             setActionBarButtonInvisible()
                             setActionBarTitle(R.string.app_about_title)
-                            unsetActionBarLayoutMargin()
+                            setActionBarVisibility(false)
                         }
 
                         else -> {
@@ -151,25 +150,22 @@ class MainActivity : AppCompatActivity() {
                 viewpager.setCurrentItem(page, true)
             }
             frameLayout.visibility = View.GONE
-            unsetActionBarLayoutMargin()
+            setActionBarVisibility(false)
             setActionBarTitle(title)
             button.visibility = View.GONE
         }
     }
 
-    fun setActionBarLayoutMargin() {
+    fun setActionBarVisibility(shouldShowOnScreen: Boolean) {
         val textView = supportActionBar?.customView?.findViewById<TextView>(R.id.name)
         val params = textView?.layoutParams as ViewGroup.MarginLayoutParams
-        params.topMargin = -50
-        params.bottomMargin = 30
-        textView.layoutParams = params
-    }
-
-    fun unsetActionBarLayoutMargin() {
-        val textView = supportActionBar?.customView?.findViewById<TextView>(R.id.name)
-        val params = textView?.layoutParams as ViewGroup.MarginLayoutParams
-        params.topMargin = 50
-        params.bottomMargin = 0
+        if (shouldShowOnScreen) {
+            params.topMargin = 50
+            params.bottomMargin = 0
+        } else {
+            params.topMargin = -50
+            params.bottomMargin = 30
+        }
         textView.layoutParams = params
     }
 

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.viewpager2.widget.ViewPager2
 import be.scri.R
 import be.scri.adapters.ViewPagerAdapter
 import be.scri.databinding.ActivityMainBinding
+import be.scri.helpers.PreferencesHelper
 import be.scri.services.EnglishKeyboardIME
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
@@ -36,7 +37,7 @@ class MainActivity : AppCompatActivity() {
         setActionBarTitle(R.string.app_launcher_name)
         val mButton = supportActionBar?.customView?.findViewById<Button>(R.id.button)
         val mImage = getDrawable(R.drawable.chevron)
-        applyUserDarkModePreference(this)
+        AppCompatDelegate.setDefaultNightMode(PreferencesHelper.getUserDarkModePreference(this))
         mButton?.setCompoundDrawablesWithIntrinsicBounds(mImage, null, null, null)
         mButton?.compoundDrawablePadding = 2
         mButton?.visibility = View.GONE
@@ -170,24 +171,6 @@ class MainActivity : AppCompatActivity() {
         params.topMargin = 50
         params.bottomMargin = 0
         textView.layoutParams = params
-    }
-
-    private fun applyUserDarkModePreference(context: Context) {
-        val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val isSystemDarkTheme = isDarkMode(context)
-        val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkTheme)
-        AppCompatDelegate.setDefaultNightMode(
-            if (isUserDarkMode) {
-                AppCompatDelegate.MODE_NIGHT_YES
-            } else {
-                AppCompatDelegate.MODE_NIGHT_NO
-            },
-        )
-    }
-
-    fun isDarkMode(context: Context): Boolean {
-        val uiModeManager = context.getSystemService(UI_MODE_SERVICE) as UiModeManager
-        return uiModeManager.nightMode == UiModeManager.MODE_NIGHT_YES
     }
 
     fun showHint(

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -64,20 +64,20 @@ class MainActivity : AppCompatActivity() {
                         0 -> {
                             binding.fragmentContainer.visibility = View.GONE
                             setActionBarTitle(R.string.app_launcher_name)
-                            setActionBarButtonInvisible()
+                            setActionBarButtonVisibility(false)
                             setActionBarVisibility(false)
                         }
 
                         1 -> {
                             binding.fragmentContainer.visibility = View.GONE
                             setActionBarTitle(R.string.app_settings_title)
-                            setActionBarButtonInvisible()
+                            setActionBarButtonVisibility(false)
                             setActionBarVisibility(false)
                         }
 
                         2 -> {
                             binding.fragmentContainer.visibility = View.GONE
-                            setActionBarButtonInvisible()
+                            setActionBarButtonVisibility(false)
                             setActionBarTitle(R.string.app_about_title)
                             setActionBarVisibility(false)
                         }
@@ -129,12 +129,12 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.customView?.findViewById<TextView>(R.id.name)?.text = getString(title)
     }
 
-    fun setActionBarButtonVisible() {
-        supportActionBar?.customView?.findViewById<Button>(R.id.button)?.visibility = View.VISIBLE
-    }
-
-    fun setActionBarButtonInvisible() {
-        supportActionBar?.customView?.findViewById<Button>(R.id.button)?.visibility = View.GONE
+    fun setActionBarButtonVisibility(visible: Boolean) {
+        if (visible) {
+            supportActionBar?.customView?.findViewById<Button>(R.id.button)?.visibility = View.VISIBLE
+        } else {
+            supportActionBar?.customView?.findViewById<Button>(R.id.button)?.visibility = View.GONE
+        }
     }
 
     fun setActionBarButtonFunction(

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -160,11 +160,11 @@ class MainActivity : AppCompatActivity() {
         val textView = supportActionBar?.customView?.findViewById<TextView>(R.id.name)
         val params = textView?.layoutParams as ViewGroup.MarginLayoutParams
         if (shouldShowOnScreen) {
-            params.topMargin = 50
-            params.bottomMargin = 0
-        } else {
             params.topMargin = -50
             params.bottomMargin = 30
+        } else {
+            params.topMargin = 50
+            params.bottomMargin = 0
         }
         textView.layoutParams = params
     }

--- a/app/src/main/java/be/scri/extensions/RecyclerView.kt
+++ b/app/src/main/java/be/scri/extensions/RecyclerView.kt
@@ -1,0 +1,17 @@
+package be.scri.extensions
+
+import CustomDividerItemDecoration
+import androidx.appcompat.content.res.AppCompatResources.getDrawable
+import androidx.recyclerview.widget.RecyclerView
+import be.scri.R
+
+fun RecyclerView.addCustomItemDecoration(context: android.content.Context) {
+    val itemDecoration =
+        CustomDividerItemDecoration(
+            drawable = getDrawable(context, R.drawable.rv_divider)!!,
+            width = 1,
+            marginLeft = 50,
+            marginRight = 50,
+        )
+    addItemDecoration(itemDecoration)
+}

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -21,8 +21,10 @@ import be.scri.BuildConfig
 import be.scri.R
 import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentAboutBinding
+import be.scri.extensions.addCustomItemDecoration
 import be.scri.helpers.CustomAdapter
 import be.scri.helpers.HintUtils
+import be.scri.helpers.ShareHelper
 import be.scri.models.ItemsViewModel
 import com.google.android.play.core.review.ReviewManagerFactory
 
@@ -110,7 +112,7 @@ class AboutFragment : Fragment() {
                 image2 = R.drawable.external_link,
                 url = null,
                 activity = null,
-                action = ::shareScribe,
+                action = ({ ShareHelper.shareScribe(requireContext()) }),
             ),
             ItemsViewModel(
                 image = R.drawable.wikimedia_logo_black,
@@ -146,7 +148,7 @@ class AboutFragment : Fragment() {
                 image2 = R.drawable.external_link,
                 url = null,
                 activity = null,
-                action = ::sendEmail,
+                action = ({ ShareHelper.sendEmail(requireContext()) }),
             ),
             ItemsViewModel(
                 image = R.drawable.bookmark_icon,
@@ -189,37 +191,6 @@ class AboutFragment : Fragment() {
     private fun resetHints() {
         HintUtils.resetHints(requireContext())
         (activity as MainActivity).showHint("hint_shown_about", R.string.app_about_app_hint)
-    }
-
-    private fun shareScribe() {
-        try {
-            val sharingIntent =
-                Intent(Intent.ACTION_SEND).apply {
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, "https://github.com/scribe-org/Scribe-Android")
-                }
-            startActivity(Intent.createChooser(sharingIntent, "Share via"))
-        } catch (e: ActivityNotFoundException) {
-            Log.e("AboutFragment", "No application found to share content", e)
-        } catch (e: IllegalArgumentException) {
-            Log.e("AboutFragment", "Invalid argument for sharing", e)
-        }
-    }
-
-    private fun sendEmail() {
-        try {
-            val intent =
-                Intent(Intent.ACTION_SEND).apply {
-                    putExtra(Intent.EXTRA_EMAIL, arrayOf("team@scri.be"))
-                    putExtra(Intent.EXTRA_SUBJECT, "Hey Scribe!")
-                    type = "message/rfc822"
-                }
-            startActivity(Intent.createChooser(intent, "Choose an Email client:"))
-        } catch (e: ActivityNotFoundException) {
-            Log.e("AboutFragment", "No email client found", e)
-        } catch (e: IllegalArgumentException) {
-            Log.e("AboutFragment", "Invalid argument for sending email", e)
-        }
     }
 
     private fun loadOtherFragment(fragment: Fragment, pageName: String?) {

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -33,7 +33,7 @@ class AboutFragment : ScribeFragment("About") {
         callback.isEnabled = true
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
         (requireActivity() as MainActivity).setActionBarVisibility(false)
-        (requireActivity() as MainActivity).setActionBarButtonInvisible()
+        (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
         return binding.root
     }
 

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -1,7 +1,5 @@
 package be.scri.fragments
 
-import android.content.ActivityNotFoundException
-import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -118,7 +118,7 @@ class AboutFragment : Fragment() {
                 image2 = R.drawable.right_arrow,
                 url = null,
                 activity = null,
-                action = ::loadWikimediaScribeFragment,
+                action = ({ loadOtherFragment(WikimediaScribeFragment(), "WikimediaScribePage") }),
             ),
         )
 
@@ -174,7 +174,7 @@ class AboutFragment : Fragment() {
                 image2 = R.drawable.right_arrow,
                 url = null,
                 activity = null,
-                action = ::loadPrivacyPolicyFragment,
+                action = ({ loadOtherFragment(PrivacyPolicyFragment(), null) }),
             ),
             ItemsViewModel(
                 image = R.drawable.license_icon,
@@ -182,7 +182,7 @@ class AboutFragment : Fragment() {
                 image2 = R.drawable.right_arrow,
                 url = null,
                 activity = null,
-                action = ::loadThirdPartyLicensesFragment,
+                action = ({ loadOtherFragment(ThirdPartyFragment(), null) }),
             ),
         )
 
@@ -222,36 +222,15 @@ class AboutFragment : Fragment() {
         }
     }
 
-    private fun loadWikimediaScribeFragment() {
+    private fun loadOtherFragment(fragment: Fragment, pageName: String?) {
         try {
-            val fragment = WikimediaScribeFragment()
             val fragmentTransaction = requireActivity().supportFragmentManager.beginTransaction()
-            fragmentTransaction.replace(R.id.fragment_container, fragment, "WikimediaScribePage")
-            fragmentTransaction.addToBackStack("WikimediaScribePage")
-            fragmentTransaction.commit()
-        } catch (e: IllegalStateException) {
-            Log.e("AboutFragment", "Failed to load fragment", e)
-        }
-    }
-
-    private fun loadPrivacyPolicyFragment() {
-        try {
-            val fragment = PrivacyPolicyFragment()
-            val fragmentTransaction = requireActivity().supportFragmentManager.beginTransaction()
-            fragmentTransaction.replace(R.id.fragment_container, fragment)
-            fragmentTransaction.addToBackStack(null)
-            fragmentTransaction.commit()
-        } catch (e: IllegalStateException) {
-            Log.e("AboutFragment", "Failed to load fragment", e)
-        }
-    }
-
-    private fun loadThirdPartyLicensesFragment() {
-        try {
-            val fragment = ThirdPartyFragment()
-            val fragmentTransaction = requireActivity().supportFragmentManager.beginTransaction()
-            fragmentTransaction.replace(R.id.fragment_container, fragment)
-            fragmentTransaction.addToBackStack(null)
+            if (pageName != null) {
+                fragmentTransaction.replace(R.id.fragment_container, fragment, pageName)
+            } else {
+                fragmentTransaction.replace(R.id.fragment_container, fragment)
+            }
+            fragmentTransaction.addToBackStack(pageName)
             fragmentTransaction.commit()
         } catch (e: IllegalStateException) {
             Log.e("AboutFragment", "Failed to load fragment", e)

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -1,22 +1,15 @@
 package be.scri.fragments
 
-import CustomDividerItemDecoration
 import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.activity.addCallback
-import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import be.scri.BuildConfig
 import be.scri.R
 import be.scri.activities.MainActivity
@@ -25,8 +18,8 @@ import be.scri.extensions.addCustomItemDecoration
 import be.scri.helpers.CustomAdapter
 import be.scri.helpers.HintUtils
 import be.scri.helpers.ShareHelper
+import be.scri.helpers.RatingHelper
 import be.scri.models.ItemsViewModel
-import com.google.android.play.core.review.ReviewManagerFactory
 
 class AboutFragment : Fragment() {
     private lateinit var binding: FragmentAboutBinding
@@ -132,7 +125,7 @@ class AboutFragment : Fragment() {
                 image2 = R.drawable.external_link,
                 url = null,
                 activity = null,
-                action = ::rateScribe,
+                action = ({ RatingHelper.rateScribe(requireContext(), activity as MainActivity) }),
             ),
             ItemsViewModel(
                 image = R.drawable.bug_report_icon,
@@ -205,47 +198,6 @@ class AboutFragment : Fragment() {
             fragmentTransaction.commit()
         } catch (e: IllegalStateException) {
             Log.e("AboutFragment", "Failed to load fragment", e)
-        }
-    }
-
-    private fun getInstallSource(context: Context): String? =
-        try {
-            val packageManager = context.packageManager
-            packageManager.getInstallerPackageName(context.packageName)
-        } catch (e: PackageManager.NameNotFoundException) {
-            null
-        }
-
-    private fun rateScribe() {
-        val context = requireContext()
-        var installSource = getInstallSource(context)
-
-        if (installSource == "com.android.vending") {
-            val reviewManager = ReviewManagerFactory.create(context)
-            val request = reviewManager.requestReviewFlow()
-
-            request.addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    val reviewInfo = task.result
-                    val activity = requireActivity()
-                    reviewManager
-                        .launchReviewFlow(activity, reviewInfo)
-                        .addOnCompleteListener { _ ->
-                        }
-                } else {
-                    Toast.makeText(context, "Failed to launch review flow", Toast.LENGTH_SHORT).show()
-                }
-            }
-        } else if (installSource == "org.fdroid.fdroid") {
-            val url = "https://f-droid.org/packages/${context.packageName}"
-            val intent =
-                Intent(Intent.ACTION_VIEW)
-                    .apply {
-                        data = Uri.parse(url)
-                    }
-            context.startActivity(intent)
-        } else {
-            Toast.makeText(context, "Unknown installation source", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -1,12 +1,10 @@
 package be.scri.fragments
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.addCallback
-import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import be.scri.BuildConfig
 import be.scri.R
@@ -19,7 +17,7 @@ import be.scri.helpers.RatingHelper
 import be.scri.helpers.ShareHelper
 import be.scri.models.ItemsViewModel
 
-class AboutFragment : Fragment() {
+class AboutFragment : ScribeFragment("About") {
     private lateinit var binding: FragmentAboutBinding
 
     override fun onCreateView(
@@ -184,31 +182,8 @@ class AboutFragment : Fragment() {
         (activity as MainActivity).showHint("hint_shown_about", R.string.app_about_app_hint)
     }
 
-    private fun loadOtherFragment(
-        fragment: Fragment,
-        pageName: String?,
-    ) {
-        try {
-            val fragmentTransaction = requireActivity().supportFragmentManager.beginTransaction()
-            if (pageName != null) {
-                fragmentTransaction.replace(R.id.fragment_container, fragment, pageName)
-            } else {
-                fragmentTransaction.replace(R.id.fragment_container, fragment)
-            }
-            fragmentTransaction.addToBackStack(pageName)
-            fragmentTransaction.commit()
-        } catch (e: IllegalStateException) {
-            Log.e("AboutFragment", "Failed to load fragment", e)
-        }
-    }
-
     override fun onResume() {
         super.onResume()
         (activity as MainActivity).showHint("hint_shown_about", R.string.app_about_app_hint)
-    }
-
-    override fun onPause() {
-        super.onPause()
-        (activity as MainActivity).hideHint()
     }
 }

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -32,7 +32,7 @@ class AboutFragment : ScribeFragment("About") {
             }
         callback.isEnabled = true
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
-        (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+        (requireActivity() as MainActivity).setActionBarVisibility(false)
         (requireActivity() as MainActivity).setActionBarButtonInvisible()
         return binding.root
     }

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -15,8 +15,8 @@ import be.scri.databinding.FragmentAboutBinding
 import be.scri.extensions.addCustomItemDecoration
 import be.scri.helpers.CustomAdapter
 import be.scri.helpers.HintUtils
-import be.scri.helpers.ShareHelper
 import be.scri.helpers.RatingHelper
+import be.scri.helpers.ShareHelper
 import be.scri.models.ItemsViewModel
 
 class AboutFragment : Fragment() {
@@ -184,7 +184,10 @@ class AboutFragment : Fragment() {
         (activity as MainActivity).showHint("hint_shown_about", R.string.app_about_app_hint)
     }
 
-    private fun loadOtherFragment(fragment: Fragment, pageName: String?) {
+    private fun loadOtherFragment(
+        fragment: Fragment,
+        pageName: String?,
+    ) {
         try {
             val fragmentTransaction = requireActivity().supportFragmentManager.beginTransaction()
             if (pageName != null) {

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -60,33 +60,22 @@ class AboutFragment : Fragment() {
         recyclerView1.adapter = CustomAdapter(getFirstRecyclerViewData(), requireContext())
         recyclerView1.suppressLayout(true)
         recyclerView1.apply {
-            addCustomItemDecoration()
+            addCustomItemDecoration(requireContext())
         }
         val recyclerView2 = binding.recycleView
         recyclerView2.layoutManager = LinearLayoutManager(context)
         recyclerView2.adapter = CustomAdapter(getSecondRecyclerViewData(), requireContext())
         recyclerView2.suppressLayout(true)
         recyclerView2.apply {
-            addCustomItemDecoration()
+            addCustomItemDecoration(requireContext())
         }
         val recyclerView3 = binding.recycleView3
         recyclerView3.layoutManager = LinearLayoutManager(context)
         recyclerView3.adapter = CustomAdapter(getThirdRecyclerViewData(), requireContext())
         recyclerView3.suppressLayout(true)
         recyclerView3.apply {
-            addCustomItemDecoration()
+            addCustomItemDecoration(requireContext())
         }
-    }
-
-    private fun RecyclerView.addCustomItemDecoration() {
-        val itemDecoration =
-            CustomDividerItemDecoration(
-                drawable = getDrawable(requireContext(), R.drawable.rv_divider)!!,
-                width = 1,
-                marginLeft = 50,
-                marginRight = 50,
-            )
-        addItemDecoration(itemDecoration)
     }
 
     private fun getFirstRecyclerViewData(): List<Any> =

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -2,12 +2,10 @@ package be.scri.fragments
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
@@ -17,6 +15,7 @@ import be.scri.R
 import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentLanguageSettingsBinding
 import be.scri.helpers.CustomAdapter
+import be.scri.helpers.PreferencesHelper
 import be.scri.models.SwitchItem
 
 @Suppress("LongMethod")
@@ -119,8 +118,12 @@ class LanguageSettingsFragment : Fragment() {
                 isChecked = sharedPref.getBoolean("period_on_double_tap_$language", false),
                 title = getString(R.string.app_settings_keyboard_functionality_double_space_period),
                 description = getString(R.string.app_settings_keyboard_functionality_double_space_period_description),
-                action = { enablePeriodOnSpaceBarDoubleTap(language) },
-                action2 = { disablePeriodOnSpaceBarDoubleTap(language) },
+                action = {
+                    PreferencesHelper.setPeriodOnSpaceBarDoubleTapPreference(requireContext(), language, true)
+                },
+                action2 = {
+                    PreferencesHelper.setPeriodOnSpaceBarDoubleTapPreference(requireContext(), language, false)
+                },
             ),
         )
         list.add(
@@ -128,8 +131,12 @@ class LanguageSettingsFragment : Fragment() {
                 isChecked = sharedPref.getBoolean("autosuggest_emojis_$language", true),
                 title = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji),
                 description = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description),
-                action = { enableEmojiAutosuggestions(language) },
-                action2 = { disableEmojiAutosuggestions(language) },
+                action = {
+                    PreferencesHelper.setEmojiAutoSuggestionsPreference(requireContext(), language, true)
+                },
+                action2 = {
+                    PreferencesHelper.setEmojiAutoSuggestionsPreference(requireContext(), language, false)
+                },
             ),
         )
         return list
@@ -155,8 +162,12 @@ class LanguageSettingsFragment : Fragment() {
                             getString(
                                 R.string.app_settings_keyboard_layout_disable_accent_characters_description,
                             ),
-                        action = { disableAccentCharacter(language) },
-                        action2 = { enableAccentCharacters(language) },
+                        action = {
+                            PreferencesHelper.setAccentCharacterPreference(requireContext(), language, true)
+                        },
+                        action2 = {
+                            PreferencesHelper.setAccentCharacterPreference(requireContext(), language, false)
+                        },
                     ),
                 )
             }
@@ -176,8 +187,12 @@ class LanguageSettingsFragment : Fragment() {
                             getString(
                                 R.string.app_settings_keyboard_layout_disable_accent_characters_description,
                             ),
-                        action = { disableAccentCharacter(language) },
-                        action2 = { enableAccentCharacters(language) },
+                        action = {
+                            PreferencesHelper.setAccentCharacterPreference(requireContext(), language, true)
+                        },
+                        action2 = {
+                            PreferencesHelper.setAccentCharacterPreference(requireContext(), language, false)
+                        },
                     ),
                 )
             }
@@ -197,8 +212,12 @@ class LanguageSettingsFragment : Fragment() {
                             getString(
                                 R.string.app_settings_keyboard_layout_disable_accent_characters_description,
                             ),
-                        action = { disableAccentCharacter(language) },
-                        action2 = { enableAccentCharacters(language) },
+                        action = {
+                            PreferencesHelper.setAccentCharacterPreference(requireContext(), language, true)
+                        },
+                        action2 = {
+                            PreferencesHelper.setAccentCharacterPreference(requireContext(), language, false)
+                        },
                     ),
                 )
             }
@@ -208,8 +227,12 @@ class LanguageSettingsFragment : Fragment() {
                 isChecked = sharedPref.getBoolean("period_on_double_tap_$language", false),
                 title = getString(R.string.app_settings_keyboard_functionality_double_space_period),
                 description = getString(R.string.app_settings_keyboard_functionality_double_space_period_description),
-                action = { enablePeriodOnSpaceBarDoubleTap(language) },
-                action2 = { disablePeriodOnSpaceBarDoubleTap(language) },
+                action = {
+                    PreferencesHelper.setPeriodOnSpaceBarDoubleTapPreference(requireContext(), language, true)
+                },
+                action2 = {
+                    PreferencesHelper.setPeriodOnSpaceBarDoubleTapPreference(requireContext(), language, false)
+                },
             ),
         )
         list.add(
@@ -217,8 +240,12 @@ class LanguageSettingsFragment : Fragment() {
                 isChecked = sharedPref.getBoolean("emoji_suggestions_$language", true),
                 title = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji),
                 description = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description),
-                action = { enableEmojiAutosuggestions(language) },
-                action2 = { disableEmojiAutosuggestions(language) },
+                action = {
+                    PreferencesHelper.setEmojiAutoSuggestionsPreference(requireContext(), language, true)
+                },
+                action2 = {
+                    PreferencesHelper.setEmojiAutoSuggestionsPreference(requireContext(), language, false)
+                },
             ),
         )
         list.add(
@@ -226,67 +253,11 @@ class LanguageSettingsFragment : Fragment() {
                 isChecked = sharedPref.getBoolean("period_and_comma_$language", false),
                 title = getString(R.string.app_settings_keyboard_layout_period_and_comma),
                 description = getString(R.string.app_settings_keyboard_layout_period_and_comma_description),
-                action = { enableCommaAndPeriod() },
-                action2 = { disableCommaAndPeriod() },
+                action = { PreferencesHelper.setCommaAndPeriodPreference() },
+                action2 = { PreferencesHelper.setCommaAndPeriodPreference() },
             ),
         )
         return list
-    }
-
-    private fun enableAccentCharacters(language: String) {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("disable_accent_character_$language", false)
-        editor.apply()
-        Toast.makeText(requireContext(), "$language Accent Character Enabled", Toast.LENGTH_SHORT).show()
-    }
-
-    private fun disableAccentCharacter(language: String) {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("disable_accent_character_$language", true)
-        editor.apply()
-        Toast.makeText(requireContext(), "$language Accent Characters Disabled", Toast.LENGTH_SHORT).show()
-    }
-
-    private fun enablePeriodOnSpaceBarDoubleTap(language: String) {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("period_on_double_tap_$language", true)
-        editor.apply()
-        Toast.makeText(requireContext(), "$language Period on Double Tap of Space Bar on ", Toast.LENGTH_SHORT).show()
-    }
-
-    private fun disablePeriodOnSpaceBarDoubleTap(language: String) {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("period_on_double_tap_$language", false)
-        editor.apply()
-        Toast.makeText(requireContext(), "$language Period on Double Tap of Space Bar on ", Toast.LENGTH_SHORT).show()
-    }
-
-    private fun enableEmojiAutosuggestions(language: String) {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("emoji_suggestions_$language", true)
-        editor.apply()
-        Toast.makeText(requireContext(), "$language Emoji Autosuggestions on", Toast.LENGTH_SHORT).show()
-    }
-
-    private fun disableEmojiAutosuggestions(language: String) {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("emoji_suggestions_$language", false)
-        editor.apply()
-        Toast.makeText(requireContext(), "$language Emoji Autosuggestions off", Toast.LENGTH_SHORT).show()
-    }
-
-    private fun enableCommaAndPeriod() {
-        Log.d("LanguageSettingsFragment", "This enableCommaAndPeriod-function is to be implemented later")
-    }
-
-    private fun disableCommaAndPeriod() {
-        Log.d("LanguageSettingsFragment", "This disableCommaAndPeriod-function is to be implemented later")
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -85,10 +85,10 @@ class LanguageSettingsFragment : Fragment() {
         val titleInt = getLanguageStringFromi18n(language)
         (requireActivity() as MainActivity).setActionBarTitle(titleInt)
         (requireActivity() as MainActivity).showFragmentContainer()
-        (requireActivity() as MainActivity).setActionBarButtonVisible()
+        (requireActivity() as MainActivity).setActionBarButtonVisibility(true)
         (requireActivity() as MainActivity).setActionBarButtonFunction(3, R.string.app_settings_title)
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
-            (requireActivity() as MainActivity).setActionBarButtonInvisible()
+            (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
             parentFragmentManager
                 .beginTransaction()
                 .replace(R.id.fragment_container, SettingsFragment())

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -31,9 +31,9 @@ class LanguageSettingsFragment : Fragment() {
             requireActivity().onBackPressedDispatcher.addCallback(this) {
                 viewpager.setCurrentItem(3, true)
                 (requireActivity() as MainActivity).supportActionBar?.setDisplayHomeAsUpEnabled(false)
-                (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                (requireActivity() as MainActivity).setActionBarVisibility(false)
             }
-        (requireActivity() as MainActivity).setActionBarLayoutMargin()
+        (requireActivity() as MainActivity).setActionBarVisibility(true)
         (requireActivity() as MainActivity)
             .supportActionBar
             ?.customView
@@ -54,11 +54,11 @@ class LanguageSettingsFragment : Fragment() {
                 override fun handleOnBackPressed() {
                     val viewpager = requireActivity().findViewById<ViewPager2>(R.id.view_pager)
                     val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
-                    (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                    (requireActivity() as MainActivity).setActionBarVisibility(false)
                     if (viewpager.currentItem == 3) {
                         viewpager.setCurrentItem(3, true)
                         frameLayout.visibility = View.GONE
-                        (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                        (requireActivity() as MainActivity).setActionBarVisibility(false)
                     } else {
                         if (parentFragmentManager.backStackEntryCount > 0) {
                             parentFragmentManager.popBackStack()

--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -171,6 +171,7 @@ class LanguageSettingsFragment : Fragment() {
                     ),
                 )
             }
+
             "Swedish" -> {
                 list.add(
                     SwitchItem(
@@ -196,6 +197,7 @@ class LanguageSettingsFragment : Fragment() {
                     ),
                 )
             }
+
             "Spanish" -> {
                 list.add(
                     SwitchItem(

--- a/app/src/main/java/be/scri/fragments/MainFragment.kt
+++ b/app/src/main/java/be/scri/fragments/MainFragment.kt
@@ -31,7 +31,7 @@ class MainFragment : ScribeFragment("Main") {
         binding.cardView.setOnClickListener {
             openKeyboardSettings()
         }
-        (requireActivity() as MainActivity).setActionBarLayoutMargin(false)
+        (requireActivity() as MainActivity).setActionBarVisibility(false)
         applyUserDarkModePreference()
         val callback =
             requireActivity().onBackPressedDispatcher.addCallback(this) {

--- a/app/src/main/java/be/scri/fragments/MainFragment.kt
+++ b/app/src/main/java/be/scri/fragments/MainFragment.kt
@@ -37,7 +37,7 @@ class MainFragment : ScribeFragment("Main") {
             requireActivity().onBackPressedDispatcher.addCallback(this) {
                 getParentFragmentManager().popBackStack()
             }
-        (requireActivity() as MainActivity).setActionBarButtonInvisible()
+        (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
         callback.isEnabled = true
         return binding.root
     }

--- a/app/src/main/java/be/scri/fragments/MainFragment.kt
+++ b/app/src/main/java/be/scri/fragments/MainFragment.kt
@@ -11,12 +11,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.fragment.app.Fragment
 import be.scri.R
 import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentMainBinding
 
-class MainFragment : Fragment() {
+class MainFragment : ScribeFragment("Main") {
     private var _binding: FragmentMainBinding? = null
     val binding get() = _binding!!
 
@@ -32,7 +31,7 @@ class MainFragment : Fragment() {
         binding.cardView.setOnClickListener {
             openKeyboardSettings()
         }
-        (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+        (requireActivity() as MainActivity).setActionBarLayoutMargin(false)
         applyUserDarkModePreference()
         val callback =
             requireActivity().onBackPressedDispatcher.addCallback(this) {
@@ -86,10 +85,5 @@ class MainFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         (activity as MainActivity).showHint("hint_shown_main", R.string.app_installation_app_hint)
-    }
-
-    override fun onPause() {
-        super.onPause()
-        (activity as MainActivity).hideHint()
     }
 }

--- a/app/src/main/java/be/scri/fragments/PrivacyPolicyFragment.kt
+++ b/app/src/main/java/be/scri/fragments/PrivacyPolicyFragment.kt
@@ -24,11 +24,11 @@ class PrivacyPolicyFragment : Fragment() {
         val callback =
             requireActivity().onBackPressedDispatcher.addCallback(this) {
                 viewpager.setCurrentItem(2, true)
-                (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                (requireActivity() as MainActivity).setActionBarVisibility(false)
             }
         (requireActivity() as MainActivity).setActionBarButtonVisible()
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_legal_privacy_policy)
-        (requireActivity() as MainActivity).setActionBarLayoutMargin()
+        (requireActivity() as MainActivity).setActionBarVisibility(true)
         val textView =
             (requireActivity() as MainActivity)
                 .supportActionBar
@@ -67,7 +67,7 @@ class PrivacyPolicyFragment : Fragment() {
                     val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
                     (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
                     (requireActivity() as MainActivity).setActionBarButtonInvisible()
-                    (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                    (requireActivity() as MainActivity).setActionBarVisibility(false)
                     if (viewpager.currentItem == 2) {
                         viewpager.setCurrentItem(2, true)
                         frameLayout.visibility = View.GONE

--- a/app/src/main/java/be/scri/fragments/PrivacyPolicyFragment.kt
+++ b/app/src/main/java/be/scri/fragments/PrivacyPolicyFragment.kt
@@ -26,7 +26,7 @@ class PrivacyPolicyFragment : Fragment() {
                 viewpager.setCurrentItem(2, true)
                 (requireActivity() as MainActivity).setActionBarVisibility(false)
             }
-        (requireActivity() as MainActivity).setActionBarButtonVisible()
+        (requireActivity() as MainActivity).setActionBarButtonVisibility(true)
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_legal_privacy_policy)
         (requireActivity() as MainActivity).setActionBarVisibility(true)
         val textView =
@@ -66,7 +66,7 @@ class PrivacyPolicyFragment : Fragment() {
                     val viewpager = requireActivity().findViewById<ViewPager2>(R.id.view_pager)
                     val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
                     (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
-                    (requireActivity() as MainActivity).setActionBarButtonInvisible()
+                    (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
                     (requireActivity() as MainActivity).setActionBarVisibility(false)
                     if (viewpager.currentItem == 2) {
                         viewpager.setCurrentItem(2, true)

--- a/app/src/main/java/be/scri/fragments/ScribeFragment.kt
+++ b/app/src/main/java/be/scri/fragments/ScribeFragment.kt
@@ -1,0 +1,33 @@
+package be.scri.fragments
+
+import android.util.Log
+import androidx.fragment.app.Fragment
+import be.scri.R
+import be.scri.activities.MainActivity
+
+abstract class ScribeFragment(
+    val fragmentName: String,
+) : Fragment() {
+    override fun onPause() {
+        super.onPause()
+        (activity as MainActivity).hideHint()
+    }
+
+    protected fun loadOtherFragment(
+        fragment: Fragment,
+        pageName: String?,
+    ) {
+        try {
+            val fragmentTransaction = requireActivity().supportFragmentManager.beginTransaction()
+            if (pageName != null) {
+                fragmentTransaction.replace(R.id.fragment_container, fragment, pageName)
+            } else {
+                fragmentTransaction.replace(R.id.fragment_container, fragment)
+            }
+            fragmentTransaction.addToBackStack(pageName)
+            fragmentTransaction.commit()
+        } catch (e: IllegalStateException) {
+            Log.e("${fragmentName}Fragment", "Failed to load fragment", e)
+        }
+    }
+}

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -26,6 +26,7 @@ import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentSettingsBinding
 import be.scri.extensions.config
 import be.scri.helpers.CustomAdapter
+import be.scri.helpers.PreferencesHelper
 import be.scri.models.SwitchItem
 import be.scri.models.TextItem
 
@@ -98,22 +99,30 @@ class SettingsFragment : Fragment() {
                 getString(R.string.app_settings_menu_app_color_mode),
                 description = getString(R.string.app_settings_menu_app_color_mode_description),
                 isChecked = sharedPref.getBoolean("dark_mode", isUserDarkMode),
-                action = ::darkMode,
-                action2 = ::lightMode,
+                action = ({ setLightDarkMode(isDarkMode = true) }),
+                action2 = ({ setLightDarkMode(isDarkMode = false) }),
             ),
             SwitchItem(
                 getString(R.string.app_settings_keyboard_keypress_vibration),
                 description = getString(R.string.app_settings_keyboard_keypress_vibration_description),
                 isChecked = requireContext().config.vibrateOnKeypress,
-                action = ::enableVibrateOnKeypress,
-                action2 = ::disableVibrateOnKeypress,
+                action = ({
+                    PreferencesHelper.setVibrateOnKeypress(requireContext(), shouldVibrateOnKeypress = true)
+                }),
+                action2 = ({
+                    PreferencesHelper.setVibrateOnKeypress(requireContext(), shouldVibrateOnKeypress = false)
+                }),
             ),
             SwitchItem(
                 getString(R.string.app_settings_keyboard_functionality_popup_on_keypress),
                 description = getString(R.string.app_settings_keyboard_functionality_popup_on_keypress_description),
                 isChecked = requireContext().config.showPopupOnKeypress,
-                action = ::enableShowPopupOnKeypress,
-                action2 = ::disableShowPopupOnKeypress,
+                action = ({
+                    PreferencesHelper.setShowPopupOnKeypress(requireContext(), shouldShowPopupOnKeypress = true)
+                }),
+                action2 = ({
+                    PreferencesHelper.setShowPopupOnKeypress(requireContext(), shouldShowPopupOnKeypress = false)
+                }),
             ),
         )
     }
@@ -231,54 +240,12 @@ class SettingsFragment : Fragment() {
         return result
     }
 
-    private fun lightMode() {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("dark_mode", false)
-        editor.apply()
-        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+    private fun setLightDarkMode(isDarkMode: Boolean) {
+        PreferencesHelper.setLightDarkModePreference(requireContext(), isDarkMode)
+        AppCompatDelegate.setDefaultNightMode(
+            if (isDarkMode) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO
+        )
         requireActivity().recreate()
-    }
-
-    private fun darkMode() {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("dark_mode", true)
-        editor.apply()
-        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-        requireActivity().recreate()
-    }
-
-    private fun enableVibrateOnKeypress() {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("vibrate_on_keypress", true)
-        editor.apply()
-        requireActivity().config.vibrateOnKeypress = true
-    }
-
-    private fun disableVibrateOnKeypress() {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("vibrate_on_keypress", false)
-        editor.apply()
-        requireActivity().config.vibrateOnKeypress = false
-    }
-
-    private fun enableShowPopupOnKeypress() {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("show_popup_on_keypress", true)
-        editor.apply()
-        requireActivity().config.showPopupOnKeypress = true
-    }
-
-    private fun disableShowPopupOnKeypress() {
-        val sharedPref = requireActivity().getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        val editor = sharedPref.edit()
-        editor.putBoolean("show_popup_on_keypress", false)
-        editor.apply()
-        requireActivity().config.showPopupOnKeypress = false
     }
 
     private fun setupItemVisibility() {

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -104,23 +104,23 @@ class SettingsFragment : Fragment() {
                 getString(R.string.app_settings_keyboard_keypress_vibration),
                 description = getString(R.string.app_settings_keyboard_keypress_vibration_description),
                 isChecked = requireContext().config.vibrateOnKeypress,
-                action = ({
-                    PreferencesHelper.setVibrateOnKeypress(requireContext(), shouldVibrateOnKeypress = true)
-                }),
-                action2 = ({
-                    PreferencesHelper.setVibrateOnKeypress(requireContext(), shouldVibrateOnKeypress = false)
-                }),
+                action = (
+                    { PreferencesHelper.setVibrateOnKeypress(requireContext(), shouldVibrateOnKeypress = true) }
+                ),
+                action2 = (
+                    { PreferencesHelper.setVibrateOnKeypress(requireContext(), shouldVibrateOnKeypress = false) }
+                ),
             ),
             SwitchItem(
                 getString(R.string.app_settings_keyboard_functionality_popup_on_keypress),
                 description = getString(R.string.app_settings_keyboard_functionality_popup_on_keypress_description),
                 isChecked = requireContext().config.showPopupOnKeypress,
-                action = ({
-                    PreferencesHelper.setShowPopupOnKeypress(requireContext(), shouldShowPopupOnKeypress = true)
-                }),
-                action2 = ({
-                    PreferencesHelper.setShowPopupOnKeypress(requireContext(), shouldShowPopupOnKeypress = false)
-                }),
+                action2 = (
+                    { PreferencesHelper.setShowPopupOnKeypress(requireContext(), shouldShowPopupOnKeypress = false) }
+                ),
+                action = (
+                    { PreferencesHelper.setShowPopupOnKeypress(requireContext(), shouldShowPopupOnKeypress = true) }
+                ),
             ),
         )
     }
@@ -230,7 +230,7 @@ class SettingsFragment : Fragment() {
     private fun setLightDarkMode(isDarkMode: Boolean) {
         PreferencesHelper.setLightDarkModePreference(requireContext(), isDarkMode)
         AppCompatDelegate.setDefaultNightMode(
-            if (isDarkMode) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO
+            if (isDarkMode) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO,
         )
         requireActivity().recreate()
     }

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -42,7 +42,7 @@ class SettingsFragment : ScribeFragment("Settings") {
                 getParentFragmentManager().popBackStack()
             }
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_settings_title)
-        (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+        (requireActivity() as MainActivity).setActionBarVisibility(false)
         (requireActivity() as MainActivity).setActionBarButtonInvisible()
         callback.isEnabled = true
         (requireActivity() as MainActivity).supportActionBar?.title = getString(R.string.app_settings_title)

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -43,7 +43,7 @@ class SettingsFragment : ScribeFragment("Settings") {
             }
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_settings_title)
         (requireActivity() as MainActivity).setActionBarVisibility(false)
-        (requireActivity() as MainActivity).setActionBarButtonInvisible()
+        (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
         callback.isEnabled = true
         (requireActivity() as MainActivity).supportActionBar?.title = getString(R.string.app_settings_title)
         return binding.root

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -1,6 +1,5 @@
 package be.scri.fragments
 
-import CustomDividerItemDecoration
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -17,13 +16,12 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import be.scri.R
 import be.scri.activities.MainActivity
 import be.scri.databinding.FragmentSettingsBinding
+import be.scri.extensions.addCustomItemDecoration
 import be.scri.extensions.config
 import be.scri.helpers.CustomAdapter
 import be.scri.helpers.PreferencesHelper
@@ -161,20 +159,9 @@ class SettingsFragment : Fragment() {
         if (!isDecorationSet) {
             isDecorationSet = true
             recyclerView.apply {
-                addCustomItemDecoration()
+                addCustomItemDecoration(requireContext())
             }
         }
-    }
-
-    private fun RecyclerView.addCustomItemDecoration() {
-        val itemDecoration =
-            CustomDividerItemDecoration(
-                drawable = getDrawable(requireContext(), R.drawable.rv_divider)!!,
-                width = 1,
-                marginLeft = 50,
-                marginRight = 50,
-            )
-        addItemDecoration(itemDecoration)
     }
 
     private fun getRecyclerViewElements(): MutableList<TextItem> {

--- a/app/src/main/java/be/scri/fragments/SettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/SettingsFragment.kt
@@ -16,7 +16,6 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import be.scri.R
 import be.scri.activities.MainActivity
@@ -28,7 +27,7 @@ import be.scri.helpers.PreferencesHelper
 import be.scri.models.SwitchItem
 import be.scri.models.TextItem
 
-class SettingsFragment : Fragment() {
+class SettingsFragment : ScribeFragment("Settings") {
     private lateinit var binding: FragmentSettingsBinding
     private var isDecorationSet: Boolean = false
 
@@ -61,7 +60,8 @@ class SettingsFragment : Fragment() {
         val enabledInputMethods = imm.enabledInputMethodList
         for (inputMethod in enabledInputMethods) {
             if (inputMethod.packageName == "be.scri.debug") {
-                setupItemVisibility()
+                binding.btnInstall.visibility = View.INVISIBLE
+                binding.selectLanguage.visibility = View.VISIBLE
             }
         }
 
@@ -147,7 +147,8 @@ class SettingsFragment : Fragment() {
         val enabledInputMethods = imm.enabledInputMethodList
         for (inputMethod in enabledInputMethods) {
             if (inputMethod.packageName == "be.scri.debug") {
-                setupItemVisibility()
+                binding.btnInstall.visibility = View.INVISIBLE
+                binding.selectLanguage.visibility = View.VISIBLE
             }
         }
         val recyclerView = binding.recyclerView2
@@ -184,26 +185,22 @@ class SettingsFragment : Fragment() {
                 TextItem(
                     text = localizeLanguage,
                     image = R.drawable.right_arrow,
-                    action = { loadLanguageSettingsFragment(language) },
+                    action = {
+                        loadOtherFragment(
+                            LanguageSettingsFragment().apply {
+                                arguments =
+                                    Bundle().apply {
+                                        putString("LANGUAGE_EXTRA", language)
+                                    }
+                            },
+                            "LanguageFragment",
+                        )
+                    },
                     language = language,
                 ),
             )
         }
         return list
-    }
-
-    private fun loadLanguageSettingsFragment(language: String) {
-        val fragment =
-            LanguageSettingsFragment().apply {
-                arguments =
-                    Bundle().apply {
-                        putString("LANGUAGE_EXTRA", language)
-                    }
-            }
-        val fragmentTransaction = requireActivity().supportFragmentManager.beginTransaction()
-        fragmentTransaction.replace(R.id.fragment_container, fragment, "LanguageFragment")
-        fragmentTransaction.addToBackStack("LanguageFragment")
-        fragmentTransaction.commit()
     }
 
     private fun setupKeyboardLanguage(): MutableList<String> {
@@ -235,19 +232,9 @@ class SettingsFragment : Fragment() {
         requireActivity().recreate()
     }
 
-    private fun setupItemVisibility() {
-        binding.btnInstall.visibility = View.INVISIBLE
-        binding.selectLanguage.visibility = View.VISIBLE
-    }
-
     override fun onResume() {
         super.onResume()
         (activity as MainActivity).showHint("hint_shown_settings", R.string.app_settings_app_hint)
         setupRecyclerView2()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        (activity as MainActivity).hideHint()
     }
 }

--- a/app/src/main/java/be/scri/fragments/ThirdPartyFragment.kt
+++ b/app/src/main/java/be/scri/fragments/ThirdPartyFragment.kt
@@ -23,12 +23,12 @@ class ThirdPartyFragment : Fragment() {
         val callback =
             requireActivity().onBackPressedDispatcher.addCallback(this) {
                 viewpager.setCurrentItem(2, true)
-                (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                (requireActivity() as MainActivity).setActionBarVisibility(false)
             }
         (requireActivity() as MainActivity).setActionBarButtonFunction(2, R.string.app_about_title)
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_legal_privacy_policy)
         (requireActivity() as MainActivity).setActionBarButtonVisible()
-        (requireActivity() as MainActivity).setActionBarLayoutMargin()
+        (requireActivity() as MainActivity).setActionBarVisibility(true)
         (requireActivity() as MainActivity)
             .supportActionBar
             ?.customView
@@ -53,7 +53,7 @@ class ThirdPartyFragment : Fragment() {
                     val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
                     (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
                     (requireActivity() as MainActivity).setActionBarButtonInvisible()
-                    (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                    (requireActivity() as MainActivity).setActionBarVisibility(false)
 
                     if (viewpager.currentItem == 2) {
                         viewpager.setCurrentItem(2, true)

--- a/app/src/main/java/be/scri/fragments/ThirdPartyFragment.kt
+++ b/app/src/main/java/be/scri/fragments/ThirdPartyFragment.kt
@@ -27,7 +27,7 @@ class ThirdPartyFragment : Fragment() {
             }
         (requireActivity() as MainActivity).setActionBarButtonFunction(2, R.string.app_about_title)
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_legal_privacy_policy)
-        (requireActivity() as MainActivity).setActionBarButtonVisible()
+        (requireActivity() as MainActivity).setActionBarButtonVisibility(true)
         (requireActivity() as MainActivity).setActionBarVisibility(true)
         (requireActivity() as MainActivity)
             .supportActionBar
@@ -52,7 +52,7 @@ class ThirdPartyFragment : Fragment() {
                     val viewpager = requireActivity().findViewById<ViewPager2>(R.id.view_pager)
                     val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
                     (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
-                    (requireActivity() as MainActivity).setActionBarButtonInvisible()
+                    (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
                     (requireActivity() as MainActivity).setActionBarVisibility(false)
 
                     if (viewpager.currentItem == 2) {

--- a/app/src/main/java/be/scri/fragments/WikimediaScribeFragment.kt
+++ b/app/src/main/java/be/scri/fragments/WikimediaScribeFragment.kt
@@ -26,7 +26,7 @@ class WikimediaScribeFragment : Fragment() {
                 (requireActivity() as MainActivity).setActionBarVisibility(false)
             }
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_community_wikimedia)
-        (requireActivity() as MainActivity).setActionBarButtonVisible()
+        (requireActivity() as MainActivity).setActionBarButtonVisibility(true)
         (requireActivity() as MainActivity).setActionBarButtonFunction(2, R.string.app_about_title)
         (requireActivity() as MainActivity).setActionBarVisibility(true)
         (requireActivity() as MainActivity)
@@ -51,7 +51,7 @@ class WikimediaScribeFragment : Fragment() {
                     val viewpager = requireActivity().findViewById<ViewPager2>(R.id.view_pager)
                     val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
                     (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
-                    (requireActivity() as MainActivity).setActionBarButtonInvisible()
+                    (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
                     (requireActivity() as MainActivity).setActionBarVisibility(false)
                     if (viewpager.currentItem == 2) {
                         viewpager.setCurrentItem(2, true)

--- a/app/src/main/java/be/scri/fragments/WikimediaScribeFragment.kt
+++ b/app/src/main/java/be/scri/fragments/WikimediaScribeFragment.kt
@@ -23,12 +23,12 @@ class WikimediaScribeFragment : Fragment() {
         val callback =
             requireActivity().onBackPressedDispatcher.addCallback(this) {
                 viewpager.setCurrentItem(2, true)
-                (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                (requireActivity() as MainActivity).setActionBarVisibility(false)
             }
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_community_wikimedia)
         (requireActivity() as MainActivity).setActionBarButtonVisible()
         (requireActivity() as MainActivity).setActionBarButtonFunction(2, R.string.app_about_title)
-        (requireActivity() as MainActivity).setActionBarLayoutMargin()
+        (requireActivity() as MainActivity).setActionBarVisibility(true)
         (requireActivity() as MainActivity)
             .supportActionBar
             ?.customView
@@ -52,7 +52,7 @@ class WikimediaScribeFragment : Fragment() {
                     val frameLayout = requireActivity().findViewById<ViewGroup>(R.id.fragment_container)
                     (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
                     (requireActivity() as MainActivity).setActionBarButtonInvisible()
-                    (requireActivity() as MainActivity).unsetActionBarLayoutMargin()
+                    (requireActivity() as MainActivity).setActionBarVisibility(false)
                     if (viewpager.currentItem == 2) {
                         viewpager.setCurrentItem(2, true)
                         frameLayout.visibility = View.GONE

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -7,41 +7,68 @@ import be.scri.extensions.config
 
 class PreferencesHelper {
     companion object {
-
-        fun setPeriodOnSpaceBarDoubleTapPreference(context: Context, language: String,
-                                                   shouldEnablePeriodOnSpaceBarDoubleTap: Boolean) {
+        fun setPeriodOnSpaceBarDoubleTapPreference(
+            context: Context,
+            language: String,
+            shouldEnablePeriodOnSpaceBarDoubleTap: Boolean,
+        ) {
             val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
             val editor = sharedPref.edit()
             editor.putBoolean("period_on_double_tap_$language", shouldEnablePeriodOnSpaceBarDoubleTap)
             editor.apply()
-            Toast.makeText(context, "$language Period on Double Tap of Space Bar " +
-                if (shouldEnablePeriodOnSpaceBarDoubleTap) "on" else "off",
-                Toast.LENGTH_SHORT).show()
+            Toast
+                .makeText(
+                    context,
+                    "$language Period on Double Tap of Space Bar " +
+                        if (shouldEnablePeriodOnSpaceBarDoubleTap) "on" else "off",
+                    Toast.LENGTH_SHORT,
+                ).show()
         }
 
-        fun setAccentCharacterPreference(context: Context, language: String, shouldDisableAccentCharacter: Boolean) {
+        fun setAccentCharacterPreference(
+            context: Context,
+            language: String,
+            shouldDisableAccentCharacter: Boolean,
+        ) {
             val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
             val editor = sharedPref.edit()
             editor.putBoolean("disable_accent_character_$language", shouldDisableAccentCharacter)
             editor.apply()
-            Toast.makeText(context, "$language Accent Characters " +
-                if (shouldDisableAccentCharacter) "off" else "on", Toast.LENGTH_SHORT).show()
+            Toast
+                .makeText(
+                    context,
+                    "$language Accent Characters " +
+                        if (shouldDisableAccentCharacter) "off" else "on",
+                    Toast.LENGTH_SHORT,
+                ).show()
         }
 
-        fun setEmojiAutoSuggestionsPreference(context: Context, language: String, shouldShowEmojiSuggestions: Boolean) {
+        fun setEmojiAutoSuggestionsPreference(
+            context: Context,
+            language: String,
+            shouldShowEmojiSuggestions: Boolean,
+        ) {
             val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
             val editor = sharedPref.edit()
             editor.putBoolean("emoji_suggestions_$language", shouldShowEmojiSuggestions)
             editor.apply()
-            Toast.makeText(context, "$language Emoji Autosuggestions " +
-                if (shouldShowEmojiSuggestions) "on" else "off", Toast.LENGTH_SHORT).show()
+            Toast
+                .makeText(
+                    context,
+                    "$language Emoji Autosuggestions " +
+                        if (shouldShowEmojiSuggestions) "on" else "off",
+                    Toast.LENGTH_SHORT,
+                ).show()
         }
 
         fun setCommaAndPeriodPreference() {
             Log.d("PreferencesHelper", "This setCommaAndPeriodPreference-function is to be implemented later")
         }
 
-        fun setVibrateOnKeypress(context: Context, shouldVibrateOnKeypress: Boolean) {
+        fun setVibrateOnKeypress(
+            context: Context,
+            shouldVibrateOnKeypress: Boolean,
+        ) {
             val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
             val editor = sharedPref.edit()
             editor.putBoolean("vibrate_on_keypress", shouldVibrateOnKeypress)
@@ -49,7 +76,10 @@ class PreferencesHelper {
             context.config.vibrateOnKeypress = shouldVibrateOnKeypress
         }
 
-        fun setShowPopupOnKeypress(context: Context, shouldShowPopupOnKeypress: Boolean) {
+        fun setShowPopupOnKeypress(
+            context: Context,
+            shouldShowPopupOnKeypress: Boolean,
+        ) {
             val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
             val editor = sharedPref.edit()
             editor.putBoolean("show_popup_on_keypress", shouldShowPopupOnKeypress)
@@ -57,7 +87,10 @@ class PreferencesHelper {
             context.config.showPopupOnKeypress = shouldShowPopupOnKeypress
         }
 
-        fun setLightDarkModePreference(context: Context, darkMode: Boolean) {
+        fun setLightDarkModePreference(
+            context: Context,
+            darkMode: Boolean,
+        ) {
             val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
             val editor = sharedPref.edit()
             editor.putBoolean("dark_mode", darkMode)

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,0 +1,44 @@
+package be.scri.helpers
+
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import be.scri.extensions.config
+
+class PreferencesHelper {
+    companion object {
+
+        fun setPeriodOnSpaceBarDoubleTapPreference(context: Context, language: String,
+                                                   shouldEnablePeriodOnSpaceBarDoubleTap: Boolean) {
+            val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            val editor = sharedPref.edit()
+            editor.putBoolean("period_on_double_tap_$language", shouldEnablePeriodOnSpaceBarDoubleTap)
+            editor.apply()
+            Toast.makeText(context, "$language Period on Double Tap of Space Bar " +
+                if (shouldEnablePeriodOnSpaceBarDoubleTap) "on" else "off",
+                Toast.LENGTH_SHORT).show()
+        }
+
+        fun setAccentCharacterPreference(context: Context, language: String, shouldDisableAccentCharacter: Boolean) {
+            val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            val editor = sharedPref.edit()
+            editor.putBoolean("disable_accent_character_$language", shouldDisableAccentCharacter)
+            editor.apply()
+            Toast.makeText(context, "$language Accent Characters " +
+                if (shouldDisableAccentCharacter) "off" else "on", Toast.LENGTH_SHORT).show()
+        }
+
+        fun setEmojiAutoSuggestionsPreference(context: Context, language: String, shouldShowEmojiSuggestions: Boolean) {
+            val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            val editor = sharedPref.edit()
+            editor.putBoolean("emoji_suggestions_$language", shouldShowEmojiSuggestions)
+            editor.apply()
+            Toast.makeText(context, "$language Emoji Autosuggestions " +
+                if (shouldShowEmojiSuggestions) "on" else "off", Toast.LENGTH_SHORT).show()
+        }
+
+        fun setCommaAndPeriodPreference() {
+            Log.d("PreferencesHelper", "This setCommaAndPeriodPreference-function is to be implemented later")
+        }
+    }
+}

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,8 +1,11 @@
 package be.scri.helpers
 
+import android.app.UiModeManager
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity.UI_MODE_SERVICE
+import androidx.appcompat.app.AppCompatDelegate
 import be.scri.extensions.config
 
 class PreferencesHelper {
@@ -95,6 +98,18 @@ class PreferencesHelper {
             val editor = sharedPref.edit()
             editor.putBoolean("dark_mode", darkMode)
             editor.apply()
+        }
+
+        fun getUserDarkModePreference(context: Context): Int {
+            val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            val uiModeManager = context.getSystemService(UI_MODE_SERVICE) as UiModeManager
+            val isSystemDarkTheme = uiModeManager.nightMode == UiModeManager.MODE_NIGHT_YES
+            val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkTheme)
+            return if (isUserDarkMode) {
+                AppCompatDelegate.MODE_NIGHT_YES
+            } else {
+                AppCompatDelegate.MODE_NIGHT_NO
+            }
         }
     }
 }

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -40,5 +40,28 @@ class PreferencesHelper {
         fun setCommaAndPeriodPreference() {
             Log.d("PreferencesHelper", "This setCommaAndPeriodPreference-function is to be implemented later")
         }
+
+        fun setVibrateOnKeypress(context: Context, shouldVibrateOnKeypress: Boolean) {
+            val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            val editor = sharedPref.edit()
+            editor.putBoolean("vibrate_on_keypress", shouldVibrateOnKeypress)
+            editor.apply()
+            context.config.vibrateOnKeypress = shouldVibrateOnKeypress
+        }
+
+        fun setShowPopupOnKeypress(context: Context, shouldShowPopupOnKeypress: Boolean) {
+            val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            val editor = sharedPref.edit()
+            editor.putBoolean("show_popup_on_keypress", shouldShowPopupOnKeypress)
+            editor.apply()
+            context.config.showPopupOnKeypress = shouldShowPopupOnKeypress
+        }
+
+        fun setLightDarkModePreference(context: Context, darkMode: Boolean) {
+            val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            val editor = sharedPref.edit()
+            editor.putBoolean("dark_mode", darkMode)
+            editor.apply()
+        }
     }
 }

--- a/app/src/main/java/be/scri/helpers/RatingHelper.kt
+++ b/app/src/main/java/be/scri/helpers/RatingHelper.kt
@@ -9,7 +9,6 @@ import be.scri.activities.MainActivity
 import com.google.android.play.core.review.ReviewManagerFactory
 
 class RatingHelper {
-
     companion object {
         private fun getInstallSource(context: Context): String? =
             try {
@@ -19,7 +18,10 @@ class RatingHelper {
                 null
             }
 
-        fun rateScribe(context: Context, activity: MainActivity) {
+        fun rateScribe(
+            context: Context,
+            activity: MainActivity,
+        ) {
             val installSource = getInstallSource(context)
 
             if (installSource == "com.android.vending") {

--- a/app/src/main/java/be/scri/helpers/RatingHelper.kt
+++ b/app/src/main/java/be/scri/helpers/RatingHelper.kt
@@ -1,0 +1,53 @@
+package be.scri.helpers
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.widget.Toast
+import be.scri.activities.MainActivity
+import com.google.android.play.core.review.ReviewManagerFactory
+
+class RatingHelper {
+
+    companion object {
+        private fun getInstallSource(context: Context): String? =
+            try {
+                val packageManager = context.packageManager
+                packageManager.getInstallerPackageName(context.packageName)
+            } catch (e: PackageManager.NameNotFoundException) {
+                null
+            }
+
+        fun rateScribe(context: Context, activity: MainActivity) {
+            val installSource = getInstallSource(context)
+
+            if (installSource == "com.android.vending") {
+                val reviewManager = ReviewManagerFactory.create(context)
+                val request = reviewManager.requestReviewFlow()
+
+                request.addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        val reviewInfo = task.result
+                        reviewManager
+                            .launchReviewFlow(activity, reviewInfo)
+                            .addOnCompleteListener { _ ->
+                            }
+                    } else {
+                        Toast.makeText(context, "Failed to launch review flow", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            } else if (installSource == "org.fdroid.fdroid") {
+                val url = "https://f-droid.org/packages/${context.packageName}"
+                val intent =
+                    Intent(Intent.ACTION_VIEW)
+                        .apply {
+                            data = Uri.parse(url)
+                        }
+                context.startActivity(intent)
+            } else {
+                Toast.makeText(context, "Unknown installation source", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/app/src/main/java/be/scri/helpers/ShareHelper.kt
+++ b/app/src/main/java/be/scri/helpers/ShareHelper.kt
@@ -1,0 +1,42 @@
+package be.scri.helpers
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.ContextCompat.startActivity
+
+class ShareHelper {
+    companion object {
+        fun shareScribe(context: Context) {
+            try {
+                val sharingIntent =
+                    Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, "https://github.com/scribe-org/Scribe-Android")
+                    }
+                startActivity(context, Intent.createChooser(sharingIntent, "Share via"), null)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("AboutFragment", "No application found to share content", e)
+            } catch (e: IllegalArgumentException) {
+                Log.e("AboutFragment", "Invalid argument for sharing", e)
+            }
+        }
+
+        fun sendEmail(context: Context) {
+            try {
+                val intent =
+                    Intent(Intent.ACTION_SEND).apply {
+                        putExtra(Intent.EXTRA_EMAIL, arrayOf("team@scri.be"))
+                        putExtra(Intent.EXTRA_SUBJECT, "Hey Scribe!")
+                        type = "message/rfc822"
+                    }
+                startActivity(context, Intent.createChooser(intent, "Choose an Email client:"), null)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("AboutFragment", "No email client found", e)
+            } catch (e: IllegalArgumentException) {
+                Log.e("AboutFragment", "Invalid argument for sending email", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/be/scri/models/ItemsViewModel.kt
+++ b/app/src/main/java/be/scri/models/ItemsViewModel.kt
@@ -2,7 +2,6 @@ package be.scri.models
 
 import android.app.Activity
 import androidx.annotation.StringRes
-import kotlin.reflect.KFunction0
 
 data class ItemsViewModel(
     val image: Int,
@@ -10,7 +9,7 @@ data class ItemsViewModel(
     val image2: Int,
     val url: String? = null,
     val activity: Class<out Activity>? = null,
-    val action: KFunction0<Unit>? = null,
+    val action: (() -> Unit)? = null,
 ) : Item() {
     class Text(
         @StringRes

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -30,6 +30,7 @@ import be.scri.views.MyKeyboardView
 
 // based on https://www.androidauthority.com/lets-build-custom-keyboard-android-832362/
 
+@Suppress("TooManyFunctions")
 abstract class SimpleKeyboardIME(
     var language: String,
 ) : InputMethodService(),

--- a/app/src/main/java/be/scri/views/MyKeyboardView.kt
+++ b/app/src/main/java/be/scri/views/MyKeyboardView.kt
@@ -58,7 +58,7 @@ import java.util.Arrays
 import java.util.Locale
 
 @SuppressLint("UseCompatLoadingForDrawables")
-@Suppress("LargeClass", "LongMethod")
+@Suppress("LargeClass", "LongMethod", "TooManyFunctions")
 class MyKeyboardView
     @JvmOverloads
     constructor(

--- a/detekt.yml
+++ b/detekt.yml
@@ -18,7 +18,7 @@ style:
 
 complexity:
     TooManyFunctions:
-        active: false
+        active: true
     NestedBlockDepth:
         active: false
     ComplexCondition:


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I have gone through the fragments package and the MainActivity to fix the TooManyFunctions detekt issue by refactoring common code and moving out code that was doing work outside the responsibility of the class it was previously in (example: MainActivity getting the preferences for dark mode, when that should be owned by the PreferencesHelper.)

I have added an annotation to the remaining classes (`SimpleKeyboardIME` and `MyKeyboardView`) because they are very large and I'm not sure if they can be split up.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #107 
