### PR TITLE
Fix language settings switches

### DIFF
--- a/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
+++ b/app/src/main/java/be/scri/fragments/LanguageSettingsFragment.kt
@@ -138,7 +138,7 @@ class LanguageSettingsFragment : Fragment() {
         )
         list.add(
             SwitchItem(
-                isChecked = sharedPref.getBoolean("autosuggest_emojis_$language", true),
+                isChecked = sharedPref.getBoolean("emoji_suggestions_$language", true),
                 title = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji),
                 description = getString(R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description),
                 action = {

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -109,6 +109,11 @@ abstract class SimpleKeyboardIME(
             inputConnection.deleteSurroundingText(1, 0)
             inputConnection.commitText(". ", 1)
         }
+        else {
+            val inputConnection = currentInputConnection ?: return
+            inputConnection.deleteSurroundingText(1, 0)
+            inputConnection.commitText("  ", 1)
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -108,8 +108,7 @@ abstract class SimpleKeyboardIME(
             val inputConnection = currentInputConnection ?: return
             inputConnection.deleteSurroundingText(1, 0)
             inputConnection.commitText(". ", 1)
-        }
-        else {
+        } else {
             val inputConnection = currentInputConnection ?: return
             inputConnection.deleteSurroundingText(1, 0)
             inputConnection.commitText("  ", 1)


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description
This PR fixes two bugs: one is the autosuggest switch not working, and the other is the lag when double tap space with `double space periods` switch turned off.

But the fix for the latter one is a bit of a workaround; I’d be happy to revise it if there is a better way.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #231
