### PR TITLE
feat:Added nlopez compose rules for ktlint and detekt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,6 +157,8 @@ android {
 }
 
 dependencies {
+    detektPlugins("io.nlopez.compose.rules:detekt:0.4.17")
+    lintChecks("com.slack.lint.compose:compose-lint-checks:1.4.2")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.activity:activity-ktx:1.9.2")
     implementation("androidx.navigation:navigation-fragment-ktx:2.8.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,25 +29,6 @@
         </activity>
 
         <activity
-            android:name=".activities.SplashActivity"
-            android:exported="false"
-           />
-
-        <activity-alias
-            android:name=".activities.SplashActivity.Orange"
-            android:enabled="true"
-            android:exported="true"
-            android:icon="@mipmap/ic_launcher"
-            android:roundIcon="@mipmap/ic_launcher"
-            android:targetActivity=".activities.SplashActivity" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity-alias>
-
-        <activity
             android:name=".fragments.MainFragment"
             android:exported="false" />
 

--- a/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
@@ -14,16 +14,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import be.scri.R
-import be.scri.ui.theme.ScribeTheme
 import be.scri.ui.theme.ScribeTypography
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun ThirdPartyScreen() {
-    Scaffold(modifier = Modifier.fillMaxSize()) {
+fun ThirdPartyScreen(modifier: Modifier = Modifier) {
+    Scaffold(modifier = modifier.fillMaxSize()) {
         Column(
             modifier =
                 Modifier
@@ -66,21 +64,5 @@ fun ThirdPartyScreen() {
                 }
             }
         }
-    }
-}
-
-@Preview
-@Composable
-fun ThirdPartyScreenPreviewDark() {
-    ScribeTheme(useDarkTheme = true) {
-        ThirdPartyScreen()
-    }
-}
-
-@Preview
-@Composable
-fun ThirdPartyScreenPreviewLight() {
-    ScribeTheme(useDarkTheme = false) {
-        ThirdPartyScreen()
     }
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -181,16 +181,6 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <style name="PinNumberStyle.Base">
-        <item name="android:gravity">center</item>
-        <item name="android:padding">@dimen/small_margin</item>
-        <item name="android:textSize">@dimen/big_text_size</item>
-    </style>
-
-    <style name="PinNumberStyle" parent="PinNumberStyle.Base">
-        <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
-    </style>
-
     <style name="ColoredButtonStyle" parent="@android:style/Widget.TextView">
         <item name="android:textFontWeight">600</item>
         <item name="android:textAllCaps">true</item>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript {
     }
 
     dependencies {
+        classpath("io.nlopez.compose.rules:ktlint:0.4.17")
         classpath("com.android.tools.build:gradle:8.6.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")

--- a/detekt.yml
+++ b/detekt.yml
@@ -19,7 +19,7 @@ style:
 naming:
     FunctionNaming:
         active: true
-        ignoreAnnotated: ['Composable']
+        ignoreAnnotated: ["Composable"]
 
 complexity:
     TooManyFunctions:

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="FrequentlyChangedStateReadInComposition" severity="error" />
+    <issue id="ComposableModifierFactory" severity="error" />
+    <issue id="ModifierFactoryExtensionFunction" severity="error" />
+    <issue id="ModifierFactoryReturnType" severity="error" />
+    <issue id="ModifierParameter" severity="error" />
+    <issue id="UnnecessaryComposedModifier" severity="error" />
+    <issue id="InvalidColorHexValue" severity="error" />
+    <issue id="MissingColorAlphaChannel" severity="error" />
+    <issue id="ComposableLambdaParameterNaming" severity="error" />
+    <issue id="ComposableNaming" severity="error" />
+    <issue id="CompositionLocalNaming" severity="error" />
+    <issue id="MutableCollectionMutableState" severity="error" />
+</lint>


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

The pull request adds the `nlopez` Compose rules to the `ktlint` and `detekt` tasks to check for linting issues. It also corrects the existing linting issues that were detected. Additionally, `Slack Compose rules` have been added to the lint checks, ensuring that the IDE can detect any linting issues and provide recommendations for better practices.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #240 
