### PR TITLE
Added interface variables strings constant to be used in the keyboard 

### DIFF
--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.english
 
 object EnglishLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "$"
     val currencySymbolAlternates = listOf("$", "€", "£", "¥", "₩", "¢")
@@ -17,15 +16,16 @@ object EnglishLanguageConstants {
     val verbsAfterPronounsArray = listOf("have", "be", "can")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses = mapOf(
-        "I" to "presSimp",
-        "you" to "presSimp",
-        "he" to "presTPS",
-        "she" to "presTPS",
-        "it" to "presTPS",
-        "we" to "presSimp",
-        "they" to "presSimp"
-    )
+    val pronounAutosuggestionTenses =
+        mapOf(
+            "I" to "presSimp",
+            "you" to "presSimp",
+            "he" to "presTPS",
+            "she" to "presTPS",
+            "it" to "presTPS",
+            "we" to "presSimp",
+            "they" to "presSimp",
+        )
 
     // Translate Command Texts
     const val translateKeyLbl = "Translate"

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -36,7 +36,7 @@ object ENInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Translate"
     const val TRANSLATE_PLACEHOLDER = "Enter a word"
     const val TRANSLATE_PROMPT = " en -› ${"targetLanguage()"}"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -44,7 +44,7 @@ object ENInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Conjugate"
     const val CONJUGATE_PLACEHOLDER = "Enter a verb"
     const val CONJUGATE_PROMPT = "Conjugate: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -52,7 +52,7 @@ object ENInterfaceVariables {
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Enter a noun"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Already plural"
 }

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,21 +1,25 @@
 package be.scri.helpers.english
 
 object ENInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "$"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("$", "€", "£", "¥", "₩", "¢")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "space"
     const val LANGUAGE = "English"
     const val INVALID_COMMAND_MSG = "Not in Wikidata"
     val BASE_AUTOSUGGESTIONS = listOf("I", "I'm", "we")
     val NUMERIC_AUTOSUGGESTIONS = listOf("is", "to", "and")
 
-    // Verbs After Pronouns (for suggestion)
+    // MARK: Suggestion Pronouns
+
     val VERBS_AFTER_PRONOUNS_ARRAY = listOf("have", "be", "can")
 
-    // Pronoun Tenses (for conjugation suggestion)
+    // MARK: Pronoun Conjugation
+
     val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "I" to "presSimp",
@@ -27,27 +31,28 @@ object ENInterfaceVariables {
             "they" to "presSimp",
         )
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Translate"
     const val TRANSLATE_PLACEHOLDER = "Enter a word"
-    const val TRANSLATE_PROMPT = "Currently not utilized" // Example placeholder text
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT // Replace with actual dynamic value when available
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+    const val TRANSLATE_PROMPT = " en -› ${"targetLanguage()"}"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // Conjugate Command Texts
+    // MARK: Conjugate Command
+
     const val CONJUGATE_KEY_LBL = "Conjugate"
     const val CONJUGATE_PLACEHOLDER = "Enter a verb"
     const val CONJUGATE_PROMPT = "Conjugate: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Enter a noun"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Already plural"
 }

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,0 +1,53 @@
+package be.scri.helpers.english
+
+object EnglishLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "$"
+    val currencySymbolAlternates = listOf("$", "€", "£", "¥", "₩", "¢")
+
+    // Keyboard Labels
+    const val spaceBar = "space"
+    const val language = "English"
+    const val invalidCommandMsg = "Not in Wikidata"
+    val baseAutosuggestions = listOf("I", "I'm", "we")
+    val numericAutosuggestions = listOf("is", "to", "and")
+
+    // Verbs After Pronouns (for suggestion)
+    val verbsAfterPronounsArray = listOf("have", "be", "can")
+
+    // Pronoun Tenses (for conjugation suggestion)
+    val pronounAutosuggestionTenses = mapOf(
+        "I" to "presSimp",
+        "you" to "presSimp",
+        "he" to "presTPS",
+        "she" to "presTPS",
+        "it" to "presTPS",
+        "we" to "presSimp",
+        "they" to "presSimp"
+    )
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Translate"
+    const val translatePlaceholder = "Enter a word"
+    const val translatePrompt = "Currently not utilized" // Example placeholder text
+    const val translatePromptAndCursor = translatePrompt // Replace with actual dynamic value when available
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Conjugate"
+    const val conjugatePlaceholder = "Enter a verb"
+    const val conjugatePrompt = "Conjugate: "
+    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
+    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Plural"
+    const val pluralPlaceholder = "Enter a noun"
+    const val pluralPrompt = "Plural: "
+    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
+    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Already plural"
+}

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,22 +1,22 @@
 package be.scri.helpers.english
 
-object EnglishLanguageConstants {
+object ENInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "$"
-    val currencySymbolAlternates = listOf("$", "€", "£", "¥", "₩", "¢")
+    const val CURRENCY_SYMBOL = "$"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("$", "€", "£", "¥", "₩", "¢")
 
     // Keyboard Labels
-    const val spaceBar = "space"
-    const val language = "English"
-    const val invalidCommandMsg = "Not in Wikidata"
-    val baseAutosuggestions = listOf("I", "I'm", "we")
-    val numericAutosuggestions = listOf("is", "to", "and")
+    const val SPACE_BAR = "space"
+    const val LANGUAGE = "English"
+    const val INVALID_COMMAND_MSG = "Not in Wikidata"
+    val BASE_AUTOSUGGESTIONS = listOf("I", "I'm", "we")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("is", "to", "and")
 
     // Verbs After Pronouns (for suggestion)
-    val verbsAfterPronounsArray = listOf("have", "be", "can")
+    val VERBS_AFTER_PRONOUNS_ARRAY = listOf("have", "be", "can")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses =
+    val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "I" to "presSimp",
             "you" to "presSimp",
@@ -28,26 +28,26 @@ object EnglishLanguageConstants {
         )
 
     // Translate Command Texts
-    const val translateKeyLbl = "Translate"
-    const val translatePlaceholder = "Enter a word"
-    const val translatePrompt = "Currently not utilized" // Example placeholder text
-    const val translatePromptAndCursor = translatePrompt // Replace with actual dynamic value when available
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    const val TRANSLATE_KEY_LBL = "Translate"
+    const val TRANSLATE_PLACEHOLDER = "Enter a word"
+    const val TRANSLATE_PROMPT = "Currently not utilized" // Example placeholder text
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Conjugate"
-    const val conjugatePlaceholder = "Enter a verb"
-    const val conjugatePrompt = "Conjugate: "
-    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
-    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Conjugate"
+    const val CONJUGATE_PLACEHOLDER = "Enter a verb"
+    const val CONJUGATE_PROMPT = "Conjugate: "
+    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Plural"
-    const val pluralPlaceholder = "Enter a noun"
-    const val pluralPrompt = "Plural: "
-    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
-    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Plural"
+    const val PLURAL_PLACEHOLDER = "Enter a noun"
+    const val PLURAL_PROMPT = "Plural: "
+    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Already plural"
+    const val ALREADY_PLURAL_MSG = "Already plural"
 }

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -33,7 +33,9 @@ object FRInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Traduire"
     const val TRANSLATE_PLACEHOLDER = "Entrez un mot"
     const val TRANSLATE_PROMPT = "fr -› targetLanguage()" // Example, replace with actual language code
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+
+    // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -1,21 +1,25 @@
 package be.scri.helpers.french
 
 object FRInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "€"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("€", "$", "£", "¥", "₩", "¢")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "espace"
     const val LANGUAGE = "Français"
     const val INVALID_COMMAND_MSG = "Pas dans Wikidata"
     val BASE_AUTOSUGGESTIONS = listOf("je", "il", "le")
     val NUMERIC_AUTOSUGGESTIONS = listOf("je", "que", "c’est")
 
-    // Verbs After Pronouns (for suggestion)
+    // MARK: Suggestion Pronouns
+
     val VERBS_AFTER_PRONOUNS_ARRAY = listOf("être", "avoir", "ne")
 
-    // Pronoun Tenses (for conjugation suggestion)
+    // MARK: Pronoun Conjugation
+
     val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "je" to "presFPS",
@@ -29,29 +33,28 @@ object FRInterfaceVariables {
             "elles" to "presTPP",
         )
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Traduire"
     const val TRANSLATE_PLACEHOLDER = "Entrez un mot"
-    const val TRANSLATE_PROMPT = "fr -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT = "fr -› targetLanguage()"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // Replace with actual dynamic value when available
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+    // MARK: Conjugate Command
 
-    // Conjugate Command Texts
     const val CONJUGATE_KEY_LBL = "Conjuguer"
     const val CONJUGATE_PLACEHOLDER = "Entrez un verbe"
     const val CONJUGATE_PROMPT = "Conjuguer: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Pluriel"
     const val PLURAL_PLACEHOLDER = "Entrez un nom"
     const val PLURAL_PROMPT = "Pluriel: "
-    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Déjà pluriel"
 }

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -1,6 +1,6 @@
 package be.scri.helpers.french
 
-object FR_AZERTYInterfaceVariables {
+object FRInterfaceVariables {
     // Currency Symbol and Alternates
     const val CURRENCY_SYMBOL = "€"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("€", "$", "£", "¥", "₩", "¢")

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -38,7 +38,7 @@ object FRInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Traduire"
     const val TRANSLATE_PLACEHOLDER = "Entrez un mot"
     const val TRANSLATE_PROMPT = "fr -› targetLanguage()"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -46,7 +46,7 @@ object FRInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Conjuguer"
     const val CONJUGATE_PLACEHOLDER = "Entrez un verbe"
     const val CONJUGATE_PROMPT = "Conjuguer: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -54,7 +54,7 @@ object FRInterfaceVariables {
     const val PLURAL_KEY_LBL = "Pluriel"
     const val PLURAL_PLACEHOLDER = "Entrez un nom"
     const val PLURAL_PROMPT = "Pluriel: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Déjà pluriel"
 }

--- a/app/src/main/java/be/scri/helpers/french/FR_AZERTYInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FR_AZERTYInterfaceVariables.kt
@@ -1,22 +1,22 @@
 package be.scri.helpers.french
 
-object FrenchLanguageConstants {
+object FR_AZERTYInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "€"
-    val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
+    const val CURRENCY_SYMBOL = "€"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("€", "$", "£", "¥", "₩", "¢")
 
     // Keyboard Labels
-    const val spaceBar = "espace"
-    const val language = "Français"
-    const val invalidCommandMsg = "Pas dans Wikidata"
-    val baseAutosuggestions = listOf("je", "il", "le")
-    val numericAutosuggestions = listOf("je", "que", "c’est")
+    const val SPACE_BAR = "espace"
+    const val LANGUAGE = "Français"
+    const val INVALID_COMMAND_MSG = "Pas dans Wikidata"
+    val BASE_AUTOSUGGESTIONS = listOf("je", "il", "le")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("je", "que", "c’est")
 
     // Verbs After Pronouns (for suggestion)
-    val verbsAfterPronounsArray = listOf("être", "avoir", "ne")
+    val VERBS_AFTER_PRONOUNS_ARRAY = listOf("être", "avoir", "ne")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses =
+    val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "je" to "presFPS",
             "tu" to "presSPS",
@@ -30,26 +30,26 @@ object FrenchLanguageConstants {
         )
 
     // Translate Command Texts
-    const val translateKeyLbl = "Traduire"
-    const val translatePlaceholder = "Entrez un mot"
-    const val translatePrompt = "fr -› targetLanguage()" // Example, replace with actual language code
-    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    const val TRANSLATE_KEY_LBL = "Traduire"
+    const val TRANSLATE_PLACEHOLDER = "Entrez un mot"
+    const val TRANSLATE_PROMPT = "fr -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Conjuguer"
-    const val conjugatePlaceholder = "Entrez un verbe"
-    const val conjugatePrompt = "Conjuguer: "
-    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
-    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Conjuguer"
+    const val CONJUGATE_PLACEHOLDER = "Entrez un verbe"
+    const val CONJUGATE_PROMPT = "Conjuguer: "
+    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Pluriel"
-    const val pluralPlaceholder = "Entrez un nom"
-    const val pluralPrompt = "Pluriel: "
-    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
-    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Pluriel"
+    const val PLURAL_PLACEHOLDER = "Entrez un nom"
+    const val PLURAL_PROMPT = "Pluriel: "
+    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Déjà pluriel"
+    const val ALREADY_PLURAL_MSG = "Déjà pluriel"
 }

--- a/app/src/main/java/be/scri/helpers/french/FR_AZERTYInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FR_AZERTYInterfaceVariables.kt
@@ -1,0 +1,55 @@
+package be.scri.helpers.french
+
+object FrenchLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "€"
+    val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
+
+    // Keyboard Labels
+    const val spaceBar = "espace"
+    const val language = "Français"
+    const val invalidCommandMsg = "Pas dans Wikidata"
+    val baseAutosuggestions = listOf("je", "il", "le")
+    val numericAutosuggestions = listOf("je", "que", "c’est")
+
+    // Verbs After Pronouns (for suggestion)
+    val verbsAfterPronounsArray = listOf("être", "avoir", "ne")
+
+    // Pronoun Tenses (for conjugation suggestion)
+    val pronounAutosuggestionTenses = mapOf(
+        "je" to "presFPS",
+        "tu" to "presSPS",
+        "il" to "presTPS",
+        "elle" to "presTPS",
+        "on" to "presTPS",
+        "nous" to "presFPP",
+        "vous" to "presSPP",
+        "ils" to "presTPP",
+        "elles" to "presTPP"
+    )
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Traduire"
+    const val translatePlaceholder = "Entrez un mot"
+    const val translatePrompt = "fr -› targetLanguage()" // Example, replace with actual language code
+    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Conjuguer"
+    const val conjugatePlaceholder = "Entrez un verbe"
+    const val conjugatePrompt = "Conjuguer: "
+    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
+    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Pluriel"
+    const val pluralPlaceholder = "Entrez un nom"
+    const val pluralPrompt = "Pluriel: "
+    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
+    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Déjà pluriel"
+}

--- a/app/src/main/java/be/scri/helpers/french/FR_AZERTYInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FR_AZERTYInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.french
 
 object FrenchLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "€"
     val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
@@ -17,17 +16,18 @@ object FrenchLanguageConstants {
     val verbsAfterPronounsArray = listOf("être", "avoir", "ne")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses = mapOf(
-        "je" to "presFPS",
-        "tu" to "presSPS",
-        "il" to "presTPS",
-        "elle" to "presTPS",
-        "on" to "presTPS",
-        "nous" to "presFPP",
-        "vous" to "presSPP",
-        "ils" to "presTPP",
-        "elles" to "presTPP"
-    )
+    val pronounAutosuggestionTenses =
+        mapOf(
+            "je" to "presFPS",
+            "tu" to "presSPS",
+            "il" to "presTPS",
+            "elle" to "presTPS",
+            "on" to "presTPS",
+            "nous" to "presFPP",
+            "vous" to "presSPP",
+            "ils" to "presTPP",
+            "elles" to "presTPP",
+        )
 
     // Translate Command Texts
     const val translateKeyLbl = "Traduire"

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,22 +1,22 @@
 package be.scri.helpers.german
 
-object GermanLanguageConstants {
+object DEInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "€"
-    val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
+    const val CURRENCY_SYMBOL = "€"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("€", "$", "£", "¥", "₩", "¢")
 
     // Keyboard Labels
-    const val spaceBar = "Leerzeichen"
-    const val language = "Deutsch"
-    const val invalidCommandMsg = "Nicht in Wikidata"
-    val baseAutosuggestions = listOf("ich", "die", "das")
-    val numericAutosuggestions = listOf("Prozent", "Milionen", "Meter")
+    const val SPACE_BAR = "Leerzeichen"
+    const val LANGUAGE = "Deutsch"
+    const val INVALID_COMMAND_MSG = "Nicht in Wikidata"
+    val BASE_AUTOSUGGESTIONS = listOf("ich", "die", "das")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("Prozent", "Milionen", "Meter")
 
     // Verbs After Pronouns (for suggestion)
-    val verbsAfterPronounsArray = listOf("haben", "sein", "können")
+    val VERBS_AFTER_PRONOUNS_ARRAY = listOf("haben", "sein", "können")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses =
+    val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "ich" to "presFPS",
             "du" to "presSPS",
@@ -29,26 +29,26 @@ object GermanLanguageConstants {
         )
 
     // Translate Command Texts
-    const val translateKeyLbl = "Übersetzen"
-    const val translatePlaceholder = "Wort eingeben"
-    const val translatePrompt = "de -› targetLanguage()" // Example, replace with actual language code
-    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    const val TRANSLATE_KEY_LBL = "Übersetzen"
+    const val TRANSLATE_PLACEHOLDER = "Wort eingeben"
+    const val TRANSLATE_PROMPT = "de -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Konjugieren"
-    const val conjugatePlaceholder = "Verb eingeben"
-    const val conjugatePrompt = "Konjugieren: "
-    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
-    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Konjugieren"
+    const val CONJUGATE_PLACEHOLDER = "Verb eingeben"
+    const val CONJUGATE_PROMPT = "Konjugieren: "
+    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Plural"
-    const val pluralPlaceholder = "Nomen eingeben"
-    const val pluralPrompt = "Plural: "
-    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
-    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Plural"
+    const val PLURAL_PLACEHOLDER = "Nomen eingeben"
+    const val PLURAL_PROMPT = "Plural: "
+    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Schon Plural"
+    const val ALREADY_PLURAL_MSG = "Schon Plural"
 }

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -32,7 +32,9 @@ object DEInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Übersetzen"
     const val TRANSLATE_PLACEHOLDER = "Wort eingeben"
     const val TRANSLATE_PROMPT = "de -› targetLanguage()" // Example, replace with actual language code
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+
+    // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,21 +1,25 @@
 package be.scri.helpers.german
 
 object DEInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "€"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("€", "$", "£", "¥", "₩", "¢")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "Leerzeichen"
     const val LANGUAGE = "Deutsch"
     const val INVALID_COMMAND_MSG = "Nicht in Wikidata"
     val BASE_AUTOSUGGESTIONS = listOf("ich", "die", "das")
     val NUMERIC_AUTOSUGGESTIONS = listOf("Prozent", "Milionen", "Meter")
 
-    // Verbs After Pronouns (for suggestion)
+    // MARK: Suggestion Pronouns
+
     val VERBS_AFTER_PRONOUNS_ARRAY = listOf("haben", "sein", "können")
 
-    // Pronoun Tenses (for conjugation suggestion)
+    // MARK: Pronoun Conjugation
+
     val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "ich" to "presFPS",
@@ -28,29 +32,28 @@ object DEInterfaceVariables {
             "Sie" to "presTPP",
         )
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Übersetzen"
     const val TRANSLATE_PLACEHOLDER = "Wort eingeben"
-    const val TRANSLATE_PROMPT = "de -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT = "de -› targetLanguage()"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // Replace with actual dynamic value when available
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+    // MARK: Conjugate Command
 
-    // Conjugate Command Texts
     const val CONJUGATE_KEY_LBL = "Konjugieren"
     const val CONJUGATE_PLACEHOLDER = "Verb eingeben"
     const val CONJUGATE_PROMPT = "Konjugieren: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Nomen eingeben"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Schon Plural"
 }

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,0 +1,54 @@
+package be.scri.helpers.german
+
+object GermanLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "€"
+    val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
+
+    // Keyboard Labels
+    const val spaceBar = "Leerzeichen"
+    const val language = "Deutsch"
+    const val invalidCommandMsg = "Nicht in Wikidata"
+    val baseAutosuggestions = listOf("ich", "die", "das")
+    val numericAutosuggestions = listOf("Prozent", "Milionen", "Meter")
+
+    // Verbs After Pronouns (for suggestion)
+    val verbsAfterPronounsArray = listOf("haben", "sein", "können")
+
+    // Pronoun Tenses (for conjugation suggestion)
+    val pronounAutosuggestionTenses = mapOf(
+        "ich" to "presFPS",
+        "du" to "presSPS",
+        "er" to "presTPS",
+        "sie" to "presTPS",
+        "es" to "presTPS",
+        "wir" to "presFPP",
+        "ihr" to "presSPP",
+        "Sie" to "presTPP"
+    )
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Übersetzen"
+    const val translatePlaceholder = "Wort eingeben"
+    const val translatePrompt = "de -› targetLanguage()" // Example, replace with actual language code
+    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Konjugieren"
+    const val conjugatePlaceholder = "Verb eingeben"
+    const val conjugatePrompt = "Konjugieren: "
+    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
+    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Plural"
+    const val pluralPlaceholder = "Nomen eingeben"
+    const val pluralPrompt = "Plural: "
+    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
+    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Schon Plural"
+}

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.german
 
 object GermanLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "€"
     val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
@@ -17,16 +16,17 @@ object GermanLanguageConstants {
     val verbsAfterPronounsArray = listOf("haben", "sein", "können")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses = mapOf(
-        "ich" to "presFPS",
-        "du" to "presSPS",
-        "er" to "presTPS",
-        "sie" to "presTPS",
-        "es" to "presTPS",
-        "wir" to "presFPP",
-        "ihr" to "presSPP",
-        "Sie" to "presTPP"
-    )
+    val pronounAutosuggestionTenses =
+        mapOf(
+            "ich" to "presFPS",
+            "du" to "presSPS",
+            "er" to "presTPS",
+            "sie" to "presTPS",
+            "es" to "presTPS",
+            "wir" to "presFPP",
+            "ihr" to "presSPP",
+            "Sie" to "presTPP",
+        )
 
     // Translate Command Texts
     const val translateKeyLbl = "Übersetzen"

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -37,7 +37,7 @@ object DEInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Übersetzen"
     const val TRANSLATE_PLACEHOLDER = "Wort eingeben"
     const val TRANSLATE_PROMPT = "de -› targetLanguage()"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -45,7 +45,7 @@ object DEInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Konjugieren"
     const val CONJUGATE_PLACEHOLDER = "Verb eingeben"
     const val CONJUGATE_PROMPT = "Konjugieren: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -53,7 +53,7 @@ object DEInterfaceVariables {
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Nomen eingeben"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Schon Plural"
 }

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.italian
 
 object ItalianLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "€"
     val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -1,0 +1,39 @@
+package be.scri.helpers.italian
+
+object ItalianLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "€"
+    val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
+
+    // Keyboard Labels
+    const val spaceBar = "spazio"
+    const val language = "Italiano"
+    const val invalidCommandMsg = "Non in Wikidata"
+    val baseAutosuggestions = listOf("ho", "non", "ma")
+    val numericAutosuggestions = listOf("utenti", "anni", "e")
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Tradurre"
+    const val translatePlaceholder = "Inserisci una parola"
+    const val translatePrompt = "it -› targetLanguage()" // Example, replace with actual language code
+    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Coniugare"
+    const val conjugatePlaceholder = "Inserisci un verbo"
+    const val conjugatePrompt = "Coniugare: "
+    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
+    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Plurale"
+    const val pluralPlaceholder = "Inserisci un nome"
+    const val pluralPrompt = "Plurale: "
+    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
+    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Già plurale"
+}

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -1,40 +1,41 @@
 package be.scri.helpers.italian
 
 object ITInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "€"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("€", "$", "£", "¥", "₩", "¢")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "spazio"
     const val LANGUAGE = "Italiano"
     const val INVALID_COMMAND_MSG = "Non in Wikidata"
     val BASE_AUTOSUGGESTIONS = listOf("ho", "non", "ma")
     val NUMERIC_AUTOSUGGESTIONS = listOf("utenti", "anni", "e")
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Tradurre"
     const val TRANSLATE_PLACEHOLDER = "Inserisci una parola"
-    const val TRANSLATE_PROMPT = "it -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT = "it -› targetLanguage()"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // Replace with actual dynamic value when available
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+    // MARK: Conjugate Command
 
-    // Conjugate Command Texts
     const val CONJUGATE_KEY_LBL = "Coniugare"
     const val CONJUGATE_PLACEHOLDER = "Inserisci un verbo"
     const val CONJUGATE_PROMPT = "Coniugare: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Plurale"
     const val PLURAL_PLACEHOLDER = "Inserisci un nome"
     const val PLURAL_PROMPT = "Plurale: "
-    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Già plurale"
 }

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -19,7 +19,7 @@ object ITInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Tradurre"
     const val TRANSLATE_PLACEHOLDER = "Inserisci una parola"
     const val TRANSLATE_PROMPT = "it -› targetLanguage()"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -27,7 +27,7 @@ object ITInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Coniugare"
     const val CONJUGATE_PLACEHOLDER = "Inserisci un verbo"
     const val CONJUGATE_PROMPT = "Coniugare: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -35,7 +35,7 @@ object ITInterfaceVariables {
     const val PLURAL_KEY_LBL = "Plurale"
     const val PLURAL_PLACEHOLDER = "Inserisci un nome"
     const val PLURAL_PROMPT = "Plurale: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Già plurale"
 }

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -16,7 +16,9 @@ object ITInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Tradurre"
     const val TRANSLATE_PLACEHOLDER = "Inserisci una parola"
     const val TRANSLATE_PROMPT = "it -› targetLanguage()" // Example, replace with actual language code
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+
+    // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -1,38 +1,38 @@
 package be.scri.helpers.italian
 
-object ItalianLanguageConstants {
+object ITInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "€"
-    val currencySymbolAlternates = listOf("€", "$", "£", "¥", "₩", "¢")
+    const val CURRENCY_SYMBOL = "€"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("€", "$", "£", "¥", "₩", "¢")
 
     // Keyboard Labels
-    const val spaceBar = "spazio"
-    const val language = "Italiano"
-    const val invalidCommandMsg = "Non in Wikidata"
-    val baseAutosuggestions = listOf("ho", "non", "ma")
-    val numericAutosuggestions = listOf("utenti", "anni", "e")
+    const val SPACE_BAR = "spazio"
+    const val LANGUAGE = "Italiano"
+    const val INVALID_COMMAND_MSG = "Non in Wikidata"
+    val BASE_AUTOSUGGESTIONS = listOf("ho", "non", "ma")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("utenti", "anni", "e")
 
     // Translate Command Texts
-    const val translateKeyLbl = "Tradurre"
-    const val translatePlaceholder = "Inserisci una parola"
-    const val translatePrompt = "it -› targetLanguage()" // Example, replace with actual language code
-    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    const val TRANSLATE_KEY_LBL = "Tradurre"
+    const val TRANSLATE_PLACEHOLDER = "Inserisci una parola"
+    const val TRANSLATE_PROMPT = "it -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Coniugare"
-    const val conjugatePlaceholder = "Inserisci un verbo"
-    const val conjugatePrompt = "Coniugare: "
-    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
-    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Coniugare"
+    const val CONJUGATE_PLACEHOLDER = "Inserisci un verbo"
+    const val CONJUGATE_PROMPT = "Coniugare: "
+    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Plurale"
-    const val pluralPlaceholder = "Inserisci un nome"
-    const val pluralPrompt = "Plurale: "
-    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
-    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Plurale"
+    const val PLURAL_PLACEHOLDER = "Inserisci un nome"
+    const val PLURAL_PROMPT = "Plurale: "
+    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Già plurale"
+    const val ALREADY_PLURAL_MSG = "Già plurale"
 }

--- a/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
@@ -1,0 +1,39 @@
+package be.scri.helpers.portugese
+
+object PortugueseLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "$"
+    val currencySymbolAlternates = listOf("$", "€", "£", "¥", "₩", "¢")
+
+    // Keyboard Labels
+    const val spaceBar = "espaço"
+    const val language = "Português"
+    const val invalidCommandMsg = "Não está no Wikidata"
+    val baseAutosuggestions = listOf("o", "a", "eu")
+    val numericAutosuggestions = listOf("de", "que", "a")
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Traduzir"
+    const val translatePlaceholder = "Digite uma palavra"
+    const val translatePrompt = "pt -› targetLanguage()" // Example, replace with actual language code
+    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Conjugar"
+    const val conjugatePlaceholder = "Digite um verbo"
+    const val conjugatePrompt = "Conjugar: "
+    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
+    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Plural"
+    const val pluralPlaceholder = "Digite um substantivo"
+    const val pluralPrompt = "Plural: "
+    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
+    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Já plural"
+}

--- a/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
@@ -1,38 +1,38 @@
 package be.scri.helpers.portugese
 
-object PortugueseLanguageConstants {
+object PTInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "$"
-    val currencySymbolAlternates = listOf("$", "€", "£", "¥", "₩", "¢")
+    const val CURRENCY_SYMBOL = "$"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("$", "€", "£", "¥", "₩", "¢")
 
     // Keyboard Labels
-    const val spaceBar = "espaço"
-    const val language = "Português"
-    const val invalidCommandMsg = "Não está no Wikidata"
-    val baseAutosuggestions = listOf("o", "a", "eu")
-    val numericAutosuggestions = listOf("de", "que", "a")
+    const val SPACE_BAR = "espaço"
+    const val LANGUAGE = "Português"
+    const val INVALID_COMMAND_MSG = "Não está no Wikidata"
+    val BASE_AUTOSUGGESTIONS = listOf("o", "a", "eu")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("de", "que", "a")
 
     // Translate Command Texts
-    const val translateKeyLbl = "Traduzir"
-    const val translatePlaceholder = "Digite uma palavra"
-    const val translatePrompt = "pt -› targetLanguage()" // Example, replace with actual language code
-    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    const val TRANSLATE_KEY_LBL = "Traduzir"
+    const val TRANSLATE_PLACEHOLDER = "Digite uma palavra"
+    const val TRANSLATE_PROMPT = "pt -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Conjugar"
-    const val conjugatePlaceholder = "Digite um verbo"
-    const val conjugatePrompt = "Conjugar: "
-    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
-    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Conjugar"
+    const val CONJUGATE_PLACEHOLDER = "Digite um verbo"
+    const val CONJUGATE_PROMPT = "Conjugar: "
+    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Plural"
-    const val pluralPlaceholder = "Digite um substantivo"
-    const val pluralPrompt = "Plural: "
-    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
-    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Plural"
+    const val PLURAL_PLACEHOLDER = "Digite um substantivo"
+    const val PLURAL_PROMPT = "Plural: "
+    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Já plural"
+    const val ALREADY_PLURAL_MSG = "Já plural"
 }

--- a/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.portugese
 
 object PortugueseLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "$"
     val currencySymbolAlternates = listOf("$", "€", "£", "¥", "₩", "¢")

--- a/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
@@ -16,7 +16,9 @@ object PTInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Traduzir"
     const val TRANSLATE_PLACEHOLDER = "Digite uma palavra"
     const val TRANSLATE_PROMPT = "pt -› targetLanguage()" // Example, replace with actual language code
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+
+    // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts

--- a/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
@@ -19,7 +19,7 @@ object PTInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Traduzir"
     const val TRANSLATE_PLACEHOLDER = "Digite uma palavra"
     const val TRANSLATE_PROMPT = "pt -› targetLanguage()"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -27,7 +27,7 @@ object PTInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Conjugar"
     const val CONJUGATE_PLACEHOLDER = "Digite um verbo"
     const val CONJUGATE_PROMPT = "Conjugar: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -35,7 +35,7 @@ object PTInterfaceVariables {
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Digite um substantivo"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Já plural"
 }

--- a/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portugese/PTInterfaceVariables.kt
@@ -1,40 +1,41 @@
 package be.scri.helpers.portugese
 
 object PTInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "$"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("$", "€", "£", "¥", "₩", "¢")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "espaço"
     const val LANGUAGE = "Português"
     const val INVALID_COMMAND_MSG = "Não está no Wikidata"
     val BASE_AUTOSUGGESTIONS = listOf("o", "a", "eu")
     val NUMERIC_AUTOSUGGESTIONS = listOf("de", "que", "a")
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Traduzir"
     const val TRANSLATE_PLACEHOLDER = "Digite uma palavra"
-    const val TRANSLATE_PROMPT = "pt -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT = "pt -› targetLanguage()"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // Replace with actual dynamic value when available
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+    // MARK: Conjugate Command
 
-    // Conjugate Command Texts
     const val CONJUGATE_KEY_LBL = "Conjugar"
     const val CONJUGATE_PLACEHOLDER = "Digite um verbo"
     const val CONJUGATE_PROMPT = "Conjugar: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Digite um substantivo"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Já plural"
 }

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,38 +1,38 @@
 package be.scri.helpers.russian
 
-object RussianLanguageConstants {
+object RUInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "₽"
-    val currencySymbolAlternates = listOf("₽", "$", "€", "£", "¥")
+    const val CURRENCY_SYMBOL = "₽"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("₽", "$", "€", "£", "¥")
 
     // Keyboard Labels
-    const val spaceBar = "Пробел"
-    const val language = "Pусский"
-    const val invalidCommandMsg = "Нет в Викиданных"
-    val baseAutosuggestions = listOf("я", "а", "в")
-    val numericAutosuggestions = listOf("в", "и", "я")
+    const val SPACE_BAR = "Пробел"
+    const val LANGUAGE = "Pусский"
+    const val INVALID_COMMAND_MSG = "Нет в Викиданных"
+    val BASE_AUTOSUGGESTIONS = listOf("я", "а", "в")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("в", "и", "я")
 
     // Translate Command Texts
-    const val translateKeyLbl = "Перевести"
-    const val translatePlaceholder = "Введите слово"
-    const val translatePrompt = "ru -› targetLanguage()" // Example, replace with actual language code
-    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    const val TRANSLATE_KEY_LBL = "Перевести"
+    const val TRANSLATE_PLACEHOLDER = "Введите слово"
+    const val TRANSLATE_PROMPT = "ru -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Спрягать"
-    const val conjugatePlaceholder = "Введите глагол"
-    const val conjugatePrompt = "Спрягать: "
-    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
-    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Спрягать"
+    const val CONJUGATE_PLACEHOLDER = "Введите глагол"
+    const val CONJUGATE_PROMPT = "Спрягать: "
+    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Множ-ое"
-    const val pluralPlaceholder = "Введите существительное"
-    const val pluralPrompt = "Множ-ое: "
-    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
-    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Множ-ое"
+    const val PLURAL_PLACEHOLDER = "Введите существительное"
+    const val PLURAL_PROMPT = "Множ-ое: "
+    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Уже во множ-ом"
+    const val ALREADY_PLURAL_MSG = "Уже во множ-ом"
 }

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -19,7 +19,7 @@ object RUInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Перевести"
     const val TRANSLATE_PLACEHOLDER = "Введите слово"
     const val TRANSLATE_PROMPT = "ru -› targetLanguage()"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -27,7 +27,7 @@ object RUInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Спрягать"
     const val CONJUGATE_PLACEHOLDER = "Введите глагол"
     const val CONJUGATE_PROMPT = "Спрягать: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -35,7 +35,7 @@ object RUInterfaceVariables {
     const val PLURAL_KEY_LBL = "Множ-ое"
     const val PLURAL_PLACEHOLDER = "Введите существительное"
     const val PLURAL_PROMPT = "Множ-ое: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Уже во множ-ом"
 }

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,40 +1,41 @@
 package be.scri.helpers.russian
 
 object RUInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "₽"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("₽", "$", "€", "£", "¥")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "Пробел"
     const val LANGUAGE = "Pусский"
     const val INVALID_COMMAND_MSG = "Нет в Викиданных"
     val BASE_AUTOSUGGESTIONS = listOf("я", "а", "в")
     val NUMERIC_AUTOSUGGESTIONS = listOf("в", "и", "я")
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Перевести"
     const val TRANSLATE_PLACEHOLDER = "Введите слово"
-    const val TRANSLATE_PROMPT = "ru -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT = "ru -› targetLanguage()"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // Replace with actual dynamic value when available
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+    // MARK: Conjugate Command
 
-    // Conjugate Command Texts
     const val CONJUGATE_KEY_LBL = "Спрягать"
     const val CONJUGATE_PLACEHOLDER = "Введите глагол"
     const val CONJUGATE_PROMPT = "Спрягать: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Множ-ое"
     const val PLURAL_PLACEHOLDER = "Введите существительное"
     const val PLURAL_PROMPT = "Множ-ое: "
-    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Уже во множ-ом"
 }

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -16,7 +16,9 @@ object RUInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Перевести"
     const val TRANSLATE_PLACEHOLDER = "Введите слово"
     const val TRANSLATE_PROMPT = "ru -› targetLanguage()" // Example, replace with actual language code
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+
+    // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.russian
 
 object RussianLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "₽"
     val currencySymbolAlternates = listOf("₽", "$", "€", "£", "¥")

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,0 +1,39 @@
+package be.scri.helpers.russian
+
+object RussianLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "₽"
+    val currencySymbolAlternates = listOf("₽", "$", "€", "£", "¥")
+
+    // Keyboard Labels
+    const val spaceBar = "Пробел"
+    const val language = "Pусский"
+    const val invalidCommandMsg = "Нет в Викиданных"
+    val baseAutosuggestions = listOf("я", "а", "в")
+    val numericAutosuggestions = listOf("в", "и", "я")
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Перевести"
+    const val translatePlaceholder = "Введите слово"
+    const val translatePrompt = "ru -› targetLanguage()" // Example, replace with actual language code
+    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Спрягать"
+    const val conjugatePlaceholder = "Введите глагол"
+    const val conjugatePrompt = "Спрягать: "
+    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
+    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Множ-ое"
+    const val pluralPlaceholder = "Введите существительное"
+    const val pluralPrompt = "Множ-ое: "
+    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
+    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Уже во множ-ом"
+}

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -34,8 +34,12 @@ object ESInterfaceVariables {
     // Translate Command Texts
     const val TRANSLATE_KEY_LBL = "Traducir"
     const val TRANSLATE_PLACEHOLDER = "Ingrese una palabra"
-    const val TRANSLATE_PROMPT = " es -› ${"targetLanguage()"}" // Example, replace with actual language code
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "commandCursor" // commandCursor needs to be replaced with the actual value
+
+    // Example, replace with actual language code
+    const val TRANSLATE_PROMPT = " es -› ${"targetLanguage()"}"
+
+    // commandCursor needs to be replaced with the actual value
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "commandCursor"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 // it would be better to add mutability for changing the color of the cursor when we are ready to use these variables
 
@@ -43,15 +47,15 @@ object ESInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Conjugar"
     const val CONJUGATE_PLACEHOLDER = "Ingrese un verbo"
     const val CONJUGATE_PROMPT = "Conjugar: "
-    val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "commandCursor" // same here
-    val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "commandCursor" // same here
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Ingrese un sustantivo"
     const val PLURAL_PROMPT = "Plural: "
-    val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "commandCursor" // same
-    val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "commandCursor" // same
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
     const val ALREADY_PLURAL_MSG = "Ya en plural"

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -40,7 +40,7 @@ object ESInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Traducir"
     const val TRANSLATE_PLACEHOLDER = "Ingrese una palabra"
     const val TRANSLATE_PROMPT = " es -› ${"targetLanguage()"}"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -48,7 +48,7 @@ object ESInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Conjugar"
     const val CONJUGATE_PLACEHOLDER = "Ingrese un verbo"
     const val CONJUGATE_PROMPT = "Conjugar: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -56,7 +56,7 @@ object ESInterfaceVariables {
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Ingrese un sustantivo"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Ya en plural"
 }

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,21 +1,25 @@
 package be.scri.helpers.spanish
 
 object ESInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "$"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("₡", "S", "€", "£", "₲", "¢")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "espacio"
     const val LANGUAGE = "Español"
     const val INVALID_COMMAND_MSG = "No en Wikidata"
     val BASE_AUTOSUGGESTIONS = listOf("el", "la", "no")
     val NUMERIC_AUTOSUGGESTIONS = listOf("que", "de", "en")
 
-    // Verbs After Pronouns (for suggestion)
+    // MARK: Suggestion Pronouns
+
     val VERBS_AFTER_PRONOUNS_ARRAY = listOf("ser", "REFLEXIVE_PRONOUN", "no")
 
-    // Pronoun Tenses (for conjugation suggestion)
+    // MARK: Pronoun Conjugation
+
     val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "yo" to "presFPS",
@@ -31,32 +35,28 @@ object ESInterfaceVariables {
             "ustedes" to "presTPP",
         )
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Traducir"
     const val TRANSLATE_PLACEHOLDER = "Ingrese una palabra"
-
-    // Example, replace with actual language code
     const val TRANSLATE_PROMPT = " es -› ${"targetLanguage()"}"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // commandCursor needs to be replaced with the actual value
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "commandCursor"
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
-// it would be better to add mutability for changing the color of the cursor when we are ready to use these variables
+    // MARK: Conjugate Command
 
-    // Conjugate Command Texts
     const val CONJUGATE_KEY_LBL = "Conjugar"
     const val CONJUGATE_PLACEHOLDER = "Ingrese un verbo"
     const val CONJUGATE_PROMPT = "Conjugar: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "commandCursor" // same here
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Ingrese un sustantivo"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "commandCursor" // same
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Ya en plural"
 }

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,22 +1,22 @@
 package be.scri.helpers.spanish
 
-object SpanishLanguageConstants {
+object ESInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "$"
-    val currencySymbolAlternates = listOf("₡", "S", "€", "£", "₲", "¢")
+    const val CURRENCY_SYMBOL = "$"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("₡", "S", "€", "£", "₲", "¢")
 
     // Keyboard Labels
-    const val spaceBar = "espacio"
-    const val language = "Español"
-    const val invalidCommandMsg = "No en Wikidata"
-    val baseAutosuggestions = listOf("el", "la", "no")
-    val numericAutosuggestions = listOf("que", "de", "en")
+    const val SPACE_BAR = "espacio"
+    const val LANGUAGE = "Español"
+    const val INVALID_COMMAND_MSG = "No en Wikidata"
+    val BASE_AUTOSUGGESTIONS = listOf("el", "la", "no")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("que", "de", "en")
 
     // Verbs After Pronouns (for suggestion)
-    val verbsAfterPronounsArray = listOf("ser", "REFLEXIVE_PRONOUN", "no")
+    val VERBS_AFTER_PRONOUNS_ARRAY = listOf("ser", "REFLEXIVE_PRONOUN", "no")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses =
+    val PRONOUN_AUTOSUGGESTION_TENSES =
         mapOf(
             "yo" to "presFPS",
             "tú" to "presSPS",
@@ -32,27 +32,27 @@ object SpanishLanguageConstants {
         )
 
     // Translate Command Texts
-    const val translateKeyLbl = "Traducir"
-    const val translatePlaceholder = "Ingrese una palabra"
-    const val translatePrompt = " es -› ${"targetLanguage()"}" // Example, replace with actual language code
-    const val translatePromptAndCursor = translatePrompt + "commandCursor" // commandCursor needs to be replaced with the actual value
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
-    // it would be better to add mutability for changing the color of the cursor when we are ready to use this variables
+    const val TRANSLATE_KEY_LBL = "Traducir"
+    const val TRANSLATE_PLACEHOLDER = "Ingrese una palabra"
+    const val TRANSLATE_PROMPT = " es -› ${"targetLanguage()"}" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "commandCursor" // commandCursor needs to be replaced with the actual value
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+// it would be better to add mutability for changing the color of the cursor when we are ready to use these variables
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Conjugar"
-    const val conjugatePlaceholder = "Ingrese un verbo"
-    const val conjugatePrompt = "Conjugar: "
-    val conjugatePromptAndCursor = conjugatePrompt + "commandCursor" // same here
-    val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Conjugar"
+    const val CONJUGATE_PLACEHOLDER = "Ingrese un verbo"
+    const val CONJUGATE_PROMPT = "Conjugar: "
+    val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "commandCursor" // same here
+    val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Plural"
-    const val pluralPlaceholder = "Ingrese un sustantivo"
-    const val pluralPrompt = "Plural: "
-    val pluralPromptAndCursor = pluralPrompt + "commandCursor" // same
-    val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Plural"
+    const val PLURAL_PLACEHOLDER = "Ingrese un sustantivo"
+    const val PLURAL_PROMPT = "Plural: "
+    val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "commandCursor" // same
+    val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Ya en plural"
+    const val ALREADY_PLURAL_MSG = "Ya en plural"
 }

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,0 +1,59 @@
+package be.scri.helpers.spanish
+
+object SpanishLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "$"
+    val currencySymbolAlternates = listOf("₡", "S", "€", "£", "₲", "¢")
+
+    // Keyboard Labels
+    const val spaceBar = "espacio"
+    const val language = "Español"
+    const val invalidCommandMsg = "No en Wikidata"
+    val baseAutosuggestions = listOf("el", "la", "no")
+    val numericAutosuggestions = listOf("que", "de", "en")
+
+    // Verbs After Pronouns (for suggestion)
+    val verbsAfterPronounsArray = listOf("ser", "REFLEXIVE_PRONOUN", "no")
+
+    // Pronoun Tenses (for conjugation suggestion)
+    val pronounAutosuggestionTenses = mapOf(
+        "yo" to "presFPS",
+        "tú" to "presSPS",
+        "él" to "presTPS",
+        "ella" to "presTPS",
+        "nosotros" to "presFPP",
+        "nosotras" to "presFPP",
+        "vosotros" to "presSPP",
+        "vosotras" to "presSPP",
+        "ellos" to "presTPP",
+        "ellas" to "presTPP",
+        "ustedes" to "presTPP"
+    )
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Traducir"
+    const val translatePlaceholder = "Ingrese una palabra"
+    const val translatePrompt = " es -› ${"targetLanguage()"}" // Example, replace with actual language code
+    const val translatePromptAndCursor = translatePrompt + "commandCursor"    // commandCursor needs to be replaced with the actual value
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    // it would be better to add mutability for changing the color of the cursor when we are ready to use this variables
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Conjugar"
+    const val conjugatePlaceholder = "Ingrese un verbo"
+    const val conjugatePrompt = "Conjugar: "
+    val conjugatePromptAndCursor = conjugatePrompt + "commandCursor"  // same here
+    val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Plural"
+    const val pluralPlaceholder = "Ingrese un sustantivo"
+    const val pluralPrompt = "Plural: "
+    val pluralPromptAndCursor = pluralPrompt + "commandCursor" // same
+    val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Ya en plural"
+}
+

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.spanish
 
 object SpanishLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "$"
     val currencySymbolAlternates = listOf("₡", "S", "€", "£", "₲", "¢")
@@ -17,25 +16,26 @@ object SpanishLanguageConstants {
     val verbsAfterPronounsArray = listOf("ser", "REFLEXIVE_PRONOUN", "no")
 
     // Pronoun Tenses (for conjugation suggestion)
-    val pronounAutosuggestionTenses = mapOf(
-        "yo" to "presFPS",
-        "tú" to "presSPS",
-        "él" to "presTPS",
-        "ella" to "presTPS",
-        "nosotros" to "presFPP",
-        "nosotras" to "presFPP",
-        "vosotros" to "presSPP",
-        "vosotras" to "presSPP",
-        "ellos" to "presTPP",
-        "ellas" to "presTPP",
-        "ustedes" to "presTPP"
-    )
+    val pronounAutosuggestionTenses =
+        mapOf(
+            "yo" to "presFPS",
+            "tú" to "presSPS",
+            "él" to "presTPS",
+            "ella" to "presTPS",
+            "nosotros" to "presFPP",
+            "nosotras" to "presFPP",
+            "vosotros" to "presSPP",
+            "vosotras" to "presSPP",
+            "ellos" to "presTPP",
+            "ellas" to "presTPP",
+            "ustedes" to "presTPP",
+        )
 
     // Translate Command Texts
     const val translateKeyLbl = "Traducir"
     const val translatePlaceholder = "Ingrese una palabra"
     const val translatePrompt = " es -› ${"targetLanguage()"}" // Example, replace with actual language code
-    const val translatePromptAndCursor = translatePrompt + "commandCursor"    // commandCursor needs to be replaced with the actual value
+    const val translatePromptAndCursor = translatePrompt + "commandCursor" // commandCursor needs to be replaced with the actual value
     const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
     // it would be better to add mutability for changing the color of the cursor when we are ready to use this variables
 
@@ -43,7 +43,7 @@ object SpanishLanguageConstants {
     const val conjugateKeyLbl = "Conjugar"
     const val conjugatePlaceholder = "Ingrese un verbo"
     const val conjugatePrompt = "Conjugar: "
-    val conjugatePromptAndCursor = conjugatePrompt + "commandCursor"  // same here
+    val conjugatePromptAndCursor = conjugatePrompt + "commandCursor" // same here
     val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
 
     // Plural Command Texts
@@ -56,4 +56,3 @@ object SpanishLanguageConstants {
     // Already Plural Message
     const val alreadyPluralMsg = "Ya en plural"
 }
-

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,38 +1,38 @@
 package be.scri.helpers.swedish
 
-object SwedishLanguageConstants {
+object SVInterfaceVariables {
     // Currency Symbol and Alternates
-    const val currencySymbol = "kr"
-    val currencySymbolAlternates = listOf("kr", "$", "€", "£", "¥")
+    const val CURRENCY_SYMBOL = "kr"
+    val CURRENCY_SYMBOL_ALTERNATES = listOf("kr", "$", "€", "£", "¥")
 
     // Keyboard Labels
-    const val spaceBar = "mellanslag"
-    const val language = "Svenska"
-    const val invalidCommandMsg = "Inte i Wikidata"
-    val baseAutosuggestions = listOf("jag", "det", "men")
-    val numericAutosuggestions = listOf("jag", "det", "och")
+    const val SPACE_BAR = "mellanslag"
+    const val LANGUAGE = "Svenska"
+    const val INVALID_COMMAND_MSG = "Inte i Wikidata"
+    val BASE_AUTOSUGGESTIONS = listOf("jag", "det", "men")
+    val NUMERIC_AUTOSUGGESTIONS = listOf("jag", "det", "och")
 
     // Translate Command Texts
-    const val translateKeyLbl = "Översätt"
-    const val translatePlaceholder = "Ange ett ord"
-    const val translatePrompt = "sv -› targetLanguage()" // Example, replace with actual language code
-    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
-    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+    const val TRANSLATE_KEY_LBL = "Översätt"
+    const val TRANSLATE_PLACEHOLDER = "Ange ett ord"
+    const val TRANSLATE_PROMPT = "sv -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts
-    const val conjugateKeyLbl = "Konjugera"
-    const val conjugatePlaceholder = "Ange ett verb"
-    const val conjugatePrompt = "Konjugera: "
-    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
-    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+    const val CONJUGATE_KEY_LBL = "Konjugera"
+    const val CONJUGATE_PLACEHOLDER = "Ange ett verb"
+    const val CONJUGATE_PROMPT = "Konjugera: "
+    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
 
     // Plural Command Texts
-    const val pluralKeyLbl = "Plural"
-    const val pluralPlaceholder = "Ange ett substantiv"
-    const val pluralPrompt = "Plural: "
-    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
-    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+    const val PLURAL_KEY_LBL = "Plural"
+    const val PLURAL_PLACEHOLDER = "Ange ett substantiv"
+    const val PLURAL_PROMPT = "Plural: "
+    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
 
     // Already Plural Message
-    const val alreadyPluralMsg = "Redan plural"
+    const val ALREADY_PLURAL_MSG = "Redan plural"
 }

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,7 +1,6 @@
 package be.scri.helpers.swedish
 
 object SwedishLanguageConstants {
-
     // Currency Symbol and Alternates
     const val currencySymbol = "kr"
     val currencySymbolAlternates = listOf("kr", "$", "€", "£", "¥")

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -19,7 +19,7 @@ object SVInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Översätt"
     const val TRANSLATE_PLACEHOLDER = "Ange ett ord"
     const val TRANSLATE_PROMPT = "sv -› targetLanguage()"
-    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "COMMAND_CURSOR"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
     // MARK: Conjugate Command
@@ -27,7 +27,7 @@ object SVInterfaceVariables {
     const val CONJUGATE_KEY_LBL = "Konjugera"
     const val CONJUGATE_PLACEHOLDER = "Ange ett verb"
     const val CONJUGATE_PROMPT = "Konjugera: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "COMMAND_CURSOR"
     const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
     // MARK: Plural Command
@@ -35,7 +35,7 @@ object SVInterfaceVariables {
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Ange ett substantiv"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "COMMAND_CURSOR"
     const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Redan plural"
 }

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,0 +1,39 @@
+package be.scri.helpers.swedish
+
+object SwedishLanguageConstants {
+
+    // Currency Symbol and Alternates
+    const val currencySymbol = "kr"
+    val currencySymbolAlternates = listOf("kr", "$", "€", "£", "¥")
+
+    // Keyboard Labels
+    const val spaceBar = "mellanslag"
+    const val language = "Svenska"
+    const val invalidCommandMsg = "Inte i Wikidata"
+    val baseAutosuggestions = listOf("jag", "det", "men")
+    val numericAutosuggestions = listOf("jag", "det", "och")
+
+    // Translate Command Texts
+    const val translateKeyLbl = "Översätt"
+    const val translatePlaceholder = "Ange ett ord"
+    const val translatePrompt = "sv -› targetLanguage()" // Example, replace with actual language code
+    const val translatePromptAndCursor = "$translatePrompt commandCursor" // Replace with actual dynamic value when available
+    const val translatePromptAndPlaceholder = "$translatePromptAndCursor $translatePlaceholder"
+
+    // Conjugate Command Texts
+    const val conjugateKeyLbl = "Konjugera"
+    const val conjugatePlaceholder = "Ange ett verb"
+    const val conjugatePrompt = "Konjugera: "
+    const val conjugatePromptAndCursor = "$conjugatePrompt commandCursor" // Replace with actual value
+    const val conjugatePromptAndPlaceholder = "$conjugatePromptAndCursor $conjugatePlaceholder"
+
+    // Plural Command Texts
+    const val pluralKeyLbl = "Plural"
+    const val pluralPlaceholder = "Ange ett substantiv"
+    const val pluralPrompt = "Plural: "
+    const val pluralPromptAndCursor = "$pluralPrompt commandCursor" // Replace with actual value
+    const val pluralPromptAndPlaceholder = "$pluralPromptAndCursor $pluralPlaceholder"
+
+    // Already Plural Message
+    const val alreadyPluralMsg = "Redan plural"
+}

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,40 +1,41 @@
 package be.scri.helpers.swedish
 
 object SVInterfaceVariables {
-    // Currency Symbol and Alternates
+    // MARK: Currency Symbols
+
     const val CURRENCY_SYMBOL = "kr"
     val CURRENCY_SYMBOL_ALTERNATES = listOf("kr", "$", "€", "£", "¥")
 
-    // Keyboard Labels
+    // MARK: Keyboard Labels
+
     const val SPACE_BAR = "mellanslag"
     const val LANGUAGE = "Svenska"
     const val INVALID_COMMAND_MSG = "Inte i Wikidata"
     val BASE_AUTOSUGGESTIONS = listOf("jag", "det", "men")
     val NUMERIC_AUTOSUGGESTIONS = listOf("jag", "det", "och")
 
-    // Translate Command Texts
+    // MARK: Translate Command
+
     const val TRANSLATE_KEY_LBL = "Översätt"
     const val TRANSLATE_PLACEHOLDER = "Ange ett ord"
-    const val TRANSLATE_PROMPT = "sv -› targetLanguage()" // Example, replace with actual language code
+    const val TRANSLATE_PROMPT = "sv -› targetLanguage()"
+    const val TRANSLATE_PROMPT_AND_CURSOR = TRANSLATE_PROMPT + "$COMMAND_CURSOR"
+    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = TRANSLATE_PROMPT_AND_CURSOR + "$TRANSLATE_PLACEHOLDER"
 
-    // Replace with actual dynamic value when available
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
-    const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
+    // MARK: Conjugate Command
 
-    // Conjugate Command Texts
     const val CONJUGATE_KEY_LBL = "Konjugera"
     const val CONJUGATE_PLACEHOLDER = "Ange ett verb"
     const val CONJUGATE_PROMPT = "Konjugera: "
-    const val CONJUGATE_PROMPT_AND_CURSOR = "$CONJUGATE_PROMPT commandCursor" // Replace with actual value
-    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = "$CONJUGATE_PROMPT_AND_CURSOR $CONJUGATE_PLACEHOLDER"
+    const val CONJUGATE_PROMPT_AND_CURSOR = CONJUGATE_PROMPT + "$COMMAND_CURSOR"
+    const val CONJUGATE_PROMPT_AND_PLACEHOLDER = CONJUGATE_PROMPT_AND_CURSOR + "$CONJUGATE_PLACEHOLDER"
 
-    // Plural Command Texts
+    // MARK: Plural Command
+
     const val PLURAL_KEY_LBL = "Plural"
     const val PLURAL_PLACEHOLDER = "Ange ett substantiv"
     const val PLURAL_PROMPT = "Plural: "
-    const val PLURAL_PROMPT_AND_CURSOR = "$PLURAL_PROMPT commandCursor" // Replace with actual value
-    const val PLURAL_PROMPT_AND_PLACEHOLDER = "$PLURAL_PROMPT_AND_CURSOR $PLURAL_PLACEHOLDER"
-
-    // Already Plural Message
+    const val PLURAL_PROMPT_AND_CURSOR = PLURAL_PROMPT + "$COMMAND_CURSOR"
+    const val PLURAL_PROMPT_AND_PLACEHOLDER = PLURAL_PROMPT_AND_CURSOR + "$PLURAL_PLACEHOLDER"
     const val ALREADY_PLURAL_MSG = "Redan plural"
 }

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -16,7 +16,9 @@ object SVInterfaceVariables {
     const val TRANSLATE_KEY_LBL = "Översätt"
     const val TRANSLATE_PLACEHOLDER = "Ange ett ord"
     const val TRANSLATE_PROMPT = "sv -› targetLanguage()" // Example, replace with actual language code
-    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor" // Replace with actual dynamic value when available
+
+    // Replace with actual dynamic value when available
+    const val TRANSLATE_PROMPT_AND_CURSOR = "$TRANSLATE_PROMPT commandCursor"
     const val TRANSLATE_PROMPT_AND_PLACEHOLDER = "$TRANSLATE_PROMPT_AND_CURSOR $TRANSLATE_PLACEHOLDER"
 
     // Conjugate Command Texts


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

In this PR, I’ve added all required interface variable strings to the keyboard constants for each language. Based on the new approach, these strings are now hard-coded into each keyboard file rather than being localized via Weblate.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #214 