### PR TITLE
Migrated about page from XML to Jetpack Compose

### DIFF
--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -6,27 +6,17 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.compose.foundation.background
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.recyclerview.widget.LinearLayoutManager
-import be.scri.BuildConfig
 import be.scri.R
 import be.scri.activities.MainActivity
-import be.scri.databinding.FragmentAboutBinding
-import be.scri.extensions.addCustomItemDecoration
-import be.scri.helpers.CustomAdapter
 import be.scri.helpers.HintUtils
 import be.scri.helpers.PreferencesHelper
 import be.scri.helpers.RatingHelper
 import be.scri.helpers.ShareHelper
-import be.scri.models.ItemsViewModel
 import be.scri.ui.screens.AboutScreen
-import be.scri.ui.screens.LanguageSettingsScreen
 import be.scri.ui.theme.ScribeTheme
 
 class AboutFragment : ScribeFragment("About") {
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -45,162 +35,27 @@ class AboutFragment : ScribeFragment("About") {
             setContent {
                 ScribeTheme(
                     useDarkTheme =
-                    PreferencesHelper.getUserDarkModePreference(requireContext())
-                        == AppCompatDelegate.MODE_NIGHT_YES,
+                        PreferencesHelper.getUserDarkModePreference(requireContext())
+                            == AppCompatDelegate.MODE_NIGHT_YES,
                 ) {
                     AboutScreen(
-                        onWikimediaAndScribeClick = { loadOtherFragment(WikimediaScribeFragment(), "WikimediaScribePage") },
+                        onWikimediaAndScribeClick = {
+                            loadOtherFragment(WikimediaScribeFragment(), "WikimediaScribePage")
+                        },
+                        onShareScribeClick = { ShareHelper.shareScribe(requireContext()) },
                         onPrivacyPolicyClick = { loadOtherFragment(PrivacyPolicyFragment(), null) },
                         onThirdPartyLicensesClick = { loadOtherFragment(ThirdPartyFragment(), null) },
-                        onRateScribeClick = { RatingHelper.rateScribe(requireContext(), activity as MainActivity) },
+                        onRateScribeClick = {
+                            RatingHelper.rateScribe(requireContext(), activity as MainActivity)
+                        },
                         onMailClick = { ShareHelper.sendEmail(requireContext()) },
                         onResetHintsClick = ::resetHints,
-                        context = requireContext()
+                        context = requireContext(),
                     )
                 }
             }
         }
     }
-
-//    override fun onViewCreated(
-//        view: View,
-//        savedInstanceState: Bundle?,
-//    ) {
-//        super.onViewCreated(view, savedInstanceState)
-//        setupRecyclerViews()
-//    }
-//
-//    private fun setupRecyclerViews() {
-//        val recyclerView1 = binding.recycleView2
-//        recyclerView1.layoutManager = LinearLayoutManager(context)
-//        recyclerView1.adapter = CustomAdapter(getFirstRecyclerViewData(), requireContext())
-//        recyclerView1.suppressLayout(true)
-//        recyclerView1.apply {
-//            addCustomItemDecoration(requireContext())
-//        }
-//        val recyclerView2 = binding.recycleView
-//        recyclerView2.layoutManager = LinearLayoutManager(context)
-//        recyclerView2.adapter = CustomAdapter(getSecondRecyclerViewData(), requireContext())
-//        recyclerView2.suppressLayout(true)
-//        recyclerView2.apply {
-//            addCustomItemDecoration(requireContext())
-//        }
-//        val recyclerView3 = binding.recycleView3
-//        recyclerView3.layoutManager = LinearLayoutManager(context)
-//        recyclerView3.adapter = CustomAdapter(getThirdRecyclerViewData(), requireContext())
-//        recyclerView3.suppressLayout(true)
-//        recyclerView3.apply {
-//            addCustomItemDecoration(requireContext())
-//        }
-//    }
-//
-//    private fun getFirstRecyclerViewData(): List<Any> =
-//        listOf(
-//            ItemsViewModel(
-//                image = R.drawable.github_logo,
-//                text = ItemsViewModel.Text(R.string.app_about_community_github),
-//                image2 = R.drawable.external_link,
-//                url = "https://github.com/scribe-org/Scribe-Android",
-//                activity = null,
-//                action = null,
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.matrix_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_community_matrix),
-//                image2 = R.drawable.external_link,
-//                url = "https://matrix.to/%23/%23scribe_community:matrix.org",
-//                activity = null,
-//                action = null,
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.mastodon_svg_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_community_mastodon),
-//                image2 = R.drawable.external_link,
-//                url = "https://wikis.world/@scribe",
-//                activity = null,
-//                action = null,
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.share_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_community_share_scribe),
-//                image2 = R.drawable.external_link,
-//                url = null,
-//                activity = null,
-//                action = ({ ShareHelper.shareScribe(requireContext()) }),
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.wikimedia_logo_black,
-//                text = ItemsViewModel.Text(R.string.app_about_community_wikimedia),
-//                image2 = R.drawable.right_arrow,
-//                url = null,
-//                activity = null,
-//                action = ({ loadOtherFragment(WikimediaScribeFragment(), "WikimediaScribePage") }),
-//            ),
-//        )
-//
-//    private fun getSecondRecyclerViewData(): List<Any> =
-//        listOf(
-//            ItemsViewModel(
-//                image = R.drawable.star,
-//                text = ItemsViewModel.Text(R.string.app_about_feedback_rate_scribe),
-//                image2 = R.drawable.external_link,
-//                url = null,
-//                activity = null,
-//                action = ({ RatingHelper.rateScribe(requireContext(), activity as MainActivity) }),
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.bug_report_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_feedback_bug_report),
-//                image2 = R.drawable.external_link,
-//                url = "https://github.com/scribe-org/Scribe-Android/issues",
-//                activity = null,
-//                action = null,
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.mail_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_feedback_email),
-//                image2 = R.drawable.external_link,
-//                url = null,
-//                activity = null,
-//                action = ({ ShareHelper.sendEmail(requireContext()) }),
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.bookmark_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_feedback_version, BuildConfig.VERSION_NAME),
-//                image2 = R.drawable.external_link,
-//                url = "https://github.com/scribe-org/Scribe-Android/releases/",
-//                activity = null,
-//                action = null,
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.light_bulb_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_feedback_app_hints),
-//                image2 = R.drawable.counter_clockwise_icon,
-//                url = null,
-//                activity = null,
-//                action = ::resetHints,
-//            ),
-//        )
-//
-//    private fun getThirdRecyclerViewData(): List<ItemsViewModel> =
-//        listOf(
-//            ItemsViewModel(
-//                image = R.drawable.shield_lock,
-//                text = ItemsViewModel.Text(R.string.app_about_legal_privacy_policy),
-//                image2 = R.drawable.right_arrow,
-//                url = null,
-//                activity = null,
-//                action = ({ loadOtherFragment(PrivacyPolicyFragment(), null) }),
-//            ),
-//            ItemsViewModel(
-//                image = R.drawable.license_icon,
-//                text = ItemsViewModel.Text(R.string.app_about_legal_third_party),
-//                image2 = R.drawable.right_arrow,
-//                url = null,
-//                activity = null,
-//                action = ({ loadOtherFragment(ThirdPartyFragment(), null) }),
-//            ),
-//        )
 
     private fun resetHints() {
         HintUtils.resetHints(requireContext())

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.addCallback
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.LinearLayoutManager
 import be.scri.BuildConfig
 import be.scri.R
@@ -13,19 +15,21 @@ import be.scri.databinding.FragmentAboutBinding
 import be.scri.extensions.addCustomItemDecoration
 import be.scri.helpers.CustomAdapter
 import be.scri.helpers.HintUtils
+import be.scri.helpers.PreferencesHelper
 import be.scri.helpers.RatingHelper
 import be.scri.helpers.ShareHelper
 import be.scri.models.ItemsViewModel
+import be.scri.ui.screens.AboutScreen
+import be.scri.ui.screens.LanguageSettingsScreen
+import be.scri.ui.theme.ScribeTheme
 
 class AboutFragment : ScribeFragment("About") {
-    private lateinit var binding: FragmentAboutBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        binding = FragmentAboutBinding.inflate(inflater, container, false)
         val callback =
             requireActivity().onBackPressedDispatcher.addCallback(this) {
                 getParentFragmentManager().popBackStack()
@@ -34,148 +38,166 @@ class AboutFragment : ScribeFragment("About") {
         (requireActivity() as MainActivity).setActionBarTitle(R.string.app_about_title)
         (requireActivity() as MainActivity).setActionBarVisibility(false)
         (requireActivity() as MainActivity).setActionBarButtonVisibility(false)
-        return binding.root
-    }
 
-    override fun onViewCreated(
-        view: View,
-        savedInstanceState: Bundle?,
-    ) {
-        super.onViewCreated(view, savedInstanceState)
-        setupRecyclerViews()
-    }
-
-    private fun setupRecyclerViews() {
-        val recyclerView1 = binding.recycleView2
-        recyclerView1.layoutManager = LinearLayoutManager(context)
-        recyclerView1.adapter = CustomAdapter(getFirstRecyclerViewData(), requireContext())
-        recyclerView1.suppressLayout(true)
-        recyclerView1.apply {
-            addCustomItemDecoration(requireContext())
-        }
-        val recyclerView2 = binding.recycleView
-        recyclerView2.layoutManager = LinearLayoutManager(context)
-        recyclerView2.adapter = CustomAdapter(getSecondRecyclerViewData(), requireContext())
-        recyclerView2.suppressLayout(true)
-        recyclerView2.apply {
-            addCustomItemDecoration(requireContext())
-        }
-        val recyclerView3 = binding.recycleView3
-        recyclerView3.layoutManager = LinearLayoutManager(context)
-        recyclerView3.adapter = CustomAdapter(getThirdRecyclerViewData(), requireContext())
-        recyclerView3.suppressLayout(true)
-        recyclerView3.apply {
-            addCustomItemDecoration(requireContext())
+        return ComposeView(requireContext()).apply {
+            setContent {
+                ScribeTheme(
+                    useDarkTheme =
+                    PreferencesHelper.getUserDarkModePreference(requireContext())
+                        == AppCompatDelegate.MODE_NIGHT_YES,
+                ) {
+                    AboutScreen(
+                        onWikimediaAndScribeClick = { loadOtherFragment(WikimediaScribeFragment(), "WikimediaScribePage") },
+                        onPrivacyPolicyClick = { loadOtherFragment(PrivacyPolicyFragment(), null) },
+                        onThirdPartyLicensesClick = { loadOtherFragment(ThirdPartyFragment(), null) },
+                        onRateScribeClick = { RatingHelper.rateScribe(requireContext(), activity as MainActivity) },
+                        onMailClick = { ShareHelper.sendEmail(requireContext()) },
+                        onResetHintsClick = ::resetHints,
+                    )
+                }
+            }
         }
     }
 
-    private fun getFirstRecyclerViewData(): List<Any> =
-        listOf(
-            ItemsViewModel(
-                image = R.drawable.github_logo,
-                text = ItemsViewModel.Text(R.string.app_about_community_github),
-                image2 = R.drawable.external_link,
-                url = "https://github.com/scribe-org/Scribe-Android",
-                activity = null,
-                action = null,
-            ),
-            ItemsViewModel(
-                image = R.drawable.matrix_icon,
-                text = ItemsViewModel.Text(R.string.app_about_community_matrix),
-                image2 = R.drawable.external_link,
-                url = "https://matrix.to/%23/%23scribe_community:matrix.org",
-                activity = null,
-                action = null,
-            ),
-            ItemsViewModel(
-                image = R.drawable.mastodon_svg_icon,
-                text = ItemsViewModel.Text(R.string.app_about_community_mastodon),
-                image2 = R.drawable.external_link,
-                url = "https://wikis.world/@scribe",
-                activity = null,
-                action = null,
-            ),
-            ItemsViewModel(
-                image = R.drawable.share_icon,
-                text = ItemsViewModel.Text(R.string.app_about_community_share_scribe),
-                image2 = R.drawable.external_link,
-                url = null,
-                activity = null,
-                action = ({ ShareHelper.shareScribe(requireContext()) }),
-            ),
-            ItemsViewModel(
-                image = R.drawable.wikimedia_logo_black,
-                text = ItemsViewModel.Text(R.string.app_about_community_wikimedia),
-                image2 = R.drawable.right_arrow,
-                url = null,
-                activity = null,
-                action = ({ loadOtherFragment(WikimediaScribeFragment(), "WikimediaScribePage") }),
-            ),
-        )
-
-    private fun getSecondRecyclerViewData(): List<Any> =
-        listOf(
-            ItemsViewModel(
-                image = R.drawable.star,
-                text = ItemsViewModel.Text(R.string.app_about_feedback_rate_scribe),
-                image2 = R.drawable.external_link,
-                url = null,
-                activity = null,
-                action = ({ RatingHelper.rateScribe(requireContext(), activity as MainActivity) }),
-            ),
-            ItemsViewModel(
-                image = R.drawable.bug_report_icon,
-                text = ItemsViewModel.Text(R.string.app_about_feedback_bug_report),
-                image2 = R.drawable.external_link,
-                url = "https://github.com/scribe-org/Scribe-Android/issues",
-                activity = null,
-                action = null,
-            ),
-            ItemsViewModel(
-                image = R.drawable.mail_icon,
-                text = ItemsViewModel.Text(R.string.app_about_feedback_email),
-                image2 = R.drawable.external_link,
-                url = null,
-                activity = null,
-                action = ({ ShareHelper.sendEmail(requireContext()) }),
-            ),
-            ItemsViewModel(
-                image = R.drawable.bookmark_icon,
-                text = ItemsViewModel.Text(R.string.app_about_feedback_version, BuildConfig.VERSION_NAME),
-                image2 = R.drawable.external_link,
-                url = "https://github.com/scribe-org/Scribe-Android/releases/",
-                activity = null,
-                action = null,
-            ),
-            ItemsViewModel(
-                image = R.drawable.light_bulb_icon,
-                text = ItemsViewModel.Text(R.string.app_about_feedback_app_hints),
-                image2 = R.drawable.counter_clockwise_icon,
-                url = null,
-                activity = null,
-                action = ::resetHints,
-            ),
-        )
-
-    private fun getThirdRecyclerViewData(): List<ItemsViewModel> =
-        listOf(
-            ItemsViewModel(
-                image = R.drawable.shield_lock,
-                text = ItemsViewModel.Text(R.string.app_about_legal_privacy_policy),
-                image2 = R.drawable.right_arrow,
-                url = null,
-                activity = null,
-                action = ({ loadOtherFragment(PrivacyPolicyFragment(), null) }),
-            ),
-            ItemsViewModel(
-                image = R.drawable.license_icon,
-                text = ItemsViewModel.Text(R.string.app_about_legal_third_party),
-                image2 = R.drawable.right_arrow,
-                url = null,
-                activity = null,
-                action = ({ loadOtherFragment(ThirdPartyFragment(), null) }),
-            ),
-        )
+//    override fun onViewCreated(
+//        view: View,
+//        savedInstanceState: Bundle?,
+//    ) {
+//        super.onViewCreated(view, savedInstanceState)
+//        setupRecyclerViews()
+//    }
+//
+//    private fun setupRecyclerViews() {
+//        val recyclerView1 = binding.recycleView2
+//        recyclerView1.layoutManager = LinearLayoutManager(context)
+//        recyclerView1.adapter = CustomAdapter(getFirstRecyclerViewData(), requireContext())
+//        recyclerView1.suppressLayout(true)
+//        recyclerView1.apply {
+//            addCustomItemDecoration(requireContext())
+//        }
+//        val recyclerView2 = binding.recycleView
+//        recyclerView2.layoutManager = LinearLayoutManager(context)
+//        recyclerView2.adapter = CustomAdapter(getSecondRecyclerViewData(), requireContext())
+//        recyclerView2.suppressLayout(true)
+//        recyclerView2.apply {
+//            addCustomItemDecoration(requireContext())
+//        }
+//        val recyclerView3 = binding.recycleView3
+//        recyclerView3.layoutManager = LinearLayoutManager(context)
+//        recyclerView3.adapter = CustomAdapter(getThirdRecyclerViewData(), requireContext())
+//        recyclerView3.suppressLayout(true)
+//        recyclerView3.apply {
+//            addCustomItemDecoration(requireContext())
+//        }
+//    }
+//
+//    private fun getFirstRecyclerViewData(): List<Any> =
+//        listOf(
+//            ItemsViewModel(
+//                image = R.drawable.github_logo,
+//                text = ItemsViewModel.Text(R.string.app_about_community_github),
+//                image2 = R.drawable.external_link,
+//                url = "https://github.com/scribe-org/Scribe-Android",
+//                activity = null,
+//                action = null,
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.matrix_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_community_matrix),
+//                image2 = R.drawable.external_link,
+//                url = "https://matrix.to/%23/%23scribe_community:matrix.org",
+//                activity = null,
+//                action = null,
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.mastodon_svg_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_community_mastodon),
+//                image2 = R.drawable.external_link,
+//                url = "https://wikis.world/@scribe",
+//                activity = null,
+//                action = null,
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.share_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_community_share_scribe),
+//                image2 = R.drawable.external_link,
+//                url = null,
+//                activity = null,
+//                action = ({ ShareHelper.shareScribe(requireContext()) }),
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.wikimedia_logo_black,
+//                text = ItemsViewModel.Text(R.string.app_about_community_wikimedia),
+//                image2 = R.drawable.right_arrow,
+//                url = null,
+//                activity = null,
+//                action = ({ loadOtherFragment(WikimediaScribeFragment(), "WikimediaScribePage") }),
+//            ),
+//        )
+//
+//    private fun getSecondRecyclerViewData(): List<Any> =
+//        listOf(
+//            ItemsViewModel(
+//                image = R.drawable.star,
+//                text = ItemsViewModel.Text(R.string.app_about_feedback_rate_scribe),
+//                image2 = R.drawable.external_link,
+//                url = null,
+//                activity = null,
+//                action = ({ RatingHelper.rateScribe(requireContext(), activity as MainActivity) }),
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.bug_report_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_feedback_bug_report),
+//                image2 = R.drawable.external_link,
+//                url = "https://github.com/scribe-org/Scribe-Android/issues",
+//                activity = null,
+//                action = null,
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.mail_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_feedback_email),
+//                image2 = R.drawable.external_link,
+//                url = null,
+//                activity = null,
+//                action = ({ ShareHelper.sendEmail(requireContext()) }),
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.bookmark_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_feedback_version, BuildConfig.VERSION_NAME),
+//                image2 = R.drawable.external_link,
+//                url = "https://github.com/scribe-org/Scribe-Android/releases/",
+//                activity = null,
+//                action = null,
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.light_bulb_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_feedback_app_hints),
+//                image2 = R.drawable.counter_clockwise_icon,
+//                url = null,
+//                activity = null,
+//                action = ::resetHints,
+//            ),
+//        )
+//
+//    private fun getThirdRecyclerViewData(): List<ItemsViewModel> =
+//        listOf(
+//            ItemsViewModel(
+//                image = R.drawable.shield_lock,
+//                text = ItemsViewModel.Text(R.string.app_about_legal_privacy_policy),
+//                image2 = R.drawable.right_arrow,
+//                url = null,
+//                activity = null,
+//                action = ({ loadOtherFragment(PrivacyPolicyFragment(), null) }),
+//            ),
+//            ItemsViewModel(
+//                image = R.drawable.license_icon,
+//                text = ItemsViewModel.Text(R.string.app_about_legal_third_party),
+//                image2 = R.drawable.right_arrow,
+//                url = null,
+//                activity = null,
+//                action = ({ loadOtherFragment(ThirdPartyFragment(), null) }),
+//            ),
+//        )
 
     private fun resetHints() {
         HintUtils.resetHints(requireContext())

--- a/app/src/main/java/be/scri/fragments/AboutFragment.kt
+++ b/app/src/main/java/be/scri/fragments/AboutFragment.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.background
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.LinearLayoutManager
 import be.scri.BuildConfig
@@ -53,6 +55,7 @@ class AboutFragment : ScribeFragment("About") {
                         onRateScribeClick = { RatingHelper.rateScribe(requireContext(), activity as MainActivity) },
                         onMailClick = { ShareHelper.sendEmail(requireContext()) },
                         onResetHintsClick = ::resetHints,
+                        context = requireContext()
                     )
                 }
             }

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItem.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItem.kt
@@ -32,47 +32,45 @@ fun AboutPageItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier =
-        modifier
+    Row(
+        modifier = modifier
             .fillMaxWidth()
             .padding(
-                horizontal = 12.dp,
-                vertical = 10.dp,
+                start = 12.dp,
+                end = 20.dp,
+                top = 10.dp,
+                bottom = 10.dp
             )
             .clip(RoundedCornerShape(12.dp))
             .clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                painter = painterResource(leadingIcon),
-                modifier =
-                Modifier
-                    .padding(start = 2.dp)
-                    .size(18.dp),
-                tint = colorResource(R.color.app_text_color),
-                contentDescription = "Right Arrow",
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = title,
-                modifier = Modifier.weight(1f),
-                fontSize = 16.sp,
-                color = colorResource(R.color.app_text_color),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Icon(
-                painter = painterResource(trailingIcon),
-                modifier =
-                Modifier
-                    .padding(start = 6.dp)
-                    .size(14.dp),
-                contentDescription = "Right Arrow",
-            )
-        }
+        Icon(
+            painter = painterResource(leadingIcon),
+            modifier =
+            Modifier
+                .padding(start = 2.dp)
+                .size(20.dp),
+            tint = colorResource(R.color.app_text_color),
+            contentDescription = "Right Arrow",
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = title,
+            modifier = Modifier.weight(1f),
+            fontSize = 16.sp,
+            color = colorResource(R.color.app_text_color),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Icon(
+            painter = painterResource(trailingIcon),
+            modifier =
+            Modifier
+                .padding(start = 6.dp)
+                .size(24.dp),
+            contentDescription = "Right Arrow",
+            tint = Color.Gray
+        )
     }
 }
 

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItem.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItem.kt
@@ -1,0 +1,88 @@
+package be.scri.ui.common.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import be.scri.R
+
+@Composable
+fun AboutPageItem(
+    title: String,
+    leadingIcon: Int,
+    trailingIcon: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier =
+        modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = 12.dp,
+                vertical = 10.dp,
+            )
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(leadingIcon),
+                modifier =
+                Modifier
+                    .padding(start = 2.dp)
+                    .size(18.dp),
+                tint = colorResource(R.color.app_text_color),
+                contentDescription = "Right Arrow",
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = title,
+                modifier = Modifier.weight(1f),
+                fontSize = 16.sp,
+                color = colorResource(R.color.app_text_color),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Icon(
+                painter = painterResource(trailingIcon),
+                modifier =
+                Modifier
+                    .padding(start = 6.dp)
+                    .size(14.dp),
+                contentDescription = "Right Arrow",
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun AboutPageItemPreview(modifier: Modifier = Modifier) {
+    AboutPageItem(
+        title = "About Scribe",
+        leadingIcon = R.drawable.github_logo,
+        trailingIcon = R.drawable.right_arrow,
+        onClick = {}
+    )
+}

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItem.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItem.kt
@@ -1,7 +1,6 @@
 package be.scri.ui.common.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,38 +18,37 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import be.scri.R
 
 @Composable
-fun AboutPageItem(
+fun AboutPageItemComp(
     title: String,
     leadingIcon: Int,
     trailingIcon: Int,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(
-                start = 12.dp,
-                end = 20.dp,
-                top = 10.dp,
-                bottom = 10.dp
-            )
-            .clip(RoundedCornerShape(12.dp))
-            .clickable(onClick = onClick),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(
+                    start = 12.dp,
+                    end = 20.dp,
+                    top = 10.dp,
+                    bottom = 10.dp,
+                ).clip(RoundedCornerShape(12.dp))
+                .clickable(onClick = onClick),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
             painter = painterResource(leadingIcon),
             modifier =
-            Modifier
-                .padding(start = 2.dp)
-                .size(20.dp),
+                Modifier
+                    .padding(start = 2.dp)
+                    .size(20.dp),
             tint = colorResource(R.color.app_text_color),
             contentDescription = "Right Arrow",
         )
@@ -65,22 +63,11 @@ fun AboutPageItem(
         Icon(
             painter = painterResource(trailingIcon),
             modifier =
-            Modifier
-                .padding(start = 6.dp)
-                .size(24.dp),
+                Modifier
+                    .padding(start = 6.dp)
+                    .size(24.dp),
             contentDescription = "Right Arrow",
-            tint = Color.Gray
+            tint = Color.Gray,
         )
     }
-}
-
-@PreviewLightDark
-@Composable
-private fun AboutPageItemPreview(modifier: Modifier = Modifier) {
-    AboutPageItem(
-        title = "About Scribe",
-        leadingIcon = R.drawable.github_logo,
-        trailingIcon = R.drawable.right_arrow,
-        onClick = {}
-    )
 }

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
@@ -48,14 +48,14 @@ fun AboutPageItemComp(
             modifier =
                 Modifier
                     .padding(start = 2.dp)
-                    .size(20.dp),
+                    .size(22.dp),
             tint = colorResource(R.color.app_text_color),
             contentDescription = "Right Arrow",
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = title,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).padding(start = 4.dp),
             fontSize = 16.sp,
             color = colorResource(R.color.app_text_color),
             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -27,7 +27,7 @@ fun ItemsCardContainer(
         Column(
             modifier =
                 Modifier
-                    .padding(vertical = 4.dp, horizontal = 4.dp),
+                    .padding(vertical = 10.dp, horizontal = 4.dp),
         ) {
             cardItemsList.items.forEach { item ->
                 when (item) {
@@ -66,7 +66,7 @@ fun ItemsCardContainer(
                     cardItemsList.items.indexOf(item) != cardItemsList.items.lastIndex
                 ) {
                     HorizontalDivider(
-                        color = Color.Gray.copy(alpha = 0.25f),
+                        color = Color.Gray.copy(alpha = 0.38f),
                         thickness = 1.dp,
                         modifier =
                             Modifier.padding(

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -52,7 +52,7 @@ fun ItemsCardContainer(
                     }
 
                     is ScribeItem.ExternalLinkItem -> {
-                        AboutPageItem(
+                        AboutPageItemComp(
                             title = item.title,
                             leadingIcon = item.leadingIcon,
                             trailingIcon = item.trailingIcon,

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -52,6 +52,12 @@ fun ItemsCardContainer(
                     }
 
                     is ScribeItem.ExternalLinkItem -> {
+                        AboutPageItem(
+                            title = item.title,
+                            leadingIcon = item.leadingIcon,
+                            trailingIcon = item.trailingIcon,
+                            onClick = item.onClick,
+                        )
                     }
                 }
 

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -66,7 +66,7 @@ fun ItemsCardContainer(
                     cardItemsList.items.indexOf(item) != cardItemsList.items.lastIndex
                 ) {
                     HorizontalDivider(
-                        color = Color.Gray.copy(alpha = 0.38f),
+                        color = Color.Gray.copy(alpha = 0.3f),
                         thickness = 1.dp,
                         modifier =
                             Modifier.padding(

--- a/app/src/main/java/be/scri/ui/models/ScribeItem.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItem.kt
@@ -1,5 +1,7 @@
 package be.scri.ui.models
 
+import androidx.annotation.DrawableRes
+
 sealed class ScribeItem(
     open val title: String,
     open val desc: String?,
@@ -19,9 +21,11 @@ sealed class ScribeItem(
 
     data class ExternalLinkItem(
         override val title: String,
-        override val desc: String,
-        val url: String,
-        val onClick: (String) -> Unit,
+        override val desc: String? = null,
+        @DrawableRes val leadingIcon: Int,
+        @DrawableRes val trailingIcon: Int,
+        val url: String?,
+        val onClick: () -> Unit,
     ) : ScribeItem(title, desc)
 
     data class CustomItem(

--- a/app/src/main/java/be/scri/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/AboutScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
@@ -22,13 +20,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import be.scri.BuildConfig
 import be.scri.R
-import be.scri.activities.MainActivity
-import be.scri.fragments.PrivacyPolicyFragment
-import be.scri.fragments.ThirdPartyFragment
-import be.scri.fragments.WikimediaScribeFragment
-import be.scri.helpers.RatingHelper
-import be.scri.helpers.ShareHelper
-import be.scri.models.ItemsViewModel
 import be.scri.ui.common.components.ItemCardContainerWithTitle
 import be.scri.ui.models.ScribeItem
 import be.scri.ui.models.ScribeItemList
@@ -37,48 +28,58 @@ import be.scri.ui.models.ScribeItemList
 @Composable
 fun AboutScreen(
     onWikimediaAndScribeClick: () -> Unit,
+    onShareScribeClick: () -> Unit,
     onPrivacyPolicyClick: () -> Unit,
     onThirdPartyLicensesClick: () -> Unit,
     onRateScribeClick: () -> Unit,
     onMailClick: () -> Unit,
     onResetHintsClick: () -> Unit,
     context: Context,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
 
-    val communityList = ScribeItemList(
-        items = getCommunityList(
-            onWikimediaAndScribeClick = onWikimediaAndScribeClick,
-            context = context
+    val communityList =
+        ScribeItemList(
+            items =
+                getCommunityList(
+                    onWikimediaAndScribeClick = onWikimediaAndScribeClick,
+                    onShareScribeClick = onShareScribeClick,
+                    context = context,
+                ),
         )
-    )
 
-    val feedbackAndSupportList = ScribeItemList(
-        items = getFeedbackAndSupportList(
-            onRateScribeClick = onRateScribeClick,
-            onMailClick = onMailClick,
-            onResetHintsClick = onResetHintsClick,
-            context = context
+    val feedbackAndSupportList =
+        ScribeItemList(
+            items =
+                getFeedbackAndSupportList(
+                    onRateScribeClick = onRateScribeClick,
+                    onMailClick = onMailClick,
+                    onResetHintsClick = onResetHintsClick,
+                    context = context,
+                ),
         )
-    )
 
-    val legalItemsList = ScribeItemList(
-        items = getLegalListItems(
-            onPrivacyPolicyClick = onPrivacyPolicyClick,
-            onThirdPartyLicensesClick = onThirdPartyLicensesClick
+    val legalItemsList =
+        ScribeItemList(
+            items =
+                getLegalListItems(
+                    onPrivacyPolicyClick = onPrivacyPolicyClick,
+                    onThirdPartyLicensesClick = onThirdPartyLicensesClick,
+                ),
         )
-    )
 
     Scaffold(
-        modifier = modifier
-            .background(color = MaterialTheme.colorScheme.background )
+        modifier =
+            modifier
+                .background(color = MaterialTheme.colorScheme.background),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(scrollState),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             ItemCardContainerWithTitle(
                 title = stringResource(R.string.community_title),
@@ -95,7 +96,7 @@ fun AboutScreen(
             ItemCardContainerWithTitle(
                 title = stringResource(R.string.app_about_legal_title),
                 cardItemsList = legalItemsList,
-                isDivider = true
+                isDivider = true,
             )
 
             Spacer(modifier = Modifier.height(80.dp))
@@ -103,24 +104,28 @@ fun AboutScreen(
     }
 }
 
-
 @Composable
 fun getCommunityList(
     onWikimediaAndScribeClick: () -> Unit,
-    context: Context
-): List<ScribeItem.ExternalLinkItem> {
-    return listOf(
+    onShareScribeClick: () -> Unit,
+    context: Context,
+): List<ScribeItem.ExternalLinkItem> =
+    listOf(
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.github_logo,
             title = stringResource(R.string.app_about_community_github),
             trailingIcon = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android",
             onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
-                    "https://github.com/scribe-org/Scribe-Android"
-                ))
+                val intent =
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(
+                            "https://github.com/scribe-org/Scribe-Android",
+                        ),
+                    )
                 context.startActivity(intent)
-            }
+            },
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.matrix_icon,
@@ -128,9 +133,13 @@ fun getCommunityList(
             trailingIcon = R.drawable.external_link,
             url = "https://matrix.to/%23/%23scribe_community:matrix.org",
             onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
-                    "https://matrix.to/%23/%23scribe_community:matrix.org"
-                ))
+                val intent =
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(
+                            "https://matrix.to/%23/%23scribe_community:matrix.org",
+                        ),
+                    )
                 context.startActivity(intent)
             },
         ),
@@ -140,9 +149,13 @@ fun getCommunityList(
             trailingIcon = R.drawable.external_link,
             url = "https://wikis.world/@scribe",
             onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
-                    "https://wikis.world/@scribe"
-                ))
+                val intent =
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(
+                            "https://wikis.world/@scribe",
+                        ),
+                    )
                 context.startActivity(intent)
             },
         ),
@@ -151,7 +164,9 @@ fun getCommunityList(
             title = stringResource(R.string.app_about_community_share_scribe),
             trailingIcon = R.drawable.external_link,
             url = null,
-            onClick = { },
+            onClick = {
+                onShareScribeClick()
+            },
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.wikimedia_logo_black,
@@ -160,19 +175,18 @@ fun getCommunityList(
             url = null,
             onClick = {
                 onWikimediaAndScribeClick()
-            }
+            },
         ),
     )
-}
 
 @Composable
 fun getFeedbackAndSupportList(
     onRateScribeClick: () -> Unit,
     onMailClick: () -> Unit,
     onResetHintsClick: () -> Unit,
-    context: Context
-): List<ScribeItem.ExternalLinkItem> {
-    return listOf(
+    context: Context,
+): List<ScribeItem.ExternalLinkItem> =
+    listOf(
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.star,
             title = stringResource(R.string.app_about_feedback_rate_scribe),
@@ -188,9 +202,13 @@ fun getFeedbackAndSupportList(
             trailingIcon = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android/issues",
             onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
-                    "https://github.com/scribe-org/Scribe-Android/issues"
-                ))
+                val intent =
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(
+                            "https://github.com/scribe-org/Scribe-Android/issues",
+                        ),
+                    )
                 context.startActivity(intent)
             },
         ),
@@ -207,9 +225,13 @@ fun getFeedbackAndSupportList(
             trailingIcon = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android/releases/",
             onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
-                    "https://github.com/scribe-org/Scribe-Android/releases/"
-                ))
+                val intent =
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(
+                            "https://github.com/scribe-org/Scribe-Android/releases/",
+                        ),
+                    )
                 context.startActivity(intent)
             },
         ),
@@ -221,14 +243,13 @@ fun getFeedbackAndSupportList(
             onClick = { onResetHintsClick() },
         ),
     )
-}
 
 @Composable
 fun getLegalListItems(
     onPrivacyPolicyClick: () -> Unit,
-    onThirdPartyLicensesClick: () -> Unit
-): List<ScribeItem.ExternalLinkItem> {
-    return listOf(
+    onThirdPartyLicensesClick: () -> Unit,
+): List<ScribeItem.ExternalLinkItem> =
+    listOf(
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.shield_lock,
             title = stringResource(R.string.app_about_legal_privacy_policy),
@@ -244,4 +265,3 @@ fun getLegalListItems(
             onClick = { onThirdPartyLicensesClick() },
         ),
     )
-}

--- a/app/src/main/java/be/scri/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/AboutScreen.kt
@@ -1,0 +1,202 @@
+package be.scri.ui.screens
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import be.scri.BuildConfig
+import be.scri.R
+import be.scri.activities.MainActivity
+import be.scri.fragments.PrivacyPolicyFragment
+import be.scri.fragments.ThirdPartyFragment
+import be.scri.fragments.WikimediaScribeFragment
+import be.scri.helpers.RatingHelper
+import be.scri.helpers.ShareHelper
+import be.scri.models.ItemsViewModel
+import be.scri.ui.common.components.ItemCardContainerWithTitle
+import be.scri.ui.models.ScribeItem
+import be.scri.ui.models.ScribeItemList
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun AboutScreen(
+    onWikimediaAndScribeClick: () -> Unit,
+    onPrivacyPolicyClick: () -> Unit,
+    onThirdPartyLicensesClick: () -> Unit,
+    onRateScribeClick: () -> Unit,
+    onMailClick: () -> Unit,
+    onResetHintsClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+
+    val communityList = ScribeItemList(
+        items = getCommunityList(
+            onWikimediaAndScribeClick = onWikimediaAndScribeClick
+        )
+    )
+
+    val feedbackAndSupportList = ScribeItemList(
+        items = getFeedbackAndSupportList(
+            onRateScribeClick = onRateScribeClick,
+            onMailClick = onMailClick,
+            onResetHintsClick = onResetHintsClick
+        )
+    )
+
+    val legalItemsList = ScribeItemList(
+        items = getLegalListItems(
+            onPrivacyPolicyClick = onPrivacyPolicyClick,
+            onThirdPartyLicensesClick = onThirdPartyLicensesClick
+        )
+    )
+
+    Scaffold(
+        modifier = modifier
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            item {
+                ItemCardContainerWithTitle(
+                    title = stringResource(R.string.community_title),
+                    cardItemsList = communityList,
+                    isDivider = true,
+                )
+            }
+            item {
+                ItemCardContainerWithTitle(
+                    title = stringResource(R.string.app_about_feedback_title),
+                    cardItemsList = feedbackAndSupportList,
+                    isDivider = true,
+                )
+            }
+
+            item {
+                ItemCardContainerWithTitle(
+                    title = stringResource(R.string.app_about_legal_title),
+                    cardItemsList = legalItemsList,
+                    isDivider = true
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+fun getCommunityList(
+    onWikimediaAndScribeClick: () -> Unit
+): List<ScribeItem.ExternalLinkItem> {
+    return listOf(
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.github_logo,
+            title = stringResource(R.string.app_about_community_github),
+            trailingIcon = R.drawable.external_link,
+            url = "https://github.com/scribe-org/Scribe-Android",
+            onClick = {  }
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.matrix_icon,
+            title = stringResource(R.string.app_about_community_matrix),
+            trailingIcon = R.drawable.external_link,
+            url = "https://matrix.to/%23/%23scribe_community:matrix.org",
+            onClick = { },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.mastodon_svg_icon,
+            title = stringResource(R.string.app_about_community_mastodon),
+            trailingIcon = R.drawable.external_link,
+            url = "https://wikis.world/@scribe",
+            onClick = { },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.share_icon,
+            title = stringResource(R.string.app_about_community_share_scribe),
+            trailingIcon = R.drawable.external_link,
+            url = null,
+            onClick = { },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.wikimedia_logo_black,
+            title = stringResource(R.string.app_about_community_wikimedia),
+            trailingIcon = R.drawable.right_arrow,
+            url = null,
+            onClick = {
+                onWikimediaAndScribeClick()
+            }
+        ),
+    )
+}
+
+@Composable
+fun getFeedbackAndSupportList(
+    onRateScribeClick: () -> Unit,
+    onMailClick: () -> Unit,
+    onResetHintsClick: () -> Unit,
+
+): List<ScribeItem.ExternalLinkItem> {
+    return listOf(
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.star,
+            title = stringResource(R.string.app_about_feedback_rate_scribe),
+            trailingIcon = R.drawable.external_link,
+            url = null,
+            onClick = { onMailClick() },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.bug_report_icon,
+            title = stringResource(R.string.app_about_feedback_bug_report),
+            trailingIcon = R.drawable.external_link,
+            url = "https://github.com/scribe-org/Scribe-Android/issues",
+            onClick = { },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.mail_icon,
+            title = stringResource(R.string.app_about_feedback_email),
+            trailingIcon = R.drawable.external_link,
+            url = null,
+            onClick = { onMailClick() },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.bookmark_icon,
+            title = stringResource(R.string.app_about_feedback_version, BuildConfig.VERSION_NAME),
+            trailingIcon = R.drawable.external_link,
+            url = "https://github.com/scribe-org/Scribe-Android/releases/",
+            onClick = { },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.light_bulb_icon,
+            title = stringResource(R.string.app_about_feedback_app_hints),
+            trailingIcon = R.drawable.counter_clockwise_icon,
+            url = null,
+            onClick = { onResetHintsClick() },
+        ),
+    )
+}
+
+@Composable
+fun getLegalListItems(
+    onPrivacyPolicyClick: () -> Unit,
+    onThirdPartyLicensesClick: () -> Unit
+): List<ScribeItem.ExternalLinkItem> {
+    return listOf(
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.shield_lock,
+            title = stringResource(R.string.app_about_legal_privacy_policy),
+            trailingIcon = R.drawable.right_arrow,
+            url = null,
+            onClick = { onPrivacyPolicyClick() },
+        ),
+        ScribeItem.ExternalLinkItem(
+            leadingIcon = R.drawable.license_icon,
+            title = stringResource(R.string.app_about_legal_third_party),
+            trailingIcon = R.drawable.right_arrow,
+            url = null,
+            onClick = { onThirdPartyLicensesClick() },
+        ),
+    )
+}

--- a/app/src/main/java/be/scri/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/AboutScreen.kt
@@ -1,12 +1,25 @@
 package be.scri.ui.screens
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import be.scri.BuildConfig
 import be.scri.R
 import be.scri.activities.MainActivity
@@ -29,12 +42,15 @@ fun AboutScreen(
     onRateScribeClick: () -> Unit,
     onMailClick: () -> Unit,
     onResetHintsClick: () -> Unit,
+    context: Context,
     modifier: Modifier = Modifier
 ) {
+    val scrollState = rememberScrollState()
 
     val communityList = ScribeItemList(
         items = getCommunityList(
-            onWikimediaAndScribeClick = onWikimediaAndScribeClick
+            onWikimediaAndScribeClick = onWikimediaAndScribeClick,
+            context = context
         )
     )
 
@@ -42,7 +58,8 @@ fun AboutScreen(
         items = getFeedbackAndSupportList(
             onRateScribeClick = onRateScribeClick,
             onMailClick = onMailClick,
-            onResetHintsClick = onResetHintsClick
+            onResetHintsClick = onResetHintsClick,
+            context = context
         )
     )
 
@@ -55,33 +72,33 @@ fun AboutScreen(
 
     Scaffold(
         modifier = modifier
+            .background(color = MaterialTheme.colorScheme.background )
     ) {
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            item {
-                ItemCardContainerWithTitle(
-                    title = stringResource(R.string.community_title),
-                    cardItemsList = communityList,
-                    isDivider = true,
-                )
-            }
-            item {
-                ItemCardContainerWithTitle(
-                    title = stringResource(R.string.app_about_feedback_title),
-                    cardItemsList = feedbackAndSupportList,
-                    isDivider = true,
-                )
-            }
+            ItemCardContainerWithTitle(
+                title = stringResource(R.string.community_title),
+                cardItemsList = communityList,
+                isDivider = true,
+            )
 
-            item {
-                ItemCardContainerWithTitle(
-                    title = stringResource(R.string.app_about_legal_title),
-                    cardItemsList = legalItemsList,
-                    isDivider = true
-                )
-            }
+            ItemCardContainerWithTitle(
+                title = stringResource(R.string.app_about_feedback_title),
+                cardItemsList = feedbackAndSupportList,
+                isDivider = true,
+            )
+
+            ItemCardContainerWithTitle(
+                title = stringResource(R.string.app_about_legal_title),
+                cardItemsList = legalItemsList,
+                isDivider = true
+            )
+
+            Spacer(modifier = Modifier.height(80.dp))
         }
     }
 }
@@ -89,7 +106,8 @@ fun AboutScreen(
 
 @Composable
 fun getCommunityList(
-    onWikimediaAndScribeClick: () -> Unit
+    onWikimediaAndScribeClick: () -> Unit,
+    context: Context
 ): List<ScribeItem.ExternalLinkItem> {
     return listOf(
         ScribeItem.ExternalLinkItem(
@@ -97,21 +115,36 @@ fun getCommunityList(
             title = stringResource(R.string.app_about_community_github),
             trailingIcon = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android",
-            onClick = {  }
+            onClick = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
+                    "https://github.com/scribe-org/Scribe-Android"
+                ))
+                context.startActivity(intent)
+            }
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.matrix_icon,
             title = stringResource(R.string.app_about_community_matrix),
             trailingIcon = R.drawable.external_link,
             url = "https://matrix.to/%23/%23scribe_community:matrix.org",
-            onClick = { },
+            onClick = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
+                    "https://matrix.to/%23/%23scribe_community:matrix.org"
+                ))
+                context.startActivity(intent)
+            },
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.mastodon_svg_icon,
             title = stringResource(R.string.app_about_community_mastodon),
             trailingIcon = R.drawable.external_link,
             url = "https://wikis.world/@scribe",
-            onClick = { },
+            onClick = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
+                    "https://wikis.world/@scribe"
+                ))
+                context.startActivity(intent)
+            },
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.share_icon,
@@ -137,7 +170,7 @@ fun getFeedbackAndSupportList(
     onRateScribeClick: () -> Unit,
     onMailClick: () -> Unit,
     onResetHintsClick: () -> Unit,
-
+    context: Context
 ): List<ScribeItem.ExternalLinkItem> {
     return listOf(
         ScribeItem.ExternalLinkItem(
@@ -145,14 +178,21 @@ fun getFeedbackAndSupportList(
             title = stringResource(R.string.app_about_feedback_rate_scribe),
             trailingIcon = R.drawable.external_link,
             url = null,
-            onClick = { onMailClick() },
+            onClick = {
+                onRateScribeClick()
+            },
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.bug_report_icon,
             title = stringResource(R.string.app_about_feedback_bug_report),
             trailingIcon = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android/issues",
-            onClick = { },
+            onClick = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
+                    "https://github.com/scribe-org/Scribe-Android/issues"
+                ))
+                context.startActivity(intent)
+            },
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.mail_icon,
@@ -166,7 +206,12 @@ fun getFeedbackAndSupportList(
             title = stringResource(R.string.app_about_feedback_version, BuildConfig.VERSION_NAME),
             trailingIcon = R.drawable.external_link,
             url = "https://github.com/scribe-org/Scribe-Android/releases/",
-            onClick = { },
+            onClick = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(
+                    "https://github.com/scribe-org/Scribe-Android/releases/"
+                ))
+                context.startActivity(intent)
+            },
         ),
         ScribeItem.ExternalLinkItem(
             leadingIcon = R.drawable.light_bulb_icon,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
The pull request moves the about page to Jetpack Compose

### Screenshots

| Before | After |
|---|---|
| ![Before](https://github.com/user-attachments/assets/66333ea1-8a90-4c0a-924b-e4d9dc201c89) | ![WhatsApp Image 2024-12-06 at 10 55 20_ea973503](https://github.com/user-attachments/assets/4432a98f-aa0c-4030-9b47-cf76ead5533f)

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #248
