### PR TITLE
Style first autosuggestion button based on the gender of a word typed 

### DIFF
--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -87,7 +87,7 @@ class DatabaseHelper(
 
     fun getNounKeyMaps(cursor: Cursor): MutableList<String> {
         val values = mutableListOf<String>()
-        values.add(cursor.getString(1))
+        values.add(cursor.getString(2))
         return values
     }
 

--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -67,4 +67,28 @@ class DatabaseHelper(
         }
         return values
     }
+
+    fun getNounKeywords(language: String): HashMap<String, MutableList<String>> {
+        val hashMap = HashMap<String, MutableList<String>>()
+        val dbFile = context.getDatabasePath("${language}LanguageData.sqlite")
+        val db = SQLiteDatabase.openDatabase(dbFile.path, null, SQLiteDatabase.OPEN_READONLY)
+        val cursor = db.rawQuery("SELECT * FROM nouns", null)
+
+        cursor.use {
+            if (cursor.moveToFirst()) {
+                do {
+                    val key = cursor.getString(0).lowercase()
+                    hashMap[key] = getNounKeyMaps(cursor)
+                } while (cursor.moveToNext())
+            }
+        }
+        return hashMap
+    }
+
+    fun getNounKeyMaps(cursor: Cursor): MutableList<String> {
+        val values = mutableListOf<String>()
+        values.add(cursor.getString(1))
+        return values
+    }
+
 }

--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -90,5 +90,4 @@ class DatabaseHelper(
         values.add(cursor.getString(2))
         return values
     }
-
 }

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -79,13 +79,18 @@ class EnglishKeyboardIME : SimpleKeyboardIME("English") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
         Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG","$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
+        updateAutoSuggestText(nounTypeSuggestion)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
+
+
+
 
     fun handleKeycodeDelete() {
         if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -56,22 +56,37 @@ class EnglishKeyboardIME : SimpleKeyboardIME("English") {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -83,7 +98,6 @@ class EnglishKeyboardIME : SimpleKeyboardIME("English") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        updateAutoSuggestText(nounTypeSuggestion)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -79,18 +79,15 @@ class EnglishKeyboardIME : SimpleKeyboardIME("English") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
-        Log.d("MY-TAG","$nounTypeSuggestion")
+        Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
         updateAutoSuggestText(nounTypeSuggestion)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
-
-
-
 
     fun handleKeycodeDelete() {
         if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -76,7 +76,7 @@ class EnglishKeyboardIME : SimpleKeyboardIME("English") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -72,7 +72,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME("French") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -48,7 +48,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME("French") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         updateAutoSuggestText(nounTypeSuggestion)
 
         when (code) {
@@ -73,7 +73,6 @@ class FrenchKeyboardIME : SimpleKeyboardIME("French") {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }
             }
-
         }
 
         lastWord = getLastWordBeforeCursor()

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -48,29 +48,41 @@ class FrenchKeyboardIME : SimpleKeyboardIME("French") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
-        updateAutoSuggestText(nounTypeSuggestion)
-
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -78,9 +90,10 @@ class FrenchKeyboardIME : SimpleKeyboardIME("French") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -48,6 +48,9 @@ class FrenchKeyboardIME : SimpleKeyboardIME("French") {
             lastShiftPressTS = 0
         }
 
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        updateAutoSuggestText(nounTypeSuggestion)
+
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
@@ -70,6 +73,7 @@ class FrenchKeyboardIME : SimpleKeyboardIME("French") {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }
             }
+
         }
 
         lastWord = getLastWordBeforeCursor()

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -81,7 +81,7 @@ class GermanKeyboardIME : SimpleKeyboardIME("German") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -88,8 +88,8 @@ class GermanKeyboardIME : SimpleKeyboardIME("German") {
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
 
         Log.d("Debug", "$autosuggestEmojis")
-        Log.d("MY-TAG","$nounTypeSuggestion")
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        Log.d("MY-TAG", "$nounTypeSuggestion")
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         updateAutoSuggestText(nounTypeSuggestion)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -61,22 +61,37 @@ class GermanKeyboardIME : SimpleKeyboardIME("German") {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -84,13 +99,10 @@ class GermanKeyboardIME : SimpleKeyboardIME("German") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
-        Log.d("Debug", "$autosuggestEmojis")
-        updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
-        updateAutoSuggestText(nounTypeSuggestion)
+        updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -87,6 +87,10 @@ class GermanKeyboardIME : SimpleKeyboardIME("German") {
         Log.d("Debug", "$autosuggestEmojis")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
 
+        Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG","$nounTypeSuggestion")
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        updateAutoSuggestText(nounTypeSuggestion)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -48,28 +48,41 @@ class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
-        updateAutoSuggestText(nounTypeSuggestion)
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -77,9 +90,10 @@ class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -48,6 +48,9 @@ class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
             lastShiftPressTS = 0
         }
 
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        updateAutoSuggestText(nounTypeSuggestion)
+
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
@@ -70,6 +73,7 @@ class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }
             }
+
         }
 
         lastWord = getLastWordBeforeCursor()

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -72,7 +72,7 @@ class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -48,9 +48,8 @@ class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         updateAutoSuggestText(nounTypeSuggestion)
-
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
@@ -73,7 +72,6 @@ class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
                 }
             }
-
         }
 
         lastWord = getLastWordBeforeCursor()

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -72,7 +72,7 @@ class PortugueseKeyboardIME : SimpleKeyboardIME("Portuguese") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -48,29 +48,41 @@ class PortugueseKeyboardIME : SimpleKeyboardIME("Portuguese") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
-        updateAutoSuggestText(nounTypeSuggestion)
-
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -78,9 +90,10 @@ class PortugueseKeyboardIME : SimpleKeyboardIME("Portuguese") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -48,6 +48,9 @@ class PortugueseKeyboardIME : SimpleKeyboardIME("Portuguese") {
             lastShiftPressTS = 0
         }
 
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        updateAutoSuggestText(nounTypeSuggestion)
+
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -48,7 +48,7 @@ class PortugueseKeyboardIME : SimpleKeyboardIME("Portuguese") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         updateAutoSuggestText(nounTypeSuggestion)
 
         when (code) {

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -48,7 +48,7 @@ class RussianKeyboardIME : SimpleKeyboardIME("Russian") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         updateAutoSuggestText(nounTypeSuggestion)
 
         when (code) {

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -48,29 +48,41 @@ class RussianKeyboardIME : SimpleKeyboardIME("Russian") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
-        updateAutoSuggestText(nounTypeSuggestion)
-
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -78,9 +90,10 @@ class RussianKeyboardIME : SimpleKeyboardIME("Russian") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -48,6 +48,9 @@ class RussianKeyboardIME : SimpleKeyboardIME("Russian") {
             lastShiftPressTS = 0
         }
 
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        updateAutoSuggestText(nounTypeSuggestion)
+
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -72,7 +72,7 @@ class RussianKeyboardIME : SimpleKeyboardIME("Russian") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -3,6 +3,8 @@ package be.scri.services
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuff.Mode
 import android.inputmethodservice.InputMethodService
 import android.text.InputType
 import android.text.InputType.TYPE_CLASS_DATETIME
@@ -20,6 +22,7 @@ import android.view.inputmethod.EditorInfo.IME_MASK_ACTION
 import android.view.inputmethod.ExtractedTextRequest
 import android.widget.Button
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.ContextCompat
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
@@ -428,13 +431,17 @@ abstract class SimpleKeyboardIME(
                 ?: Pair(R.color.transparent, "Suggestion")
 
         binding.translateBtn.text = text
-        binding.translateBtn.setBackgroundColor(getColor(colorRes))
+        val drawable = ContextCompat.getDrawable(this, R.drawable.rounded_drawable)
+        drawable?.setTintMode(PorterDuff.Mode.SRC_IN)
+        drawable?.setTint(ContextCompat.getColor(this, colorRes))
+        binding.translateBtn.background = drawable
     }
 
     fun disableAutoSuggest() {
         binding.translateBtn.text = "Suggestion"
         binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
     }
+
     private fun insertEmoji(emoji: String) {
         val inputConnection = currentInputConnection ?: return
         inputConnection.commitText(emoji, 1)
@@ -766,5 +773,4 @@ abstract class SimpleKeyboardIME(
         const val DEFAULT_SHIFT_PERM_TOGGLE_SPEED = 500
         const val TEXT_LENGTH = 20
     }
-
 }

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -67,7 +67,7 @@ abstract class SimpleKeyboardIME(
     private val shiftPermToggleSpeed: Int = DEFAULT_SHIFT_PERM_TOGGLE_SPEED
     private lateinit var dbHelper: DatabaseHelper
     lateinit var emojiKeywords: HashMap<String, MutableList<String>>
-    lateinit var nounKeywords:  HashMap<String, MutableList<String>>
+    lateinit var nounKeywords: HashMap<String, MutableList<String>>
     var isAutoSuggestEnabled: Boolean = false
     var lastWord: String? = null
     var autosuggestEmojis: MutableList<String>? = null
@@ -414,34 +414,22 @@ abstract class SimpleKeyboardIME(
     }
 
     fun updateAutoSuggestText(nounTypeSuggestion: MutableList<String>?) {
-        when (nounTypeSuggestion?.get(0)) {
-            "PL" -> {
-                binding.translateBtn.text = nounTypeSuggestion[0]
-                binding.translateBtn.setBackgroundColor(getColor(R.color.md_deep_orange))
-            }
-            "N" -> {
-                binding.translateBtn.text = nounTypeSuggestion[0]
-                binding.translateBtn.setBackgroundColor(getColor(R.color.md_light_green))
-            }
-            "C" -> {
-                binding.translateBtn.text = nounTypeSuggestion[0]
-                binding.translateBtn.setBackgroundColor(getColor(R.color.md_indigo))
-            }
-            "M" -> {
-                binding.translateBtn.text = nounTypeSuggestion[0]
-                binding.translateBtn.setBackgroundColor(getColor(R.color.background_color))
-            }
-            "F" -> {
-                binding.translateBtn.text = nounTypeSuggestion[0]
-                binding.translateBtn.setBackgroundColor(getColor(R.color.md_pink))
-            }
-            else ->  {
-                binding.translateBtn.text = "Suggestion"
-                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
-            }
-        }
-    }
+        val suggestionMap =
+            mapOf(
+                "PL" to Pair(R.color.md_deep_orange, "PL"),
+                "N" to Pair(R.color.md_light_green, "N"),
+                "C" to Pair(R.color.md_indigo, "C"),
+                "M" to Pair(R.color.background_color, "M"),
+                "F" to Pair(R.color.md_pink, "F"),
+            )
 
+        val (colorRes, text) =
+            suggestionMap[nounTypeSuggestion?.getOrNull(0)]
+                ?: Pair(R.color.transparent, "Suggestion")
+
+        binding.translateBtn.text = text
+        binding.translateBtn.setBackgroundColor(getColor(colorRes))
+    }
 
     private fun insertEmoji(emoji: String) {
         val inputConnection = currentInputConnection ?: return

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -413,6 +413,36 @@ abstract class SimpleKeyboardIME(
         }
     }
 
+    fun updateAutoSuggestText(nounTypeSuggestion: MutableList<String>?) {
+        when (nounTypeSuggestion?.get(0)) {
+            "PL" -> {
+                binding.translateBtn.text = nounTypeSuggestion[0]
+                binding.translateBtn.setBackgroundColor(getColor(R.color.md_deep_orange))
+            }
+            "N" -> {
+                binding.translateBtn.text = nounTypeSuggestion[0]
+                binding.translateBtn.setBackgroundColor(getColor(R.color.md_light_green))
+            }
+            "C" -> {
+                binding.translateBtn.text = nounTypeSuggestion[0]
+                binding.translateBtn.setBackgroundColor(getColor(R.color.md_indigo))
+            }
+            "M" -> {
+                binding.translateBtn.text = nounTypeSuggestion[0]
+                binding.translateBtn.setBackgroundColor(getColor(R.color.background_color))
+            }
+            "F" -> {
+                binding.translateBtn.text = nounTypeSuggestion[0]
+                binding.translateBtn.setBackgroundColor(getColor(R.color.md_pink))
+            }
+            else ->  {
+                binding.translateBtn.text = "Suggestion"
+                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+            }
+        }
+    }
+
+
     private fun insertEmoji(emoji: String) {
         val inputConnection = currentInputConnection ?: return
         inputConnection.commitText(emoji, 1)

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -416,11 +416,11 @@ abstract class SimpleKeyboardIME(
     fun updateAutoSuggestText(nounTypeSuggestion: MutableList<String>?) {
         val suggestionMap =
             mapOf(
-                "PL" to Pair(R.color.md_deep_orange, "PL"),
-                "N" to Pair(R.color.md_light_green, "N"),
-                "C" to Pair(R.color.md_indigo, "C"),
-                "M" to Pair(R.color.background_color, "M"),
-                "F" to Pair(R.color.md_pink, "F"),
+                "PL" to Pair(R.color.annotateOrange, "PL"),
+                "N" to Pair(R.color.annotateGreen, "N"),
+                "C" to Pair(R.color.annotatePurple, "C"),
+                "M" to Pair(R.color.annotateBlue, "M"),
+                "F" to Pair(R.color.annotateRed, "F"),
             )
 
         val (colorRes, text) =
@@ -431,6 +431,10 @@ abstract class SimpleKeyboardIME(
         binding.translateBtn.setBackgroundColor(getColor(colorRes))
     }
 
+    fun disableAutoSuggest() {
+        binding.translateBtn.text = "Suggestion"
+        binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
+    }
     private fun insertEmoji(emoji: String) {
         val inputConnection = currentInputConnection ?: return
         inputConnection.commitText(emoji, 1)
@@ -762,4 +766,5 @@ abstract class SimpleKeyboardIME(
         const val DEFAULT_SHIFT_PERM_TOGGLE_SPEED = 500
         const val TEXT_LENGTH = 20
     }
+
 }

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -67,9 +67,11 @@ abstract class SimpleKeyboardIME(
     private val shiftPermToggleSpeed: Int = DEFAULT_SHIFT_PERM_TOGGLE_SPEED
     private lateinit var dbHelper: DatabaseHelper
     lateinit var emojiKeywords: HashMap<String, MutableList<String>>
+    lateinit var nounKeywords:  HashMap<String, MutableList<String>>
     var isAutoSuggestEnabled: Boolean = false
     var lastWord: String? = null
     var autosuggestEmojis: MutableList<String>? = null
+    var nounTypeSuggestion: MutableList<String>? = null
     private var currentEnterKeyType: Int? = null
     // abstract var keyboardViewKeyboardBinding : KeyboardViewKeyboardBinding
 
@@ -373,6 +375,23 @@ abstract class SimpleKeyboardIME(
         return null
     }
 
+    fun findNounTypeForLastWord(
+        nounKeywords: HashMap<String, MutableList<String>>,
+        lastWord: String?,
+    ): MutableList<String>? {
+        lastWord?.let { word ->
+            val lowerCaseWord = word.lowercase()
+            val nouns = nounKeywords[lowerCaseWord]
+            if (nouns != null) {
+                Log.d("Debug", "Noun Types  for '$word': $nouns")
+                return nouns
+            } else {
+                Log.d("Debug", "No nouns found for '$word'")
+            }
+        }
+        return null
+    }
+
     fun updateButtonText(
         isAutoSuggestEnabled: Boolean,
         autosuggestEmojis: MutableList<String>?,
@@ -434,6 +453,7 @@ abstract class SimpleKeyboardIME(
         dbHelper = DatabaseHelper(this)
         dbHelper.loadDatabase(languageAlias)
         emojiKeywords = dbHelper.getEmojiKeywords(languageAlias)
+        nounKeywords = dbHelper.getNounKeywords(languageAlias)
 
         keyboard = MyKeyboard(this, keyboardXml, enterKeyType)
         keyboardView?.setKeyboard(keyboard!!)

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -57,22 +57,37 @@ class SpanishKeyboardIME : SimpleKeyboardIME(language = "Spanish") {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -80,11 +95,10 @@ class SpanishKeyboardIME : SimpleKeyboardIME(language = "Spanish") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
-        Log.d("Debug", "$autosuggestEmojis")
-        updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
         nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
-        Log.d("Debug", "$nounTypeSuggestion")
-        updateAutoSuggestText(nounTypeSuggestion)
+        Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG", "$nounTypeSuggestion")
+        updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -53,6 +53,9 @@ class SpanishKeyboardIME : SimpleKeyboardIME(language = "Spanish") {
             lastShiftPressTS = 0
         }
 
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        updateAutoSuggestText(nounTypeSuggestion)
+
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -77,7 +77,7 @@ class SpanishKeyboardIME : SimpleKeyboardIME(language = "Spanish") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -53,9 +53,6 @@ class SpanishKeyboardIME : SimpleKeyboardIME(language = "Spanish") {
             lastShiftPressTS = 0
         }
 
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
-        updateAutoSuggestText(nounTypeSuggestion)
-
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
@@ -85,7 +82,9 @@ class SpanishKeyboardIME : SimpleKeyboardIME(language = "Spanish") {
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
+        Log.d("Debug", "$nounTypeSuggestion")
+        updateAutoSuggestText(nounTypeSuggestion)
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -77,7 +77,7 @@ class SwedishKeyboardIME : SimpleKeyboardIME("Swedish") {
             }
 
             MyKeyboard.KEYCODE_SPACE -> {
-                handleElseCondition(code , keyboardMode , binding = null)
+                handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -52,29 +52,42 @@ class SwedishKeyboardIME : SimpleKeyboardIME("Swedish") {
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
-        Log.i("MY-TAG", "$nounTypeSuggestion")
-        updateAutoSuggestText(nounTypeSuggestion)
+
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
+                disableAutoSuggest()
             }
+
             MyKeyboard.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
+                disableAutoSuggest()
             }
+
+            MyKeyboard.KEYCODE_SPACE -> {
+                handleElseCondition(code , keyboardMode , binding = null)
+                updateAutoSuggestText(nounTypeSuggestion)
+            }
+
             else -> {
                 if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
                     handleElseCondition(code, keyboardMode, binding = null)
+                    disableAutoSuggest()
                 } else {
                     handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+                    disableAutoSuggest()
                 }
             }
         }
@@ -82,9 +95,10 @@ class SwedishKeyboardIME : SimpleKeyboardIME("Swedish") {
         lastWord = getLastWordBeforeCursor()
         Log.d("Debug", "$lastWord")
         autosuggestEmojis = findEmojisForLastWord(emojiKeywords, lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
         Log.d("Debug", "$autosuggestEmojis")
+        Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -52,7 +52,8 @@ class SwedishKeyboardIME : SimpleKeyboardIME("Swedish") {
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
-
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        updateAutoSuggestText(nounTypeSuggestion)
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {
                 handleKeycodeDelete()

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -52,7 +52,8 @@ class SwedishKeyboardIME : SimpleKeyboardIME("Swedish") {
         if (code != MyKeyboard.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
-        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords,lastWord)
+        nounTypeSuggestion = findNounTypeForLastWord(nounKeywords, lastWord)
+        Log.i("MY-TAG", "$nounTypeSuggestion")
         updateAutoSuggestText(nounTypeSuggestion)
         when (code) {
             MyKeyboard.KEYCODE_DELETE -> {

--- a/app/src/main/res/drawable/rounded_drawable.xml
+++ b/app/src/main/res/drawable/rounded_drawable.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android" android:color="?attr/colorPrimaryDark">
+    <item android:id="@+id/button_background_holder">
+        <layer-list>
+            <item android:id="@+id/button_background_shape">
+                <shape android:shape="rectangle">/>
+                    <corners android:radius="12dp"/>
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+</ripple>

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -29,4 +29,11 @@
     <color name="you_primary_color">@color/dark_scribe_color</color>
     <color name="you_primary_dark_color">@android:color/system_accent1_600</color>
     <color name="you_dialog_background_color">@android:color/system_accent2_800</color>
+
+    <color name="annotateRed">#FB5F6C</color>
+    <color name="annotateBlue">#339EEB</color>
+    <color name="annotatePurple">#AC6DEC</color>
+    <color name="annotateGreen">#85C26F</color>
+    <color name="annotateOrange">#FD9F5D</color>
+
 </resources>

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -30,6 +30,12 @@
     <color name="you_primary_color">@color/light_scribe_color</color>
     <color name="you_primary_dark_color">@android:color/system_accent1_600</color>
     <color name="you_dialog_background_color">@android:color/system_accent2_50</color>
+
+    <color name="annotateRed">#9F1722</color>
+    <color name="annotateBlue">#335C99</color>
+    <color name="annotatePurple">#700589</color>
+    <color name="annotateGreen">#3D7946</color>
+    <color name="annotateOrange">#F85A39</color>
 </resources>
 
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR implements Gender | Plural auto suggestion for each word we type. This could be seen while typing a word and the first auto suggest button changes to the gender | PL for plural. 

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

-   #135
