### PR TITLE
Change Scribe Key Icon and Cancel Key Icon Colors to White in Dark Mode & Make Emoji Key Background Transparent

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,7 +196,6 @@ dependencies {
     implementation("com.google.android.play:core:1.10.0")
     implementation("androidx.navigation:navigation-compose:2.6.0")
 
-
     // Jetpack Compose BOM
     val composeBom = platform("androidx.compose:compose-bom:2024.10.00")
     implementation(composeBom)

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -114,6 +114,14 @@ abstract class SimpleKeyboardIME(
         DISPLAY_INFORMATION,
     }
 
+    override fun onCreate() {
+        super.onCreate()
+        keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
+        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        onCreateInputView()
+        setupCommandBarTheme(binding)
+    }
+
     private fun updateCommandBarHintandPrompt() {
         val commandBarButton = keyboardBinding.commandBar
         val hintMessage = HintUtils.getCommandBarHint(currentState, language)
@@ -156,7 +164,17 @@ abstract class SimpleKeyboardIME(
             ScribeState.SELECT_COMMAND -> keyboardView?.setEnterKeyColor(null, isDarkMode = isDarkMode)
             else -> keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
         }
+
+        if (isDarkMode == true) {
+            val color = ContextCompat.getColorStateList(this, R.color.light_key_color)
+            binding.scribeKey.foregroundTintList = color
+        } else {
+            val colorLight = ContextCompat.getColorStateList(this, R.color.light_key_text_color)
+            binding.scribeKey.foregroundTintList = colorLight
+        }
     }
+
+
 
     override fun onFinishInputView(finishingInput: Boolean) {
         super.onFinishInputView(finishingInput)
@@ -179,13 +197,8 @@ abstract class SimpleKeyboardIME(
         }
     }
 
-    override fun onCreate() {
-        super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
-        onCreateInputView()
-        setupCommandBarTheme(binding)
-        keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
-    }
+
+
 
     protected fun switchToCommandToolBar() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)
@@ -219,6 +232,7 @@ abstract class SimpleKeyboardIME(
             else -> switchToToolBar()
         }
         updateEnterKeyColor(isUserDarkMode)
+//        updateCloseButtonColor(isUserDarkMode)
     }
 
     private fun switchToToolBar() {
@@ -265,6 +279,7 @@ abstract class SimpleKeyboardIME(
                 binding.pluralBtn.setTextColor(Color.WHITE)
                 binding.separator2.setBackgroundColor(getColor(R.color.special_key_dark))
                 binding.separator3.setBackgroundColor(getColor(R.color.special_key_dark))
+                binding.separator4.setBackgroundColor(getColor(R.color.special_key_dark))
             }
 
             else -> {
@@ -276,6 +291,7 @@ abstract class SimpleKeyboardIME(
                 binding.pluralBtn.setTextColor(Color.BLACK)
                 binding.separator2.setBackgroundColor(getColor(R.color.special_key_light))
                 binding.separator3.setBackgroundColor(getColor(R.color.special_key_light))
+                binding.separator4.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
 

--- a/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SimpleKeyboardIME.kt
@@ -174,8 +174,6 @@ abstract class SimpleKeyboardIME(
         }
     }
 
-
-
     override fun onFinishInputView(finishingInput: Boolean) {
         super.onFinishInputView(finishingInput)
         currentState = ScribeState.IDLE
@@ -196,9 +194,6 @@ abstract class SimpleKeyboardIME(
             inputConnection.commitText("  ", 1)
         }
     }
-
-
-
 
     protected fun switchToCommandToolBar() {
         val binding = KeyboardViewCommandOptionsBinding.inflate(layoutInflater)

--- a/app/src/main/res/drawable/emoji_phone_background_rounded.xml
+++ b/app/src/main/res/drawable/emoji_phone_background_rounded.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@color/light_key_press_color">
+    android:color="@android:color/transparent">
     <item android:id="@+id/phone_emoji_color">
         <layer-list>
             <item android:id="@+id/button_background_shape">
                 <shape android:shape="rectangle">
-                    <solid android:color="#80ffbb33" />
+                    <solid android:color="#00ffbb33" /> <!-- Fully transparent -->
                     <corners android:radius="@dimen/command_button_corner_radius" />
                 </shape>
             </item>

--- a/app/src/main/res/layout/keyboard_view_command_options.xml
+++ b/app/src/main/res/layout/keyboard_view_command_options.xml
@@ -110,6 +110,7 @@
             app:layout_constraintStart_toEndOf="@+id/separator_3"
             app:layout_constraintTop_toTopOf="@+id/command_field" />
 
+
         <Button
             android:id="@+id/emoji_btn_phone_1"
             android:layout_width="0dp"
@@ -123,16 +124,35 @@
             app:layout_constraintHorizontal_weight="1"
             app:layout_constraintStart_toStartOf="@+id/plural_btn" />
 
+
+        <View
+            android:id="@+id/separator_4"
+            android:layout_width="1dp"
+            android:layout_height="0dp"
+            android:background="@color/special_key_light"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="@+id/plural_btn"
+            app:layout_constraintEnd_toStartOf="@+id/emoji_btn_phone_2"
+            app:layout_constraintHeight_percent="0.8"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/emoji_btn_phone_1"
+
+            app:layout_constraintTop_toTopOf="@+id/plural_btn"
+            app:layout_constraintVertical_bias="0.5" />
+
+
         <TextView
             android:id="@+id/emoji_space_phone"
             android:layout_width="wrap_content"
             android:layout_height="@dimen/toolbar_icon_height"
-            android:text=" "
+            android:text=""
             android:visibility="invisible"
             app:layout_constraintBottom_toBottomOf="@+id/plural_btn"
             app:layout_constraintStart_toEndOf="@+id/emoji_btn_phone_1"
             app:layout_constraintEnd_toStartOf="@+id/emoji_btn_phone_2"
-            app:layout_constraintTop_toTopOf="@+id/plural_btn" />
+            app:layout_constraintTop_toTopOf="@+id/plural_btn"
+
+            />
 
         <Button
             android:id="@+id/emoji_btn_phone_2"


### PR DESCRIPTION
## Contributor Checklist

- [x] This pull request is on a [[separate branch](https://docs.github.com/en/get-started/quickstart/github-flow)](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch.  
- [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [[testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing).  

---

## Description  

This pull request addresses two issues:  

1. **Dark Mode Enhancements** (#289)  
   - Changed the Scribe key icon and Cancel key icon colors to white for better visibility in dark mode.  

2. **Emoji Key Background Update** (#288)  
   - Made the emoji key background transparent to align with UI design standards.  

### Changes Made:  
- Updated the dark mode color theme to apply white to the specified key icons.  
- Adjusted the emoji key background property to make it transparent.  
- Verified changes across various modes and themes.  
- Added Seperator to emoji key 

---

## Related Issues  

- Resolves #289  
- Resolves #288  

---

## Screenshots  

<img width="344" alt="image" src="https://github.com/user-attachments/assets/a2ac25ab-8a60-4a18-9dca-40beb0365de9" />

<img width="348" alt="image" src="https://github.com/user-attachments/assets/f95409aa-c961-471f-be88-20974031a8a8" />

---

### Testing  

- Verified functionality by enabling dark mode and testing the key icons.  
- Confirmed transparency for the emoji key background by checking across light and dark modes.  

Thank you for reviewing this PR! 🚀  
