### PR TITLE
#269 First iteration of Scribe-Data data contracts

### DIFF
--- a/app/src/main/assets/data-contracts/de.json
+++ b/app/src/main/assets/data-contracts/de.json
@@ -1,0 +1,39 @@
+{
+    "numbers": { "nominativeSingular": "nominativePlural" },
+    "genders": {
+        "canonical": ["gender"],
+        "feminines": [],
+        "masculines": [],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "Präsens",
+            "1": { "ich": "indicativePresentFirstPersonSingular" },
+            "2": { "du": "indicativePresentSecondPersonSingular" },
+            "3": { "er/sie/es": "indicativePresentThirdPersonSingular" },
+            "4": { "wir": "indicativePresentFirstPersonPlural" },
+            "5": { "ihr": "indicativePresentSecondPersonPlural" },
+            "6": { "sie/Sie": "indicativePresentThirdPersonPlural" }
+        },
+        "2": {
+            "title": "Preterite",
+            "1": { "ich": "indicativePreteriteFirstPersonSingular" },
+            "2": { "du": "indicativePreteriteFirstPersonPlural" },
+            "3": { "er/sie/es": "indicativePreteriteSecondPersonSingular" },
+            "4": { "wir": "indicativePreteriteSecondPersonPlural" },
+            "5": { "ihr": "indicativePreteriteThirdPersonSingular" },
+            "6": { "sie/Sie": "indicativePreteriteThirdPersonPlural" }
+        },
+        "3": {
+            "title": "Perfekt",
+            "1": { "ich": "" },
+            "2": { "du": "" },
+            "3": { "er/sie/es": "" },
+            "4": { "wir": "" },
+            "5": { "ihr": "" },
+            "6": { "sie/Sie": "" }
+        }
+    }
+}

--- a/app/src/main/assets/data-contracts/en.json
+++ b/app/src/main/assets/data-contracts/en.json
@@ -1,0 +1,21 @@
+{
+    "numbers": { "singular": "plural" },
+    "genders": {
+        "canonical": [],
+        "feminines": [],
+        "masculines": [],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "",
+            "1": "",
+            "2": "",
+            "3": "",
+            "4": "",
+            "5": "",
+            "6": ""
+        }
+    }
+}

--- a/app/src/main/assets/data-contracts/es.json
+++ b/app/src/main/assets/data-contracts/es.json
@@ -1,0 +1,42 @@
+{
+    "numbers": {
+        "feminineSingular": "femininePlural",
+        "masculineSingular": "masculinePlural"
+    },
+    "genders": {
+        "canonical": [],
+        "feminines": ["feminineSingular"],
+        "masculines": ["masculineSingular"],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "Presente",
+            "1": { "yo": "indicativePresentFirstPersonSingular" },
+            "2": { "tú": "indicativePresentFirstPersonPlural" },
+            "3": { "él/ella/Ud.": "indicativePresentSecondPersonSingular" },
+            "4": { "nosotros": "indicativePresentSecondPersonPlural" },
+            "5": { "vosotros": "indicativePresentThirdPersonSingular" },
+            "6": { "ellos/ellas/Uds.": "indicativePresentThirdPersonPlural" }
+        },
+        "2": {
+            "title": "Pretérito",
+            "1": { "yo": "preteriteFirstPersonSingular" },
+            "2": { "tú": "preteriteFirstPersonPlural" },
+            "3": { "él/ella/Ud.": "preteriteSecondPersonSingular" },
+            "4": { "nosotros": "preteriteSecondPersonPlural" },
+            "5": { "vosotros": "preteriteThirdPersonSingular" },
+            "6": { "ellos/ellas/Uds.": "preteriteThirdPersonPlural" }
+        },
+        "3": {
+            "title": "Imperfecto",
+            "1": { "yo": "pastImperfectFirstPersonSingular" },
+            "2": { "tú": "pastImperfectFirstPersonPlural" },
+            "3": { "él/ella/Ud.": "pastImperfectSecondPersonSingular" },
+            "4": { "nosotros": "pastImperfectSecondPersonPlural" },
+            "5": { "vosotros": "pastImperfectThirdPersonSingular" },
+            "6": { "ellos/ellas/Uds.": "pastImperfectThirdPersonPlural" }
+        }
+    }
+}

--- a/app/src/main/assets/data-contracts/fr.json
+++ b/app/src/main/assets/data-contracts/fr.json
@@ -1,0 +1,48 @@
+{
+    "numbers": { "singular": "plural" },
+    "genders": {
+        "canonical": ["gender"],
+        "feminines": [],
+        "masculines": [],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "Présent",
+            "1": { "je": "indicativePresentFirstPersonSingular" },
+            "2": { "tu": "indicativePresentFirstPersonPlural" },
+            "3": { "il/elle": "indicativePresentSecondPersonSingular" },
+            "4": { "nous": "indicativePresentSecondPersonPlural" },
+            "5": { "vous": "indicativePresentThirdPersonSingular" },
+            "6": { "ils/elles": "indicativePresentThirdPersonPlural" }
+        },
+        "2": {
+            "title": "Passé simple",
+            "1": { "je": "indicativePreteriteFirstPersonSingular" },
+            "2": { "tu": "indicativePreteriteFirstPersonPlural" },
+            "3": { "il/elle": "indicativePreteriteSecondPersonSingular" },
+            "4": { "nous": "indicativePreteriteSecondPersonPlural" },
+            "5": { "vous": "indicativePreteriteThirdPersonSingular" },
+            "6": { "ils/elles": "indicativePreteriteThirdPersonPlural" }
+        },
+        "3": {
+            "title": "Imparfait",
+            "1": { "je": "indicativeImperfectFirstPersonSingular" },
+            "2": { "tu": "indicativeImperfectFirstPersonPlural" },
+            "3": { "il/elle": "indicativeImperfectSecondPersonSingular" },
+            "4": { "nous": "indicativeImperfectSecondPersonPlural" },
+            "5": { "vous": "indicativeImperfectThirdPersonSingular" },
+            "6": { "ils/elles": "indicativeImperfectThirdPersonPlural" }
+        },
+        "4": {
+            "title": "Futur",
+            "1": { "je": "indicativeSimpleFutureFirstPersonSingular" },
+            "2": { "tu": "indicativeSimpleFutureFirstPersonPlural" },
+            "3": { "il/elle": "indicativeSimpleFutureSecondPersonSingular" },
+            "4": { "nous": "indicativeSimpleFutureSecondPersonPlural" },
+            "5": { "vous": "indicativeSimpleFutureThirdPersonSingular" },
+            "6": { "ils/elles": "indicativeSimpleFutureThirdPersonPlural" }
+        }
+    }
+}

--- a/app/src/main/assets/data-contracts/it.json
+++ b/app/src/main/assets/data-contracts/it.json
@@ -1,0 +1,39 @@
+{
+    "numbers": { "singular": "plural" },
+    "genders": {
+        "canonical": ["gender"],
+        "feminines": [],
+        "masculines": [],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "Presente",
+            "1": { "io": "presentIndicativeFirstPersonSingular" },
+            "2": { "tu": "presentIndicativeFirstPersonPlural" },
+            "3": { "lei/lui": "presentIndicativeSecondPersonSingular" },
+            "4": { "noi": "presentIndicativeSecondPersonPlural" },
+            "5": { "voi": "presentIndicativeThirdPersonSingular" },
+            "6": { "loro": "presentIndicativeThirdPersonPlural" }
+        },
+        "2": {
+            "title": "Preterito",
+            "1": { "io": "preteriteFirstPersonSingular" },
+            "2": { "tu": "preteriteFirstPersonPlural" },
+            "3": { "lei/lui": "preteriteSecondPersonSingular" },
+            "4": { "noi": "preteriteSecondPersonPlural" },
+            "5": { "voi": "preteriteThirdPersonSingular" },
+            "6": { "loro": "preteriteThirdPersonPlural" }
+        },
+        "3": {
+            "title": "Imperfetto",
+            "1": { "io": "pastImperfectFirstPersonSingular" },
+            "2": { "tu": "pastImperfectFirstPersonPlural" },
+            "3": { "lei/lui": "pastImperfectSecondPersonSingular" },
+            "4": { "noi": "pastImperfectSecondPersonPlural" },
+            "5": { "voi": "pastImperfectThirdPersonSingular" },
+            "6": { "loro": "pastImperfectThirdPersonPlural" }
+        }
+    }
+}

--- a/app/src/main/assets/data-contracts/pt.json
+++ b/app/src/main/assets/data-contracts/pt.json
@@ -1,0 +1,48 @@
+{
+    "numbers": { "singular": "plural" },
+    "genders": {
+        "canonical": ["gender"],
+        "feminines": [],
+        "masculines": [],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "Presente",
+            "1": { "eu": "indicativePresentFirstPersonSingular" },
+            "2": { "tu": "indicativePresentFirstPersonPlural" },
+            "3": { "ele/ela/você": "indicativePresentSecondPersonSingular" },
+            "4": { "nós": "indicativePresentSecondPersonPlural" },
+            "5": { "vós": "indicativePresentThirdPersonSingular" },
+            "6": { "eles/elas/vocês": "indicativePresentThirdPersonPlural" }
+        },
+        "2": {
+            "title": "Pretérito Perfeito",
+            "1": { "eu": "indicativePastPerfectFirstPersonSingular" },
+            "2": { "tu": "indicativePastPerfectFirstPersonPlural" },
+            "3": { "ele/ela/você": "indicativePastPerfectSecondPersonSingular" },
+            "4": { "nós": "indicativePastPerfectSecondPersonPlural" },
+            "5": { "vós": "indicativePastPerfectThirdPersonSingular" },
+            "6": { "eles/elas/vocês": "indicativePastPerfectThirdPersonPlural" }
+        },
+        "3": {
+            "title": "Pretérito Imperfeito",
+            "1": { "eu": "indicativePastImperfectFirstPersonSingular" },
+            "2": { "tu": "indicativePastImperfectFirstPersonPlural" },
+            "3": { "ele/ela/você": "indicativePastImperfectSecondPersonSingular" },
+            "4": { "nós": "indicativePastImperfectSecondPersonPlural" },
+            "5": { "vós": "indicativePastImperfectThirdPersonSingular" },
+            "6": { "eles/elas/vocês": "indicativePastImperfectThirdPersonPlural" }
+        },
+        "4": {
+            "title": "Futuro Simples",
+            "1": { "eu": "indicativePluperfectFirstPersonSingular" },
+            "2": { "tu": "indicativePluperfectFirstPersonPlural" },
+            "3": { "ele/ela/você": "indicativePluperfectSecondPersonSingular" },
+            "4": { "nós": "indicativePluperfectSecondPersonPlural" },
+            "5": { "vós": "indicativePluperfectThirdPersonSingular" },
+            "6": { "eles/elas/vocês": "indicativePluperfectThirdPersonPlural" }
+        }
+    }
+}

--- a/app/src/main/assets/data-contracts/ru.json
+++ b/app/src/main/assets/data-contracts/ru.json
@@ -1,0 +1,28 @@
+{
+    "numbers": { "nominativeSingular": "nominativePlural" },
+    "genders": {
+        "canonical": ["gender"],
+        "feminines": [],
+        "masculines": [],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "Настоящее",
+            "1": { "я": "indicativePresentFirstPersonSingular" },
+            "2": { "ты": "indicativePresentFirstPersonPlural" },
+            "3": { "он/она/оно": "indicativePresentSecondPersonSingular" },
+            "4": { "мы": "indicativePresentSecondPersonPlural" },
+            "5": { "вы": "indicativePresentThirdPersonSingular" },
+            "6": { "они": "indicativePresentThirdPersonPlural" }
+        },
+        "2": {
+            "title": "Прошедшее",
+            "1": { "я/ты/она": "feminineIndicativePast" },
+            "2": { "я/ты/он": "masculineIndicativePast" },
+            "3": { "оно": "neuterIndicativePast" },
+            "4": { "мы/вы/они": "indicativePastPlural" }
+        }
+    }
+}

--- a/app/src/main/assets/data-contracts/sv.json
+++ b/app/src/main/assets/data-contracts/sv.json
@@ -1,0 +1,29 @@
+{
+    "numbers": {
+        "nominativeIndefiniteSingular": "nominativeIndefinitePlural",
+        "nominativeDefiniteSingular": "nominativeDefinitePlural"
+    },
+    "genders": {
+        "canonical": ["gender"],
+        "feminines": [],
+        "masculines": [],
+        "commons": [],
+        "neuters": []
+    },
+    "conjugations": {
+        "1": {
+            "title": "Aktiv",
+            "1": { "": "activeInfinitive" },
+            "2": { "": "activePresent" },
+            "3": { "": "activePreterite" },
+            "4": { "": "activeSupine" }
+        },
+        "2": {
+            "title": "Passiv",
+            "1": { "": "passiveInfinitive" },
+            "2": { "": "passivePresent" },
+            "3": { "": "passivePreterite" },
+            "4": { "": "passiveSupine" }
+        }
+    }
+}


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

As discussed in #269 and in recent syncs, we need to set up data contracts that will determine how the end applications present the data coming in from Scribe-Data. This PR sends along my first ideas on them based on the call we had yesterday.

A short synopsis of this:

- For Scribe-iOS all data values are hard coded into the application
- The data might change on Wikidata's end, meaning that the labels and other information would change in Scribe-Data
    - Ex: More data being added, which as of now would require us to create a new app release to change the hard coded fields meaning that people would not have access to the new data till then
    - Ex: As of now - unlike other languages - Spanish has the feminine and masculine of nouns stored on the same lexeme
        - If this changes, then we'd then have to rework the entire way that data is accessed and the Spanish keyboard would break on the next data update requiring an update of the app

Discussed solution:
- We want to make sure that data updates are completely separate from app updates
- We create "data contracts" that are delivered with new data packs
    - Ex: User downloads Scribe-iOS/Android and wants the German keyboard
        - They get the German data and the German contract
        - Updates of the data would deliver the corresponding contract
- Note that we'd need to set up tests for Scribe-Data whereby the data that should go into the contract is changed
    - Ex again for Spanish nouns
        - Say they're split and we don't have feminine and masculine on the same lexemes
        - We check the data outputs and see if the data that's required to fulfill the current contract is coming in
        - If not, we open an issue that says what parts of the contract aren't being fulfill and we then check to see how the data has changed

Feedback is very welcome on the above! 🙏

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #269