### PR TITLE
Rename Keyboard IME

### DIFF
--- a/app/src/main/java/be/scri/helpers/HintUtils.kt
+++ b/app/src/main/java/be/scri/helpers/HintUtils.kt
@@ -28,7 +28,7 @@ import be.scri.helpers.portuguese.PTInterfaceVariables
 import be.scri.helpers.russian.RUInterfaceVariables
 import be.scri.helpers.spanish.ESInterfaceVariables
 import be.scri.helpers.swedish.SVInterfaceVariables
-import be.scri.services.SimpleKeyboardIME
+import be.scri.services.GeneralKeyboardIME
 
 object HintUtils {
     fun resetHints(context: Context) {
@@ -42,18 +42,18 @@ object HintUtils {
     }
 
     fun getCommandBarHint(
-        currentState: SimpleKeyboardIME.ScribeState,
+        currentState: GeneralKeyboardIME.ScribeState,
         language: String,
     ): String {
         val hintMessageForState = getHintForState(currentState)
         return hintMessageForState[language] ?: "" // return the placeholder or empty string if not found
     }
 
-    private fun getHintForState(currentState: SimpleKeyboardIME.ScribeState): Map<String, String> =
+    private fun getHintForState(currentState: GeneralKeyboardIME.ScribeState): Map<String, String> =
         when (currentState) {
-            SimpleKeyboardIME.ScribeState.TRANSLATE -> getTranslateHints()
-            SimpleKeyboardIME.ScribeState.CONJUGATE -> getConjugateHints()
-            SimpleKeyboardIME.ScribeState.PLURAL -> getPluralHints()
+            GeneralKeyboardIME.ScribeState.TRANSLATE -> getTranslateHints()
+            GeneralKeyboardIME.ScribeState.CONJUGATE -> getConjugateHints()
+            GeneralKeyboardIME.ScribeState.PLURAL -> getPluralHints()
             else -> emptyMap()
         }
 
@@ -94,13 +94,13 @@ object HintUtils {
         )
 
     fun getPromptText(
-        currentState: SimpleKeyboardIME.ScribeState,
+        currentState: GeneralKeyboardIME.ScribeState,
         language: String,
     ): String =
         when (currentState) {
-            SimpleKeyboardIME.ScribeState.TRANSLATE -> getTranslationPrompt(language)
-            SimpleKeyboardIME.ScribeState.CONJUGATE -> getConjugationPrompt(language)
-            SimpleKeyboardIME.ScribeState.PLURAL -> getPluralPrompt(language)
+            GeneralKeyboardIME.ScribeState.TRANSLATE -> getTranslationPrompt(language)
+            GeneralKeyboardIME.ScribeState.CONJUGATE -> getConjugationPrompt(language)
+            GeneralKeyboardIME.ScribeState.PLURAL -> getPluralPrompt(language)
             else -> ""
         }
 

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -41,7 +41,7 @@ import java.io.IOException
  * @attr ref android.R.styleable#Keyboard_horizontalGap
  */
 @Suppress("LongMethod", "NestedBlockDepth", "CyclomaticComplexMethod")
-class MyKeyboard {
+class KeyboardBase {
     /** Horizontal gap default for all rows  */
     private var mDefaultHorizontalGap = 0
 
@@ -104,7 +104,7 @@ class MyKeyboard {
      * Container for keys in the keyboard.
      * All keys in a row are at the same Y-coordinate.
      * Some of the key size defaults can be overridden per row from
-     * what the [MyKeyboard] defines.
+     * what the [KeyboardBase] defines.
      * @attr ref android.R.styleable#Keyboard_keyWidth
      * @attr ref android.R.styleable#Keyboard_horizontalGap
      */
@@ -120,19 +120,19 @@ class MyKeyboard {
 
         var mKeys = ArrayList<Key>()
 
-        var parent: MyKeyboard
+        var parent: KeyboardBase
 
-        constructor(parent: MyKeyboard) {
+        constructor(parent: KeyboardBase) {
             this.parent = parent
         }
 
-        constructor(res: Resources, parent: MyKeyboard, parser: XmlResourceParser?) {
+        constructor(res: Resources, parent: KeyboardBase, parser: XmlResourceParser?) {
             this.parent = parent
-            val a = res.obtainAttributes(Xml.asAttributeSet(parser), R.styleable.MyKeyboard)
+            val a = res.obtainAttributes(Xml.asAttributeSet(parser), R.styleable.KeyboardBase)
             defaultWidth =
                 getDimensionOrFraction(
                     a,
-                    R.styleable.MyKeyboard_keyWidth,
+                    R.styleable.KeyboardBase_keyWidth,
                     parent.mDisplayWidth,
                     parent.mDefaultWidth,
                 )
@@ -145,7 +145,7 @@ class MyKeyboard {
             defaultHorizontalGap =
                 getDimensionOrFraction(
                     a,
-                    R.styleable.MyKeyboard_horizontalGap,
+                    R.styleable.KeyboardBase_horizontalGap,
                     parent.mDisplayWidth,
                     parent.mDefaultHorizontalGap,
                 )
@@ -209,7 +209,7 @@ class MyKeyboard {
         /**
          * Flags that specify the anchoring to edges of the keyboard for detecting touch events,
          * that are just out of the boundary of the key.
-         * This is a bit mask of [MyKeyboard.EDGE_LEFT], [MyKeyboard.EDGE_RIGHT].
+         * This is a bit mask of [KeyboardBase.EDGE_LEFT], [KeyboardBase.EDGE_RIGHT].
          */
         private var edgeFlags = 0
 
@@ -224,7 +224,7 @@ class MyKeyboard {
 
         /** Create a key with the given top-left coordinate and extract its attributes from the XML parser.
          * @param res resources associated with the caller's context
-         * @param parent the row that this key belongs to. The row must already be attached to a [MyKeyboard].
+         * @param parent the row that this key belongs to. The row must already be attached to a [KeyboardBase].
          * @param x the x coordinate of the top-left
          * @param y the y coordinate of the top-left
          * @param parser the XML parser containing the attributes for this key
@@ -235,13 +235,13 @@ class MyKeyboard {
             var a =
                 res.obtainAttributes(
                     Xml.asAttributeSet(parser),
-                    R.styleable.MyKeyboard,
+                    R.styleable.KeyboardBase,
                 )
 
             width =
                 getDimensionOrFraction(
                     a,
-                    R.styleable.MyKeyboard_keyWidth,
+                    R.styleable.KeyboardBase_keyWidth,
                     keyboard.mDisplayWidth,
                     parent.defaultWidth,
                 )
@@ -251,25 +251,25 @@ class MyKeyboard {
             gap =
                 getDimensionOrFraction(
                     a,
-                    R.styleable.MyKeyboard_horizontalGap,
+                    R.styleable.KeyboardBase_horizontalGap,
                     keyboard.mDisplayWidth,
                     parent.defaultHorizontalGap,
                 )
             this.x += gap
 
             a.recycle()
-            a = res.obtainAttributes(Xml.asAttributeSet(parser), R.styleable.MyKeyboard_Key)
-            code = a.getInt(R.styleable.MyKeyboard_Key_code, 0)
+            a = res.obtainAttributes(Xml.asAttributeSet(parser), R.styleable.KeyboardBase_Key)
+            code = a.getInt(R.styleable.KeyboardBase_Key_code, 0)
 
-            popupCharacters = a.getText(R.styleable.MyKeyboard_Key_popupCharacters)
-            popupResId = a.getResourceId(R.styleable.MyKeyboard_Key_popupKeyboard, 0)
-            repeatable = a.getBoolean(R.styleable.MyKeyboard_Key_isRepeatable, false)
-            edgeFlags = a.getInt(R.styleable.MyKeyboard_Key_keyEdgeFlags, 0)
-            icon = a.getDrawable(R.styleable.MyKeyboard_Key_keyIcon)
+            popupCharacters = a.getText(R.styleable.KeyboardBase_Key_popupCharacters)
+            popupResId = a.getResourceId(R.styleable.KeyboardBase_Key_popupKeyboard, 0)
+            repeatable = a.getBoolean(R.styleable.KeyboardBase_Key_isRepeatable, false)
+            edgeFlags = a.getInt(R.styleable.KeyboardBase_Key_keyEdgeFlags, 0)
+            icon = a.getDrawable(R.styleable.KeyboardBase_Key_keyIcon)
             icon?.setBounds(0, 0, icon!!.intrinsicWidth, icon!!.intrinsicHeight)
 
-            label = a.getText(R.styleable.MyKeyboard_Key_keyLabel) ?: ""
-            topSmallNumber = a.getString(R.styleable.MyKeyboard_Key_topSmallNumber) ?: ""
+            label = a.getText(R.styleable.KeyboardBase_Key_keyLabel) ?: ""
+            topSmallNumber = a.getString(R.styleable.KeyboardBase_Key_topSmallNumber) ?: ""
 
             if (label.isNotEmpty() && code != KEYCODE_MODE_CHANGE && code != KEYCODE_SHIFT) {
                 code = label[0].code
@@ -465,9 +465,9 @@ class MyKeyboard {
                 }
             }
         } catch (e: XmlPullParserException) {
-            Log.e("MyKeyboard", "XML Parsing error: ${e.message}")
+            Log.e("KeyboardBase", "XML Parsing error: ${e.message}")
         } catch (e: IOException) {
-            Log.e("MyKeyboard", "I/O error: ${e.message}")
+            Log.e("KeyboardBase", "I/O error: ${e.message}")
         }
         mHeight = y
     }
@@ -476,12 +476,12 @@ class MyKeyboard {
         res: Resources,
         parser: XmlResourceParser,
     ) {
-        val a = res.obtainAttributes(Xml.asAttributeSet(parser), R.styleable.MyKeyboard)
-        val keyWidthResId = R.styleable.MyKeyboard_keyWidth
+        val a = res.obtainAttributes(Xml.asAttributeSet(parser), R.styleable.KeyboardBase)
+        val keyWidthResId = R.styleable.KeyboardBase_keyWidth
         val defaultWidth = mDisplayWidth / WIDTH_DIVIDER
         mDefaultWidth = getDimensionOrFraction(a, keyWidthResId, mDisplayWidth, defaultWidth)
         mDefaultHeight = res.getDimension(R.dimen.key_height).toInt()
-        mDefaultHorizontalGap = getDimensionOrFraction(a, R.styleable.MyKeyboard_horizontalGap, mDisplayWidth, 0)
+        mDefaultHorizontalGap = getDimensionOrFraction(a, R.styleable.KeyboardBase_horizontalGap, mDisplayWidth, 0)
         a.recycle()
     }
 

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class EnglishKeyboardIME : GeneralKeyboardIME("English") {
@@ -40,7 +40,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override val keyboardSymbols = 1
     override val keyboardSymbolShift = 2
 
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var keyboardView: KeyboardView? = null
     override var lastShiftPressTS = 0L
     override var keyboardMode = keyboardLetters
@@ -72,34 +72,34 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -122,7 +122,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -148,7 +148,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class EnglishKeyboardIME : SimpleKeyboardIME("English") {
+class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override fun getKeyboardLayoutXML(): Int =
         if (getEnablePeriodAndCommaABC()) {
             R.xml.keys_letters_english

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override fun getKeyboardLayoutXML(): Int =
@@ -41,7 +41,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override val keyboardSymbolShift = 2
 
     override var keyboard: MyKeyboard? = null
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var lastShiftPressTS = 0L
     override var keyboardMode = keyboardLetters
     override var inputTypeClass = InputType.TYPE_CLASS_TEXT

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class FrenchKeyboardIME : GeneralKeyboardIME("French") {
     override fun getKeyboardLayoutXML(): Int =
@@ -37,7 +37,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
         }
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var keyboard: MyKeyboard? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class FrenchKeyboardIME : GeneralKeyboardIME("French") {
@@ -38,7 +38,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
     override var keyboardView: KeyboardView? = null
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0
     override val keyboardSymbols = 1
@@ -68,34 +68,34 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -118,7 +118,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -144,7 +144,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class FrenchKeyboardIME : SimpleKeyboardIME("French") {
+class FrenchKeyboardIME : GeneralKeyboardIME("French") {
     override fun getKeyboardLayoutXML(): Int =
         if (getEnablePeriodAndCommaABC()) {
             R.xml.keys_letters_french

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -50,7 +50,7 @@ import be.scri.helpers.MyKeyboard
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
 import be.scri.helpers.SHIFT_ON_PERMANENT
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 // based on https://www.androidauthority.com/lets-build-custom-keyboard-android-832362/
 
@@ -58,7 +58,7 @@ import be.scri.views.MyKeyboardView
 abstract class GeneralKeyboardIME(
     var language: String,
 ) : InputMethodService(),
-    MyKeyboardView.OnKeyboardActionListener {
+    KeyboardView.OnKeyboardActionListener {
     abstract fun getKeyboardLayoutXML(): Int
 
     abstract val keyboardLetters: Int
@@ -66,7 +66,7 @@ abstract class GeneralKeyboardIME(
     abstract val keyboardSymbolShift: Int
 
     abstract var keyboard: MyKeyboard?
-    abstract var keyboardView: MyKeyboardView?
+    abstract var keyboardView: KeyboardView?
     abstract var lastShiftPressTS: Long
     abstract var keyboardMode: Int
     abstract var inputTypeClass: Int
@@ -642,7 +642,7 @@ abstract class GeneralKeyboardIME(
 
     fun handleModeChange(
         keyboardMode: Int,
-        keyboardView: MyKeyboardView?,
+        keyboardView: KeyboardView?,
         context: Context,
     ) {
         val keyboardXml =
@@ -660,7 +660,7 @@ abstract class GeneralKeyboardIME(
 
     fun handleKeyboardLetters(
         keyboardMode: Int,
-        keyboardView: MyKeyboardView?,
+        keyboardView: KeyboardView?,
     ) {
         if (keyboardMode == keyboardLetters) {
             when {

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -23,7 +23,6 @@ import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.PorterDuff
-import android.graphics.PorterDuff.Mode
 import android.inputmethodservice.InputMethodService
 import android.text.InputType
 import android.text.InputType.TYPE_CLASS_DATETIME
@@ -56,7 +55,7 @@ import be.scri.views.MyKeyboardView
 // based on https://www.androidauthority.com/lets-build-custom-keyboard-android-832362/
 
 @Suppress("TooManyFunctions", "LargeClass")
-abstract class SimpleKeyboardIME(
+abstract class GeneralKeyboardIME(
     var language: String,
 ) : InputMethodService(),
     MyKeyboardView.OnKeyboardActionListener {

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -46,7 +46,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.databinding.KeyboardViewKeyboardBinding
 import be.scri.helpers.DatabaseHelper
 import be.scri.helpers.HintUtils
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
 import be.scri.helpers.SHIFT_ON_PERMANENT
@@ -65,7 +65,7 @@ abstract class GeneralKeyboardIME(
     abstract val keyboardSymbols: Int
     abstract val keyboardSymbolShift: Int
 
-    abstract var keyboard: MyKeyboard?
+    abstract var keyboard: KeyboardBase?
     abstract var keyboardView: KeyboardView?
     abstract var lastShiftPressTS: Long
     abstract var keyboardMode: Int
@@ -116,7 +116,7 @@ abstract class GeneralKeyboardIME(
     override fun onCreate() {
         super.onCreate()
         keyboardBinding = KeyboardViewKeyboardBinding.inflate(layoutInflater)
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }
@@ -138,11 +138,11 @@ abstract class GeneralKeyboardIME(
         updateCommandBarHintandPrompt()
         enterKeyType =
             if (isCommandMode) {
-                MyKeyboard.MyCustomActions.IME_ACTION_COMMAND
+                KeyboardBase.MyCustomActions.IME_ACTION_COMMAND
             } else {
                 currentEnterKeyType!!
             }
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
     }
 
     fun getIsAccentCharacterDisabled(): Boolean {
@@ -347,7 +347,7 @@ abstract class GeneralKeyboardIME(
 
     override fun onInitializeInterface() {
         super.onInitializeInterface()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
     }
 
     override fun hasTextBeforeCursor(): Boolean {
@@ -534,7 +534,7 @@ abstract class GeneralKeyboardIME(
         emojiKeywords = dbHelper.getEmojiKeywords(languageAlias)
         nounKeywords = dbHelper.getNounKeywords(languageAlias)
 
-        keyboard = MyKeyboard(this, keyboardXml, enterKeyType)
+        keyboard = KeyboardBase(this, keyboardXml, enterKeyType)
         keyboardView?.setKeyboard(keyboard!!)
     }
 
@@ -570,7 +570,7 @@ abstract class GeneralKeyboardIME(
     override fun onActionUp() {
         if (switchToLetters) {
             keyboardMode = keyboardLetters
-            keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+            keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
 
             val editorInfo = currentInputEditorInfo
             if (
@@ -653,7 +653,7 @@ abstract class GeneralKeyboardIME(
                 this.keyboardMode = keyboardLetters
                 getKeyboardLayoutXML()
             }
-        keyboard = MyKeyboard(context, keyboardXml, enterKeyType)
+        keyboard = KeyboardBase(context, keyboardXml, enterKeyType)
         keyboardView?.invalidateAllKeys()
         keyboardView?.setKeyboard(keyboard!!)
     }
@@ -688,7 +688,7 @@ abstract class GeneralKeyboardIME(
                     this.keyboardMode = keyboardSymbols
                     R.xml.keys_symbols
                 }
-            keyboard = MyKeyboard(this, keyboardXml, enterKeyType)
+            keyboard = KeyboardBase(this, keyboardXml, enterKeyType)
             keyboardView!!.setKeyboard(keyboard!!)
         }
     }
@@ -752,7 +752,7 @@ abstract class GeneralKeyboardIME(
             }
         } else {
             // Handling space key logic.
-            if (keyboardMode != keyboardLetters && code == MyKeyboard.KEYCODE_SPACE) {
+            if (keyboardMode != keyboardLetters && code == KeyboardBase.KEYCODE_SPACE) {
                 binding?.commandBar?.text = " "
                 val originalText = inputConnection.getExtractedText(ExtractedTextRequest(), 0).text
                 inputConnection.commitText(codeChar.toString(), 1)

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class GermanKeyboardIME : SimpleKeyboardIME("German") {
+class GermanKeyboardIME : GeneralKeyboardIME("German") {
     override fun getKeyboardLayoutXML(): Int =
         if (getIsAccentCharacterDisabled() && !getEnablePeriodAndCommaABC()) {
             R.xml.keys_letter_german_without_accent_characters_and_without_period_and_comma

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class GermanKeyboardIME : GeneralKeyboardIME("German") {
@@ -42,7 +42,7 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
     override var keyboardView: KeyboardView? = null
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0
     override val keyboardSymbols = 1
@@ -76,34 +76,34 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -126,7 +126,7 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -152,7 +152,7 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class GermanKeyboardIME : GeneralKeyboardIME("German") {
     override fun getKeyboardLayoutXML(): Int =
@@ -41,7 +41,7 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         }
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var keyboard: MyKeyboard? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
@@ -38,7 +38,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
     override var keyboardView: KeyboardView? = null
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0
     override val keyboardSymbols = 1
@@ -68,34 +68,34 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -118,7 +118,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -144,7 +144,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
     override fun getKeyboardLayoutXML(): Int =
@@ -37,7 +37,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
         }
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var keyboard: MyKeyboard? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class ItalianKeyboardIME : SimpleKeyboardIME("Italian") {
+class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
     override fun getKeyboardLayoutXML(): Int =
         if (getEnablePeriodAndCommaABC()) {
             R.xml.keys_letters_italian

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class PortugueseKeyboardIME : SimpleKeyboardIME("Portuguese") {
+class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
     override fun getKeyboardLayoutXML(): Int =
         if (getEnablePeriodAndCommaABC()) {
             R.xml.keys_letters_portuguese

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
     override fun getKeyboardLayoutXML(): Int =
@@ -37,7 +37,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
         }
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var keyboard: MyKeyboard? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
@@ -38,7 +38,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
     override var keyboardView: KeyboardView? = null
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0
     override val keyboardSymbols = 1
@@ -68,34 +68,34 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -118,7 +118,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -144,7 +144,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
     override fun getKeyboardLayoutXML(): Int =
@@ -37,7 +37,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
         }
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var keyboard: MyKeyboard? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
@@ -38,7 +38,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
     override var keyboardView: KeyboardView? = null
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0
     override val keyboardSymbols = 1
@@ -68,34 +68,34 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -118,7 +118,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -144,7 +144,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class RussianKeyboardIME : SimpleKeyboardIME("Russian") {
+class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
     override fun getKeyboardLayoutXML(): Int =
         if (getEnablePeriodAndCommaABC()) {
             R.xml.keys_letters_russian

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
@@ -42,7 +42,7 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
     override var keyboardView: KeyboardView? = null
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0
     override val keyboardSymbols = 1
@@ -72,34 +72,34 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -122,7 +122,7 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -148,7 +148,7 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class SpanishKeyboardIME : SimpleKeyboardIME(language = "Spanish") {
+class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
     override fun getKeyboardLayoutXML(): Int =
         if (getIsAccentCharacterDisabled() && !getEnablePeriodAndCommaABC()) {
             R.xml.keys_letter_spanish_without_accent_characters_and_without_period_and_comma

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
     override fun getKeyboardLayoutXML(): Int =
@@ -41,7 +41,7 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         }
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var keyboard: MyKeyboard? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -28,7 +28,7 @@ import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
 import be.scri.views.MyKeyboardView
 
-class SwedishKeyboardIME : SimpleKeyboardIME("Swedish") {
+class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
     override fun getKeyboardLayoutXML(): Int =
         if (getIsAccentCharacterDisabled() && !getEnablePeriodAndCommaABC()) {
             R.xml.keys_letter_swedish_without_accent_characters_and_without_period_and_comma

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -26,7 +26,7 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
 import be.scri.helpers.MyKeyboard
-import be.scri.views.MyKeyboardView
+import be.scri.views.KeyboardView
 
 class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
     override fun getKeyboardLayoutXML(): Int =
@@ -41,7 +41,7 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         }
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
-    override var keyboardView: MyKeyboardView? = null
+    override var keyboardView: KeyboardView? = null
     override var keyboard: MyKeyboard? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.databinding.KeyboardViewCommandOptionsBinding
-import be.scri.helpers.MyKeyboard
+import be.scri.helpers.KeyboardBase
 import be.scri.views.KeyboardView
 
 class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
@@ -42,7 +42,7 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
 
     override lateinit var binding: KeyboardViewCommandOptionsBinding
     override var keyboardView: KeyboardView? = null
-    override var keyboard: MyKeyboard? = null
+    override var keyboard: KeyboardBase? = null
     override var enterKeyType = IME_ACTION_NONE
     override val keyboardLetters = 0
     override val keyboardSymbols = 1
@@ -72,34 +72,34 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         if (keyboard == null || inputConnection == null) {
             return
         }
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             lastShiftPressTS = 0
         }
 
         when (code) {
-            MyKeyboard.KEYCODE_DELETE -> {
+            KeyboardBase.KEYCODE_DELETE -> {
                 handleKeycodeDelete()
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SHIFT -> {
+            KeyboardBase.KEYCODE_SHIFT -> {
                 super.handleKeyboardLetters(keyboardMode, keyboardView)
                 keyboardView!!.invalidateAllKeys()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_ENTER -> {
+            KeyboardBase.KEYCODE_ENTER -> {
                 handleKeycodeEnter()
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_MODE_CHANGE -> {
+            KeyboardBase.KEYCODE_MODE_CHANGE -> {
                 handleModeChange(keyboardMode, keyboardView, this)
                 disableAutoSuggest()
             }
 
-            MyKeyboard.KEYCODE_SPACE -> {
+            KeyboardBase.KEYCODE_SPACE -> {
                 handleElseCondition(code, keyboardMode, binding = null)
                 updateAutoSuggestText(nounTypeSuggestion)
             }
@@ -122,7 +122,7 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         Log.d("Debug", "$autosuggestEmojis")
         Log.d("MY-TAG", "$nounTypeSuggestion")
         updateButtonText(isAutoSuggestEnabled, autosuggestEmojis)
-        if (code != MyKeyboard.KEYCODE_SHIFT) {
+        if (code != KeyboardBase.KEYCODE_SHIFT) {
             super.updateShiftKeyState()
         }
     }
@@ -148,7 +148,7 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
 
     override fun onCreate() {
         super.onCreate()
-        keyboard = MyKeyboard(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
         onCreateInputView()
         setupCommandBarTheme(binding)
     }

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -63,13 +63,13 @@ import be.scri.extensions.getProperPrimaryColor
 import be.scri.extensions.getProperTextColor
 import be.scri.extensions.getStrokeColor
 import be.scri.extensions.performHapticFeedback
-import be.scri.helpers.MAX_KEYS_PER_MINI_ROW
 import be.scri.helpers.KeyboardBase
 import be.scri.helpers.KeyboardBase.Companion.KEYCODE_DELETE
 import be.scri.helpers.KeyboardBase.Companion.KEYCODE_ENTER
 import be.scri.helpers.KeyboardBase.Companion.KEYCODE_MODE_CHANGE
 import be.scri.helpers.KeyboardBase.Companion.KEYCODE_SHIFT
 import be.scri.helpers.KeyboardBase.Companion.KEYCODE_SPACE
+import be.scri.helpers.MAX_KEYS_PER_MINI_ROW
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
 import be.scri.helpers.SHIFT_ON_PERMANENT

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -78,7 +78,7 @@ import java.util.Locale
 
 @SuppressLint("UseCompatLoadingForDrawables")
 @Suppress("LargeClass", "LongMethod", "TooManyFunctions", "NestedBlockDepth", "CyclomaticComplexMethod")
-class MyKeyboardView
+class KeyboardView
     @JvmOverloads
     constructor(
         context: Context,
@@ -145,7 +145,7 @@ class MyKeyboardView
         private val mCoordinates = IntArray(2)
         private val mPopupKeyboard: PopupWindow
         private var mMiniKeyboardContainer: View? = null
-        private var mMiniKeyboard: MyKeyboardView? = null
+        private var mMiniKeyboard: KeyboardView? = null
         private var mMiniKeyboardOnScreen = false
         private var mPopupParent: View
         private var mMiniKeyboardOffsetX = 0
@@ -312,7 +312,7 @@ class MyKeyboardView
             }
 
         init {
-            val attributes = context.obtainStyledAttributes(attrs, R.styleable.MyKeyboardView, 0, defStyleRes)
+            val attributes = context.obtainStyledAttributes(attrs, R.styleable.KeyboardView, 0, defStyleRes)
             val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
             val keyTextSize = 0
             val indexCnt = attributes.indexCount
@@ -320,7 +320,7 @@ class MyKeyboardView
             try {
                 for (i in 0 until indexCnt) {
                     when (val attr = attributes.getIndex(i)) {
-                        R.styleable.MyKeyboardView_keyTextSize -> {
+                        R.styleable.KeyboardView_keyTextSize -> {
                             mKeyTextSize = attributes.getDimensionPixelSize(attr, DEFAULT_KEY_TEXT_SIZE)
                         }
                     }
@@ -1039,7 +1039,7 @@ class MyKeyboardView
                     mMiniKeyboard =
                         mMiniKeyboardContainer!!
                             .findViewById<View>(R.id.mini_keyboard_view)
-                            as MyKeyboardView
+                            as KeyboardView
 
                     mMiniKeyboard!!.mOnKeyboardActionListener =
                         object : OnKeyboardActionListener {
@@ -1094,7 +1094,7 @@ class MyKeyboardView
                 } else {
                     mMiniKeyboard =
                         mMiniKeyboardContainer!!
-                            .findViewById<View>(R.id.mini_keyboard_view) as MyKeyboardView
+                            .findViewById<View>(R.id.mini_keyboard_view) as KeyboardView
                 }
 
                 getLocationInWindow(mCoordinates)

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -64,12 +64,12 @@ import be.scri.extensions.getProperTextColor
 import be.scri.extensions.getStrokeColor
 import be.scri.extensions.performHapticFeedback
 import be.scri.helpers.MAX_KEYS_PER_MINI_ROW
-import be.scri.helpers.MyKeyboard
-import be.scri.helpers.MyKeyboard.Companion.KEYCODE_DELETE
-import be.scri.helpers.MyKeyboard.Companion.KEYCODE_ENTER
-import be.scri.helpers.MyKeyboard.Companion.KEYCODE_MODE_CHANGE
-import be.scri.helpers.MyKeyboard.Companion.KEYCODE_SHIFT
-import be.scri.helpers.MyKeyboard.Companion.KEYCODE_SPACE
+import be.scri.helpers.KeyboardBase
+import be.scri.helpers.KeyboardBase.Companion.KEYCODE_DELETE
+import be.scri.helpers.KeyboardBase.Companion.KEYCODE_ENTER
+import be.scri.helpers.KeyboardBase.Companion.KEYCODE_MODE_CHANGE
+import be.scri.helpers.KeyboardBase.Companion.KEYCODE_SHIFT
+import be.scri.helpers.KeyboardBase.Companion.KEYCODE_SPACE
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
 import be.scri.helpers.SHIFT_ON_PERMANENT
@@ -126,7 +126,7 @@ class KeyboardView
             fun commitPeriodAfterSpace()
         }
 
-        private var mKeyboard: MyKeyboard? = null
+        private var mKeyboard: KeyboardBase? = null
         private var mCurrentKeyIndex: Int = NOT_A_KEY
 
         private var mLabelTextSize = 0
@@ -150,8 +150,8 @@ class KeyboardView
         private var mPopupParent: View
         private var mMiniKeyboardOffsetX = 0
         private var mMiniKeyboardOffsetY = 0
-        private val mMiniKeyboardCache: MutableMap<MyKeyboard.Key, View?>
-        private var mKeys = ArrayList<MyKeyboard.Key>()
+        private val mMiniKeyboardCache: MutableMap<KeyboardBase.Key, View?>
+        private var mKeys = ArrayList<KeyboardBase.Key>()
         private var mMiniKeyboardSelectedKeyIndex = -1
 
         var mOnKeyboardActionListener: OnKeyboardActionListener? = null
@@ -450,7 +450,7 @@ class KeyboardView
          * The keyboard can be switched at any time and the view will re-layout itself to accommodate the keyboard.
          * @param keyboard the keyboard to display in this view
          */
-        fun setKeyboard(keyboard: MyKeyboard) {
+        fun setKeyboard(keyboard: KeyboardBase) {
             if (mKeyboard != null) {
                 showPreview(NOT_A_KEY)
             }
@@ -458,7 +458,7 @@ class KeyboardView
             removeMessages()
             mKeyboard = keyboard
             val keys = mKeyboard!!.mKeys
-            mKeys = keys!!.toMutableList() as ArrayList<MyKeyboard.Key>
+            mKeys = keys!!.toMutableList() as ArrayList<KeyboardBase.Key>
             requestLayout()
             mKeyboardChanged = true
             invalidateAllKeys()
@@ -544,7 +544,7 @@ class KeyboardView
          * We use a square here and in computing the touch distance from a key's center to avoid taking a square root.
          * @param keyboard
          */
-        private fun computeProximityThreshold(keyboard: MyKeyboard?) {
+        private fun computeProximityThreshold(keyboard: KeyboardBase?) {
             if (keyboard == null) {
                 return
             }
@@ -979,7 +979,7 @@ class KeyboardView
          * Invalidates a key so that it will be redrawn on the next repaint.
          * Use this method if only one key is changing it's content. Any changes that
          * affect the position or size of the key may not be honored.
-         * @param keyIndex the index of the key in the attached [MyKeyboard].
+         * @param keyIndex the index of the key in the attached [KeyboardBase].
          */
         private fun invalidateKey(keyIndex: Int) {
             if (keyIndex < 0 || keyIndex >= mKeys.size) {
@@ -1027,7 +1027,7 @@ class KeyboardView
          * handle the call.
          */
         private fun onLongPress(
-            popupKey: MyKeyboard.Key,
+            popupKey: KeyboardBase.Key,
             me: MotionEvent,
         ): Boolean {
             val popupKeyboardId = popupKey.popupResId
@@ -1079,9 +1079,9 @@ class KeyboardView
 
                     val keyboard =
                         if (popupKey.popupCharacters != null) {
-                            MyKeyboard(context, popupKeyboardId, popupKey.popupCharacters!!, popupKey.width)
+                            KeyboardBase(context, popupKeyboardId, popupKey.popupCharacters!!, popupKey.width)
                         } else {
-                            MyKeyboard(context, popupKeyboardId, 0)
+                            KeyboardBase(context, popupKeyboardId, 0)
                         }
 
                     mMiniKeyboard!!.setKeyboard(keyboard)

--- a/app/src/main/res/layout-land/keyboard_view_keyboard.xml
+++ b/app/src/main/res/layout-land/keyboard_view_keyboard.xml
@@ -57,9 +57,9 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <be.scri.views.MyKeyboardView
+    <be.scri.views.KeyboardView
         android:id="@+id/keyboard_view"
-        style="@style/MyKeyboardView"
+        style="@style/KeyboardView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:background="@color/theme_dark_background_color"

--- a/app/src/main/res/layout/keyboard_popup_keyboard.xml
+++ b/app/src/main/res/layout/keyboard_popup_keyboard.xml
@@ -1,6 +1,6 @@
-<be.scri.views.MyKeyboardView xmlns:android="http://schemas.android.com/apk/res/android"
+<be.scri.views.KeyboardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/mini_keyboard_view"
-    style="@style/MyKeyboardViewPopup"
+    style="@style/KeyboardViewPopup"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/you_keyboard_background_color" />

--- a/app/src/main/res/layout/keyboard_view_command_options.xml
+++ b/app/src/main/res/layout/keyboard_view_command_options.xml
@@ -240,9 +240,9 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <be.scri.views.MyKeyboardView
+    <be.scri.views.KeyboardView
         android:id="@+id/keyboard_view"
-        style="@style/MyKeyboardView"
+        style="@style/KeyboardView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:background="@color/you_keyboard_background_color"

--- a/app/src/main/res/layout/keyboard_view_keyboard.xml
+++ b/app/src/main/res/layout/keyboard_view_keyboard.xml
@@ -99,9 +99,9 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <be.scri.views.MyKeyboardView
+    <be.scri.views.KeyboardView
         android:id="@+id/keyboard_view"
-        style="@style/MyKeyboardView"
+        style="@style/KeyboardView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:background="@color/theme_dark_background_color"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,12 +8,12 @@
         <attr name="keyTextSize" format="dimension" />
     </declare-styleable>
 
-    <declare-styleable name="MyKeyboard">
+    <declare-styleable name="KeyboardBase">
         <attr name="keyWidth" format="fraction" />
         <attr name="horizontalGap" format="fraction" />
     </declare-styleable>
 
-    <declare-styleable name="MyKeyboard_Key">
+    <declare-styleable name="KeyboardBase_Key">
         <!-- The unicode value that this key outputs. -->
         <attr name="code" format="integer" />
         <!-- The XML keyboard layout of any popup keyboard. -->

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -4,7 +4,7 @@
         <attr name="state_long_pressable" format="boolean" />
     </declare-styleable>
 
-    <declare-styleable name="MyKeyboardView">
+    <declare-styleable name="KeyboardView">
         <attr name="keyTextSize" format="dimension" />
     </declare-styleable>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,15 +2,15 @@
 
     <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge" />
 
-    <style name="MyKeyboard">
+    <style name="KeyboardBase">
         <item name="itemTextAppearance">?attr/itemTextAppearance</item>
     </style>
 
-    <style name="KeyboardView" parent="MyKeyboard">
+    <style name="KeyboardView" parent="KeyboardBase">
         <item name="keyTextSize">@dimen/keyboard_text_size</item>
     </style>
 
-    <style name="KeyboardViewPopup" parent="MyKeyboard">
+    <style name="KeyboardViewPopup" parent="KeyboardBase">
         <item name="keyTextSize">@dimen/preview_text_size</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,11 +6,11 @@
         <item name="itemTextAppearance">?attr/itemTextAppearance</item>
     </style>
 
-    <style name="MyKeyboardView" parent="MyKeyboard">
+    <style name="KeyboardView" parent="MyKeyboard">
         <item name="keyTextSize">@dimen/keyboard_text_size</item>
     </style>
 
-    <style name="MyKeyboardViewPopup" parent="MyKeyboard">
+    <style name="KeyboardViewPopup" parent="MyKeyboard">
         <item name="keyTextSize">@dimen/preview_text_size</item>
     </style>
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
I renamed the code variable names and XML file names according to this rule.

- `SimpleKeyboardIME` -> `GeneralKeyboardIME`
- `MyKeyboardView` -> `KeyboardView`
- `MyKeyboard` -> `KeyboardBase`

After my initial testing, the app can run normally currently.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #223
