### PR TITLE
fix(command-mode): fix shift key and capitalization behaviour

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -337,7 +337,7 @@ abstract class GeneralKeyboardIME(
             updateKeyboardMode(true)
             currentState = ScribeState.PLURAL
             if (language == "German") {
-                // Nouns are capitalized in 'German' language.
+                // All nouns are capitalized in German.
                 keyboard!!.mShiftState = SHIFT_ON_ONE_CHAR
             }
             updateUI()
@@ -556,8 +556,8 @@ abstract class GeneralKeyboardIME(
         }
 
     fun updateShiftKeyState() {
-        // The shift state in the command modes like Translate, Conjugate, Plural etc. should not depend on the
-        // capitalization mode of the Input Connection. It should be be carried on from the previous mode.
+        // The shift state in the Scribe commands should not depend on the Input Connection.
+        // The current state should be transferred to the command unless required by the language.
         if ((currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) &&
             keyboardMode == keyboardLetters
         ) {

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -142,7 +142,7 @@ abstract class GeneralKeyboardIME(
             } else {
                 currentEnterKeyType!!
             }
-        keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
+        keyboardView?.setKeyboard(keyboard!!)
     }
 
     fun getIsAccentCharacterDisabled(): Boolean {
@@ -336,6 +336,10 @@ abstract class GeneralKeyboardIME(
             Log.i("MY-TAG", "PLURAL STATE")
             updateKeyboardMode(true)
             currentState = ScribeState.PLURAL
+            if (language == "German") {
+                // Nouns are capitalized in 'German' language.
+                keyboard!!.mShiftState = SHIFT_ON_ONE_CHAR
+            }
             updateUI()
         }
     }
@@ -552,7 +556,11 @@ abstract class GeneralKeyboardIME(
         }
 
     fun updateShiftKeyState() {
-        if (keyboardMode == keyboardLetters) {
+        // The shift state in the command modes like Translate, Conjugate, Plural etc. should not depend on the
+        // capitalization mode of the Input Connection. It should be be carried on from the previous mode.
+        if ((currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) &&
+            keyboardMode == keyboardLetters
+        ) {
             val editorInfo = currentInputEditorInfo
             if (
                 editorInfo != null &&
@@ -762,11 +770,11 @@ abstract class GeneralKeyboardIME(
                 binding?.commandBar?.append(codeChar.toString())
                 inputConnection.commitText(codeChar.toString(), 1)
             }
+        }
 
-            if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR && keyboardMode == keyboardLetters) {
-                keyboard!!.mShiftState = SHIFT_OFF
-                keyboardView!!.invalidateAllKeys()
-            }
+        if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR && keyboardMode == keyboardLetters) {
+            keyboard!!.mShiftState = SHIFT_OFF
+            keyboardView!!.invalidateAllKeys()
         }
     }
 


### PR DESCRIPTION
Correct capitalization behavior, fix shift key icon, and handle German plural noun capitalization.

Closes #287

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request addresses issue #287 by resolving several issues with the command bar:

- **Corrected text capitalization behavior:** Ensured correct capitalization of text entered in the command bar, including proper handling of cases like German plural nouns.
- **Fixed shift key icon behavior:** Corrected an issue where the shift key icon and label of the keys did not accurately reflect the shift key state during command mode.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #287
