### PR TITLE
Fix(general-keyboard): Automatically switch to letter keys after command selection

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -249,6 +249,7 @@ abstract class GeneralKeyboardIME(
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
+        handleModeChange(keyboardSymbols, keyboardView, this)
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
@@ -259,6 +260,7 @@ abstract class GeneralKeyboardIME(
     }
 
     private fun setupIdleView() {
+        handleModeChange(keyboardSymbols, keyboardView, this)
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
         val isSystemDarkMode = currentNightMode == Configuration.UI_MODE_NIGHT_YES

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -246,10 +246,10 @@ abstract class GeneralKeyboardIME(
                 keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(R.color.special_key_light))
             }
         }
+        handleModeChange(keyboardSymbols, keyboardView, this)
         keyboardView = keyboardBinding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.mOnKeyboardActionListener = this
-        handleModeChange(keyboardSymbols, keyboardView, this)
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
@@ -260,7 +260,6 @@ abstract class GeneralKeyboardIME(
     }
 
     private fun setupIdleView() {
-        handleModeChange(keyboardSymbols, keyboardView, this)
         val sharedPref = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
         val isSystemDarkMode = currentNightMode == Configuration.UI_MODE_NIGHT_YES
@@ -338,11 +337,11 @@ abstract class GeneralKeyboardIME(
             Log.i("MY-TAG", "PLURAL STATE")
             updateKeyboardMode(true)
             currentState = ScribeState.PLURAL
+            updateUI()
             if (language == "German") {
                 // All nouns are capitalized in German.
                 keyboard!!.mShiftState = SHIFT_ON_ONE_CHAR
             }
-            updateUI()
         }
     }
 


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This commit addresses issue #298 by:

1. **Automatically switching the keyboard to 'keyboardLetters' after a Scribe command (e.g., translate, conjugate, plural) is selected.** This improves the user experience by streamlining the workflow and reducing the need for manual keyboard mode changes.

2. **Switching the keyboard to 'keyboardLetters' when the user switches to the Idle mode.** This ensures consistent keyboard behavior and prevents unexpected input modes.

This enhancement enhances the overall usability of Scribe by providing a more intuitive and efficient interaction flow for users.

Closes #298

### Related issue

-   #298 
