### PR TITLE
Add SPDX license identifier to all the .kt files.

### DIFF
--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Handles application-level initialization and sets the default night mode based on user configuration.
  */

--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Handles application-level initialization and sets the default night mode based on user configuration.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri

--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Handles application-level initialization and sets the default night mode based on user configuration.
  */

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Implements the main activity with a custom action bar, ViewPager navigation, and dynamic UI adjustments.
  */

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Implements the main activity with a custom action bar, ViewPager navigation, and dynamic UI adjustments.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.activities

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Implements the main activity with a custom action bar, ViewPager navigation, and dynamic UI adjustments.
  */

--- a/app/src/main/java/be/scri/extensions/CommonsContext.kt
+++ b/app/src/main/java/be/scri/extensions/CommonsContext.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions and properties for accessing shared preferences and BaseConfig.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.extensions

--- a/app/src/main/java/be/scri/extensions/CommonsContext.kt
+++ b/app/src/main/java/be/scri/extensions/CommonsContext.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Functions and properties for accessing shared preferences and BaseConfig.
  */

--- a/app/src/main/java/be/scri/extensions/CommonsContext.kt
+++ b/app/src/main/java/be/scri/extensions/CommonsContext.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions and properties for accessing shared preferences and BaseConfig.
  */

--- a/app/src/main/java/be/scri/extensions/Context.kt
+++ b/app/src/main/java/be/scri/extensions/Context.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for retrieving configuration settings and calculating color based on theme and background preferences.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.extensions

--- a/app/src/main/java/be/scri/extensions/Context.kt
+++ b/app/src/main/java/be/scri/extensions/Context.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for retrieving configuration settings and calculating color based on theme and background preferences.
  */

--- a/app/src/main/java/be/scri/extensions/Context.kt
+++ b/app/src/main/java/be/scri/extensions/Context.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Functions for retrieving configuration settings and calculating color based on theme and background preferences.
  */

--- a/app/src/main/java/be/scri/extensions/ContextStyling.kt
+++ b/app/src/main/java/be/scri/extensions/ContextStyling.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for determining and retrieving proper text and colors based on user settings.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.extensions

--- a/app/src/main/java/be/scri/extensions/ContextStyling.kt
+++ b/app/src/main/java/be/scri/extensions/ContextStyling.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for determining and retrieving proper text and colors based on user settings.
  */

--- a/app/src/main/java/be/scri/extensions/ContextStyling.kt
+++ b/app/src/main/java/be/scri/extensions/ContextStyling.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Functions for determining and retrieving proper text and colors based on user settings.
  */

--- a/app/src/main/java/be/scri/extensions/Drawable.kt
+++ b/app/src/main/java/be/scri/extensions/Drawable.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Extends the Drawable class to apply a color filter to a drawable using a specified color.
  */

--- a/app/src/main/java/be/scri/extensions/Drawable.kt
+++ b/app/src/main/java/be/scri/extensions/Drawable.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Extends the Drawable class to apply a color filter to a drawable using a specified color.
  */

--- a/app/src/main/java/be/scri/extensions/Drawable.kt
+++ b/app/src/main/java/be/scri/extensions/Drawable.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Extends the Drawable class to apply a color filter to a drawable using a specified color.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.extensions

--- a/app/src/main/java/be/scri/extensions/Int.kt
+++ b/app/src/main/java/be/scri/extensions/Int.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Functions for manipulating colors used within the application.
  */

--- a/app/src/main/java/be/scri/extensions/Int.kt
+++ b/app/src/main/java/be/scri/extensions/Int.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for manipulating colors used within the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.extensions

--- a/app/src/main/java/be/scri/extensions/Int.kt
+++ b/app/src/main/java/be/scri/extensions/Int.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for manipulating colors used within the application.
  */

--- a/app/src/main/java/be/scri/extensions/RecyclerView.kt
+++ b/app/src/main/java/be/scri/extensions/RecyclerView.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Adds a custom item decoration (divider) to a RecyclerView, using a specified drawable and custom margins.
  */

--- a/app/src/main/java/be/scri/extensions/RecyclerView.kt
+++ b/app/src/main/java/be/scri/extensions/RecyclerView.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Adds a custom item decoration (divider) to a RecyclerView, using a specified drawable and custom margins.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.extensions

--- a/app/src/main/java/be/scri/extensions/RecyclerView.kt
+++ b/app/src/main/java/be/scri/extensions/RecyclerView.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Adds a custom item decoration (divider) to a RecyclerView, using a specified drawable and custom margins.
  */

--- a/app/src/main/java/be/scri/extensions/View.kt
+++ b/app/src/main/java/be/scri/extensions/View.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Utility functions for managing visibility and haptic feedback in Android views.
  */

--- a/app/src/main/java/be/scri/extensions/View.kt
+++ b/app/src/main/java/be/scri/extensions/View.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Utility functions for managing visibility and haptic feedback in Android views.
  */

--- a/app/src/main/java/be/scri/extensions/View.kt
+++ b/app/src/main/java/be/scri/extensions/View.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Utility functions for managing visibility and haptic feedback in Android views.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.extensions

--- a/app/src/main/java/be/scri/helpers/AlphanumericComparator.kt
+++ b/app/src/main/java/be/scri/helpers/AlphanumericComparator.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A test class to prepare for application testing.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/AlphanumericComparator.kt
+++ b/app/src/main/java/be/scri/helpers/AlphanumericComparator.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A test class to prepare for application testing.
  */

--- a/app/src/main/java/be/scri/helpers/AlphanumericComparator.kt
+++ b/app/src/main/java/be/scri/helpers/AlphanumericComparator.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A test class to prepare for application testing.
  */

--- a/app/src/main/java/be/scri/helpers/BaseConfig.kt
+++ b/app/src/main/java/be/scri/helpers/BaseConfig.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A configuration helper class for managing app settings.
  */

--- a/app/src/main/java/be/scri/helpers/BaseConfig.kt
+++ b/app/src/main/java/be/scri/helpers/BaseConfig.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A configuration helper class for managing app settings.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/BaseConfig.kt
+++ b/app/src/main/java/be/scri/helpers/BaseConfig.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A configuration helper class for managing app settings.
  */

--- a/app/src/main/java/be/scri/helpers/CommonsConstants.kt
+++ b/app/src/main/java/be/scri/helpers/CommonsConstants.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Common constants that are used throughout helper classes and objects.
  */

--- a/app/src/main/java/be/scri/helpers/CommonsConstants.kt
+++ b/app/src/main/java/be/scri/helpers/CommonsConstants.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Common constants that are used throughout helper classes and objects.
  */

--- a/app/src/main/java/be/scri/helpers/CommonsConstants.kt
+++ b/app/src/main/java/be/scri/helpers/CommonsConstants.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Common constants that are used throughout helper classes and objects.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/Config.kt
+++ b/app/src/main/java/be/scri/helpers/Config.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A class that extends BaseConfig to manage additional app settings.
  */

--- a/app/src/main/java/be/scri/helpers/Config.kt
+++ b/app/src/main/java/be/scri/helpers/Config.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A class that extends BaseConfig to manage additional app settings.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/Config.kt
+++ b/app/src/main/java/be/scri/helpers/Config.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A class that extends BaseConfig to manage additional app settings.
  */

--- a/app/src/main/java/be/scri/helpers/Constants.kt
+++ b/app/src/main/java/be/scri/helpers/Constants.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Constants that are used throughout helper classes and objects.
  */

--- a/app/src/main/java/be/scri/helpers/Constants.kt
+++ b/app/src/main/java/be/scri/helpers/Constants.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants that are used throughout helper classes and objects.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/Constants.kt
+++ b/app/src/main/java/be/scri/helpers/Constants.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants that are used throughout helper classes and objects.
  */

--- a/app/src/main/java/be/scri/helpers/CustomAdapter.kt
+++ b/app/src/main/java/be/scri/helpers/CustomAdapter.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A RecyclerView adapter that supports multiple view types.
  */

--- a/app/src/main/java/be/scri/helpers/CustomAdapter.kt
+++ b/app/src/main/java/be/scri/helpers/CustomAdapter.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A RecyclerView adapter that supports multiple view types.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/CustomAdapter.kt
+++ b/app/src/main/java/be/scri/helpers/CustomAdapter.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A RecyclerView adapter that supports multiple view types.
  */

--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A helper to facilitate database calls for Scribe keyboard commands.
  */

--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate database calls for Scribe keyboard commands.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate database calls for Scribe keyboard commands.
  */

--- a/app/src/main/java/be/scri/helpers/HintUtils.kt
+++ b/app/src/main/java/be/scri/helpers/HintUtils.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A helper to facilitate resetting application hints if the user would like to see them again.
  */

--- a/app/src/main/java/be/scri/helpers/HintUtils.kt
+++ b/app/src/main/java/be/scri/helpers/HintUtils.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate resetting application hints if the user would like to see them again.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/HintUtils.kt
+++ b/app/src/main/java/be/scri/helpers/HintUtils.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate resetting application hints if the user would like to see them again.
  */

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Custom keyboard implementation for handling keyboard layouts, rows and keys with XML-based configuration.
  */

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Custom keyboard implementation for handling keyboard layouts, rows and keys with XML-based configuration.
  */

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Custom keyboard implementation for handling keyboard layouts, rows and keys with XML-based configuration.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate setting preferences for individual language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate setting preferences for individual language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A helper to facilitate setting preferences for individual language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/RatingHelper.kt
+++ b/app/src/main/java/be/scri/helpers/RatingHelper.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate rating the application on Google Play or F-Droid.
  */

--- a/app/src/main/java/be/scri/helpers/RatingHelper.kt
+++ b/app/src/main/java/be/scri/helpers/RatingHelper.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate rating the application on Google Play or F-Droid.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/RatingHelper.kt
+++ b/app/src/main/java/be/scri/helpers/RatingHelper.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A helper to facilitate rating the application on Google Play or F-Droid.
  */

--- a/app/src/main/java/be/scri/helpers/ShareHelper.kt
+++ b/app/src/main/java/be/scri/helpers/ShareHelper.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate sharing of the application and contacting the team.
  */

--- a/app/src/main/java/be/scri/helpers/ShareHelper.kt
+++ b/app/src/main/java/be/scri/helpers/ShareHelper.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A helper to facilitate sharing of the application and contacting the team.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers

--- a/app/src/main/java/be/scri/helpers/ShareHelper.kt
+++ b/app/src/main/java/be/scri/helpers/ShareHelper.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A helper to facilitate sharing of the application and contacting the team.
  */

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for English language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.english

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Interface variables for English language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for English language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for French language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Interface variables for French language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for French language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.french

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for German language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for German language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.german

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Interface variables for German language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Italian language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.italian

--- a/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Interface variables for Portuguese language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Portuguese language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.portuguese

--- a/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Portuguese language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Russian language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Russian language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.russian

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Interface variables for Russian language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Spanish language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.spanish

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Interface variables for Spanish language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Spanish language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Interface variables for Swedish language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Swedish language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.helpers.swedish

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Interface variables for Swedish language keyboards.
  */

--- a/app/src/main/java/be/scri/models/ItemsViewModel.kt
+++ b/app/src/main/java/be/scri/models/ItemsViewModel.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The item view model class used in the application.
  */

--- a/app/src/main/java/be/scri/models/ItemsViewModel.kt
+++ b/app/src/main/java/be/scri/models/ItemsViewModel.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The item view model class used in the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.models

--- a/app/src/main/java/be/scri/models/ItemsViewModel.kt
+++ b/app/src/main/java/be/scri/models/ItemsViewModel.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The item view model class used in the application.
  */

--- a/app/src/main/java/be/scri/models/SwitchItem.kt
+++ b/app/src/main/java/be/scri/models/SwitchItem.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The switch item model class used in the application.
  */

--- a/app/src/main/java/be/scri/models/SwitchItem.kt
+++ b/app/src/main/java/be/scri/models/SwitchItem.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The switch item model class used in the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.models

--- a/app/src/main/java/be/scri/models/SwitchItem.kt
+++ b/app/src/main/java/be/scri/models/SwitchItem.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The switch item model class used in the application.
  */

--- a/app/src/main/java/be/scri/models/TextItem.kt
+++ b/app/src/main/java/be/scri/models/TextItem.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The text item model class used in the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.models

--- a/app/src/main/java/be/scri/models/TextItem.kt
+++ b/app/src/main/java/be/scri/models/TextItem.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The text item model class used in the application.
  */

--- a/app/src/main/java/be/scri/models/TextItem.kt
+++ b/app/src/main/java/be/scri/models/TextItem.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The text item model class used in the application.
  */

--- a/app/src/main/java/be/scri/navigation/Screen.kt
+++ b/app/src/main/java/be/scri/navigation/Screen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 package be.scri.navigation
 
 sealed class Screen(

--- a/app/src/main/java/be/scri/navigation/Screen.kt
+++ b/app/src/main/java/be/scri/navigation/Screen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.navigation
 
 sealed class Screen(

--- a/app/src/main/java/be/scri/navigation/Screen.kt
+++ b/app/src/main/java/be/scri/navigation/Screen.kt
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.navigation
 
 sealed class Screen(

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the English language keyboard.
  */

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the English language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the English language keyboard.
  */

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the French language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the French language keyboard.
  */

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the French language keyboard.
  */

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The base keyboard input method (IME) imported into all language keyboards.
  */

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The base keyboard input method (IME) imported into all language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The base keyboard input method (IME) imported into all language keyboards.
  */

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the German language keyboard.
  */

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the German language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the German language keyboard.
  */

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Italian language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the Italian language keyboard.
  */

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Italian language keyboard.
  */

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the Portuguese language keyboard.
  */

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Portuguese language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Portuguese language keyboard.
  */

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Russian language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Russian language keyboard.
  */

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the Russian language keyboard.
  */

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Spanish language keyboard.
  */

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Spanish language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the Spanish language keyboard.
  */

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Swedish language keyboard.
  */

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The input method (IME) for the Swedish language keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.services

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The input method (IME) for the Swedish language keyboard.
  */

--- a/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * This is the base composable for all the screens.
  */

--- a/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This is the base composable for all the screens.
  */

--- a/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This is the base composable for all the screens.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common

--- a/app/src/main/java/be/scri/ui/common/appcomponents/ActionBar.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/ActionBar.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 package be.scri.ui.common.appcomponents
 
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/be/scri/ui/common/appcomponents/ActionBar.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/ActionBar.kt
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.ui.common.appcomponents
 
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/be/scri/ui/common/appcomponents/ActionBar.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/ActionBar.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.ui.common.appcomponents
 
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.ui.common.appcomponents
 
 import android.content.Context

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.ui.common.appcomponents
 
 import android.content.Context

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 package be.scri.ui.common.appcomponents
 
 import android.content.Context

--- a/app/src/main/java/be/scri/ui/common/appcomponents/PageTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/PageTitle.kt
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.ui.common.appcomponents
 
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/be/scri/ui/common/appcomponents/PageTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/PageTitle.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 package be.scri.ui.common.appcomponents
 
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/be/scri/ui/common/appcomponents/PageTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/PageTitle.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 package be.scri.ui.common.appcomponents
 
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Provides items to the navigation bar.
  */

--- a/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Provides items to the navigation bar.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.bottombar

--- a/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Provides items to the navigation bar.
  */

--- a/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The bottom bar that is displayed at the bottom of the screen for navigation purposes.
  */

--- a/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The bottom bar that is displayed at the bottom of the screen for navigation purposes.
  */

--- a/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The bottom bar that is displayed at the bottom of the screen for navigation purposes.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.bottombar

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A composable component that displays a row with a title as well as leading and trailing icons.
  */

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A composable component that displays a row with a title as well as leading and trailing icons.
  */

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A composable component that displays a row with a title as well as leading and trailing icons.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.components

--- a/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  *  A composable component that displays a clickable item with a title, optional description and an arrow icon.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  *  A composable component that displays a clickable item with a title, optional description and an arrow icon.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  *  A composable component that displays a clickable item with a title, optional description and an arrow icon.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.components

--- a/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A composable function for a screen layout in the main activity.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A composable function for a screen layout in the main activity.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.components

--- a/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A composable function for a screen layout in the main activity.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  *  A composable function that displays a list of items inside a card container.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  *  A composable function that displays a list of items inside a card container.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.components

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  *  A composable function that displays a list of items inside a card container.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  *  A composable function that displays a title above a list of items inside a card container.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  *  A composable function that displays a title above a list of items inside a card container.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  *  A composable function that displays a title above a list of items inside a card container.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.components

--- a/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A composable component that displays a switch alongside a title and description.
  */

--- a/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A composable component that displays a switch alongside a title and description.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.common.components

--- a/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A composable component that displays a switch alongside a title and description.
  */

--- a/app/src/main/java/be/scri/ui/models/ScribeItem.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItem.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A class defining different types of items used in the application interface.
  */

--- a/app/src/main/java/be/scri/ui/models/ScribeItem.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItem.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A class defining different types of items used in the application interface.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.models

--- a/app/src/main/java/be/scri/ui/models/ScribeItem.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItem.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A class defining different types of items used in the application interface.
  */

--- a/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A class defining lists of ScribeItem elements.
  */

--- a/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A class defining lists of ScribeItem elements.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.models

--- a/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A class defining lists of ScribeItem elements.
  */

--- a/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The installation page of the application with details for installing Scribe keyboards and downloading data.
  */

--- a/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The installation page of the application with details for installing Scribe keyboards and downloading data.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens

--- a/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The installation page of the application with details for installing Scribe keyboards and downloading data.
  */

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The settings sub menu page for languages that allows for customization of language keyboard interfaces.
  */

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The settings sub menu page for languages that allows for customization of language keyboard interfaces.
  */

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The settings sub menu page for languages that allows for customization of language keyboard interfaces.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens

--- a/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The about screen that displays the privacy policy for the application.
  */

--- a/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about screen that displays the privacy policy for the application.
  */

--- a/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about screen that displays the privacy policy for the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens

--- a/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about screen to display third-party legal information for software used in the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens

--- a/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about screen to display third-party legal information for software used in the application.
  */

--- a/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The about screen to display third-party legal information for software used in the application.
  */

--- a/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about screen for describing the relationship between Scribe and the Wikimedia movement.
  */

--- a/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The about screen for describing the relationship between Scribe and the Wikimedia movement.
  */

--- a/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about screen for describing the relationship between Scribe and the Wikimedia movement.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens

--- a/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The about page of the application with links to the community as well as sub pages for detailed descriptions.
  */

--- a/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about page of the application with links to the community as well as sub pages for detailed descriptions.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens.about

--- a/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The about page of the application with links to the community as well as sub pages for detailed descriptions.
  */

--- a/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This file provide utility functions for the about page
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens.about

--- a/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This file provide utility functions for the about page
  */

--- a/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * This file provide utility functions for the about page
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The settings tab for the application including settings for language keyboards as sub menus.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The settings tab for the application including settings for language keyboards as sub menus.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens.settings

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The settings tab for the application including settings for language keyboards as sub menus.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This file provides utility functions for settings page.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This file provides utility functions for settings page.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens.settings

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * This file provides utility functions for settings page.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This files handles the state and business logic for the settings screen.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens.settings

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This files handles the state and business logic for the settings screen.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * This files handles the state and business logic for the settings screen.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This file provides context for the the viewmodel to change the settings.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.screens.settings

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This file provides context for the the viewmodel to change the settings.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * This file provides context for the the viewmodel to change the settings.
  */

--- a/app/src/main/java/be/scri/ui/theme/Colors.kt
+++ b/app/src/main/java/be/scri/ui/theme/Colors.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Custom colors for use throughout the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.theme

--- a/app/src/main/java/be/scri/ui/theme/Colors.kt
+++ b/app/src/main/java/be/scri/ui/theme/Colors.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Custom colors for use throughout the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/Colors.kt
+++ b/app/src/main/java/be/scri/ui/theme/Colors.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Custom colors for use throughout the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
+++ b/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Light and dark mode themes for the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
+++ b/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Light and dark mode themes for the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.theme

--- a/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
+++ b/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Light and dark mode themes for the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/Typography.kt
+++ b/app/src/main/java/be/scri/ui/theme/Typography.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Text styles for the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/Typography.kt
+++ b/app/src/main/java/be/scri/ui/theme/Typography.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * Text styles for the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/Typography.kt
+++ b/app/src/main/java/be/scri/ui/theme/Typography.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Text styles for the application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.ui.theme

--- a/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
+++ b/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * A custom divider for use in recycle views.
  */

--- a/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
+++ b/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A custom divider for use in recycle views.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import android.graphics.Canvas

--- a/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
+++ b/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A custom divider for use in recycle views.
  */

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 /**
  * The base keyboard view for Scribe language keyboards application.
  */

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The base keyboard view for Scribe language keyboards application.
  */

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The base keyboard view for Scribe language keyboards application.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package be.scri.views

--- a/app/src/test/kotlin/helpers/AlphanumericComparatorTest.kt
+++ b/app/src/test/kotlin/helpers/AlphanumericComparatorTest.kt
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Testing for AlphanumericComparator.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package helpers


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Replaced the existing license notice with the line: // SPDX-License-Identifier: AGPL-3.0-or-later to standardise license declarations across source files.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #301 
