### PR TITLE
fix(command-bar): move cursor to end of input after typing

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -82,6 +82,7 @@ abstract class GeneralKeyboardIME(
     var autosuggestEmojis: MutableList<String>? = null
     var nounTypeSuggestion: MutableList<String>? = null
     private var currentEnterKeyType: Int? = null
+    private val commandChar = "⎜"
     // abstract var keyboardViewKeyboardBinding : KeyboardViewKeyboardBinding
 
     protected var currentState: ScribeState = ScribeState.IDLE
@@ -689,6 +690,27 @@ abstract class GeneralKeyboardIME(
         }
     }
 
+    private fun handleCommandBarDelete(binding: KeyboardViewKeyboardBinding?) {
+        binding?.commandBar?.let { commandBar ->
+            var newText = ""
+            if (commandBar.text.length <= 2) {
+                binding.promptTextBorder?.visibility = View.VISIBLE
+                binding.commandBar.setPadding(
+                    binding.commandBar.paddingRight,
+                    binding.commandBar.paddingTop,
+                    binding.commandBar.paddingRight,
+                    binding.commandBar.paddingBottom,
+                )
+                if (language == "German" && this.currentState == ScribeState.PLURAL) {
+                    keyboard?.mShiftState = SHIFT_ON_ONE_CHAR
+                }
+            } else {
+                newText = "${commandBar.text.trim().dropLast(2)}$commandChar"
+            }
+            commandBar.text = newText
+        }
+    }
+
     fun handleDelete(
         currentState: Boolean? = false,
         binding: KeyboardViewKeyboardBinding? = null,
@@ -700,10 +722,7 @@ abstract class GeneralKeyboardIME(
         }
 
         if (currentState == true) {
-            binding?.commandBar?.let { commandBar ->
-                val newText = "${commandBar.text.trim().dropLast(1)}"
-                commandBar.text = newText
-            }
+            handleCommandBarDelete(binding)
         } else {
             val selectedText = inputConnection.getSelectedText(0)
             if (TextUtils.isEmpty(selectedText)) {
@@ -743,7 +762,16 @@ abstract class GeneralKeyboardIME(
 
         if (commandBarState) {
             binding?.commandBar?.let { commandBar ->
-                val newText = "${commandBar.text}$codeChar"
+                if (commandBar.text.isEmpty()) {
+                    binding.promptTextBorder?.visibility = View.GONE
+                    binding.commandBar.setPadding(
+                        0,
+                        binding.commandBar.paddingTop,
+                        binding.commandBar.paddingRight,
+                        binding.commandBar.paddingBottom,
+                    )
+                }
+                val newText = "${commandBar.text.trim().dropLast(1)}$codeChar$commandChar"
                 commandBar.text = newText
             }
         } else {

--- a/app/src/main/res/layout/keyboard_view_keyboard.xml
+++ b/app/src/main/res/layout/keyboard_view_keyboard.xml
@@ -53,16 +53,19 @@
             app:layout_constraintStart_toEndOf="@+id/scribe_key"
             app:layout_constraintTop_toTopOf="@+id/command_field" />
 
-        <View
+        <TextView
             android:id="@+id/prompt_text_border"
-            android:layout_width="1.5dp"
+            android:layout_width="wrap_content"
             android:layout_height="0dp"
-            android:background="@android:color/black"
-            app:layout_constraintTop_toTopOf="@+id/prompt_text"
+            android:background="@drawable/cmd_bar_prompt_background"
+            android:text="⎜"
+            android:textFontWeight="500"
+            android:textSize="16sp"
+            app:layout_constraintBaseline_toBaselineOf="@+id/command_bar"
             app:layout_constraintBottom_toBottomOf="@+id/prompt_text"
-            app:layout_constraintHeight_percent="0.5"
-            app:layout_constraintEnd_toEndOf="@+id/prompt_text"
-            app:layout_constraintHorizontal_bias="1.0" />
+            app:layout_constraintEnd_toStartOf="@+id/command_bar"
+            app:layout_constraintStart_toEndOf="@+id/prompt_text"
+            app:layout_constraintTop_toTopOf="@+id/prompt_text" />
 
 
         <Button


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This commit addresses issue #286 by improving the cursor behavior within the command bar.

Previously, the cursor remained fixed after the command prompt, even as the user typed input. This has been corrected so that the cursor now dynamically moves to the end of the input text as the user types, providing a more intuitive and user-friendly experience.

### Related issue
-   #286 
