### PR TITLE
Fix initial state (on app install) of dark mode toggle.

### DIFF
--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -123,6 +123,9 @@ object PreferencesHelper {
         val uiModeManager = context.getSystemService(UI_MODE_SERVICE) as UiModeManager
         val isSystemDarkTheme = uiModeManager.nightMode == UiModeManager.MODE_NIGHT_YES
         val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkTheme)
+        if (!sharedPref.contains("dark_mode")) {
+            setLightDarkModePreference(context, isUserDarkMode)
+        }
         return if (isUserDarkMode) {
             AppCompatDelegate.MODE_NIGHT_YES
         } else {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Correct the initial state of the dark mode toggle button to match the device's system dark mode preference on first launch.

Tested on device with both dark mode and light mode enabled in system settings and verified that the dark mode toggle button now correctly matches the system preference on app launch.
Also tested that the toggle button updates when the user changes the dark mode setting within the app.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #295 
