### PR TITLE
Fix Command Bar Spacebar Input & Implement Plural Command

### DIFF
--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -6,6 +6,7 @@
 
 package be.scri.helpers
 
+import DataContract
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
@@ -60,5 +61,15 @@ class DatabaseHelper(
         dbManagers.pluralManager.checkIfWordIsPlural(
             language,
             getRequiredData(language),
+        )
+
+    fun getPluralRepresentation(
+        language: String,
+        noun: String,
+    ): Map<String, String?> =
+        dbManagers.pluralManager.queryPluralRepresentation(
+            language,
+            getRequiredData(language),
+            noun,
         )
 }

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -87,8 +87,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -132,6 +131,17 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -83,8 +83,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -127,6 +126,17 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -175,16 +175,18 @@ abstract class GeneralKeyboardIME(
     }
 
     override fun commitPeriodAfterSpace() {
-        if (getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-                .getBoolean("period_on_double_tap_$language", true)
-        ) {
-            val inputConnection = currentInputConnection ?: return
-            inputConnection.deleteSurroundingText(1, 0)
-            inputConnection.commitText(". ", 1)
-        } else {
-            val inputConnection = currentInputConnection ?: return
-            inputConnection.deleteSurroundingText(1, 0)
-            inputConnection.commitText("  ", 1)
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            if (getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+                    .getBoolean("period_on_double_tap_$language", true)
+            ) {
+                val inputConnection = currentInputConnection ?: return
+                inputConnection.deleteSurroundingText(1, 0)
+                inputConnection.commitText(". ", 1)
+            } else {
+                val inputConnection = currentInputConnection ?: return
+                inputConnection.deleteSurroundingText(1, 0)
+                inputConnection.commitText("  ", 1)
+            }
         }
     }
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -617,6 +617,13 @@ abstract class GeneralKeyboardIME(
         inputConnection.commitText(emoji, 1)
     }
 
+    private fun getPluralRepresentation(word: String?): String? {
+        if (word.isNullOrEmpty()) return null
+        val languageAlias = getLanguageAlias(language)
+        val pluralRepresentationMap = dbHelper.getPluralRepresentation(languageAlias, word)
+        return pluralRepresentationMap.values.filterNotNull().firstOrNull()
+    }
+
     override fun onPress(primaryCode: Int) {
         if (primaryCode != 0) {
             keyboardView?.vibrateIfNeeded()
@@ -754,7 +761,19 @@ abstract class GeneralKeyboardIME(
         val imeOptionsActionId = getImeOptionsActionId()
 
         if (commandBarState == true) {
-            inputConnection.commitText(binding?.commandBar?.text.toString(), 1)
+            val commandBarInput =
+                binding
+                    ?.commandBar
+                    ?.text
+                    .toString()
+                    .trim()
+                    .dropLast(1)
+            lateinit var commandModeOutput: String
+            when (currentState) {
+                ScribeState.PLURAL -> commandModeOutput = getPluralRepresentation(commandBarInput) ?: ""
+                else -> commandModeOutput = commandBarInput
+            }
+            inputConnection.commitText(commandModeOutput, 1)
             binding?.commandBar?.text = ""
         } else {
             if (imeOptionsActionId != IME_ACTION_NONE) {

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -91,8 +91,7 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -135,6 +134,17 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -83,8 +83,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -127,6 +126,17 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -83,8 +83,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -127,6 +126,17 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -83,8 +83,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -127,6 +126,17 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -87,8 +87,7 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -131,6 +130,17 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -87,8 +87,7 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
             }
 
             KeyboardBase.KEYCODE_SPACE -> {
-                handleElseCondition(code, keyboardMode, binding = null)
-                updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+                handleKeycodeSpace()
             }
 
             else -> {
@@ -131,6 +130,17 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             updateUI()
+        }
+    }
+
+    fun handleKeycodeSpace() {
+        val code = KeyboardBase.KEYCODE_SPACE
+        if (currentState == ScribeState.IDLE || currentState == ScribeState.SELECT_COMMAND) {
+            handleElseCondition(code, keyboardMode, binding = null)
+            updateAutoSuggestText(isPlural = checkIfPluralWord, nounTypeSuggestion = nounTypeSuggestion)
+        } else {
+            handleElseCondition(code, keyboardMode, keyboardBinding, commandBarState = true)
+            disableAutoSuggest()
         }
     }
 


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
This Pull Request addresses two key issues:

1. **Fixes incorrect spacebar behavior in command mode:**
    - Previously, pressing the spacebar in command mode would incorrectly add `spaces` to the main input connection instead of the command bar input.
    - This fix ensures that `spaces` are correctly added to the command bar, enabling users to enter multi-word commands as expected. This is crucial for supporting commands with multi-word lexemes.

2. I**mplements the plural command functionality:**

    This feature allows users to insert a plural form of the noun entered in the command bar using the Enter key.

    - The plural form of the noun is first retrieved from the language database using Data Contracts.
    - Then, the plural form of the noun is inserted into the input connection.
    - Finally, the keyboard is switched to Idle mode.

### Related issue
-   #272 
