### PR TITLE
Move the Vibrate on Keypress and Show Popup on keypress to Language settings 

### DIFF
--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -88,23 +88,39 @@ object PreferencesHelper {
 
     fun setVibrateOnKeypress(
         context: Context,
+        language: String,
         shouldVibrateOnKeypress: Boolean,
     ) {
         val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val editor = sharedPref.edit()
-        editor.putBoolean("vibrate_on_keypress", shouldVibrateOnKeypress)
+        editor.putBoolean("vibrate_on_keypress_$language", shouldVibrateOnKeypress)
         editor.apply()
+        Toast
+            .makeText(
+                context,
+                "$language vibrate on key press " +
+                    if (shouldVibrateOnKeypress) "enabled" else "disabled",
+                Toast.LENGTH_SHORT,
+            ).show()
         context.config.vibrateOnKeypress = shouldVibrateOnKeypress
     }
 
     fun setShowPopupOnKeypress(
         context: Context,
+        language: String,
         shouldShowPopupOnKeypress: Boolean,
     ) {
         val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
         val editor = sharedPref.edit()
-        editor.putBoolean("show_popup_on_keypress", shouldShowPopupOnKeypress)
+        editor.putBoolean("show_popup_on_keypress_$language", shouldShowPopupOnKeypress)
         editor.apply()
+        Toast
+            .makeText(
+                context,
+                "$language PopUp on Keypress " +
+                    if (shouldShowPopupOnKeypress) "enabled" else "disabled",
+                Toast.LENGTH_SHORT,
+            ).show()
         context.config.showPopupOnKeypress = shouldShowPopupOnKeypress
     }
 

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -43,6 +43,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
         val keyboardHolder = binding.root
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         when (currentState) {
             ScribeState.IDLE -> keyboardView!!.setEnterKeyColor(null)
             else -> keyboardView!!.setEnterKeyColor(R.color.dark_scribe_blue)

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -44,6 +44,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         when (currentState) {
             ScribeState.IDLE -> keyboardView!!.setEnterKeyColor(null)
             else -> keyboardView!!.setEnterKeyColor(R.color.dark_scribe_blue)

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -43,6 +43,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -42,6 +42,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
         Log.i("MY-TAG", "From French Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -355,7 +355,7 @@ abstract class GeneralKeyboardIME(
         binding.separator3.visibility = View.VISIBLE
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
-
+            disableAutoSuggest()
             updateButtonVisibility(false)
             Log.i("MY-TAG", "SELECT COMMAND STATE")
             binding.scribeKey.foreground = AppCompatResources.getDrawable(this, R.drawable.close)
@@ -420,6 +420,7 @@ abstract class GeneralKeyboardIME(
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")
             binding.translateBtn.setTextColor(Color.WHITE)
+            disableAutoSuggest()
             binding.scribeKey.foreground = AppCompatResources.getDrawable(this, R.drawable.ic_scribe_icon_vector)
             updateUI()
         }
@@ -874,6 +875,10 @@ abstract class GeneralKeyboardIME(
         binding.translateBtn.setTextColor(getColor(R.color.special_key_dark))
         binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
         handleTextSizeForSuggestion(binding)
+        if (currentState == ScribeState.SELECT_COMMAND) {
+            setupIdleView()
+            setupSelectCommandView()
+        }
     }
 
     fun handleTextSizeForSuggestion(binding: KeyboardViewCommandOptionsBinding) {

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -171,6 +171,12 @@ abstract class GeneralKeyboardIME(
         return isAccentCharacterDisabled
     }
 
+    fun getIsPreviewEmabled(): Boolean {
+        val sharedPref = getSharedPreferences("app_preferences", MODE_PRIVATE)
+        val isPreviewEnabled = sharedPref.getBoolean("show_popup_on_keypress_$language", false)
+        return isPreviewEnabled
+    }
+
     fun getEnablePeriodAndCommaABC(): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", MODE_PRIVATE)
         val isDisabledPeriodAndCommaABC = sharedPref.getBoolean("period_and_comma_$language", false)

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -173,7 +173,13 @@ abstract class GeneralKeyboardIME(
 
     fun getIsPreviewEmabled(): Boolean {
         val sharedPref = getSharedPreferences("app_preferences", MODE_PRIVATE)
-        val isPreviewEnabled = sharedPref.getBoolean("show_popup_on_keypress_$language", false)
+        val isPreviewEnabled = sharedPref.getBoolean("show_popup_on_keypress_$language", true)
+        return isPreviewEnabled
+    }
+
+    fun getIsVibrateEnabled(): Boolean {
+        val sharedPref = getSharedPreferences("app_preferences", MODE_PRIVATE)
+        val isPreviewEnabled = sharedPref.getBoolean("vibrate_on_keypress_$language", true)
         return isPreviewEnabled
     }
 

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -48,6 +48,7 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         keyboardView!!.setKeyboard(keyboard!!)
 
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         when (currentState) {
             ScribeState.IDLE -> keyboardView!!.setEnterKeyColor(null)
             else -> keyboardView!!.setEnterKeyColor(R.color.dark_scribe_blue)

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -46,6 +46,8 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         Log.i("MY-TAG", "From German Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         when (currentState) {
             ScribeState.IDLE -> keyboardView!!.setEnterKeyColor(null)
             else -> keyboardView!!.setEnterKeyColor(R.color.dark_scribe_blue)

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -43,6 +43,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         keyboardView!!.setKeyboardHolder()
         setupCommandBarTheme(binding)
         keyboardView!!.mOnKeyboardActionListener = this

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -42,6 +42,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
         Log.i("MY-TAG", "From Italian Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         keyboardView!!.setKeyboardHolder()
         setupCommandBarTheme(binding)
         keyboardView!!.mOnKeyboardActionListener = this

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -45,6 +45,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
         setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         keyboardView!!.mOnKeyboardActionListener = this
         initializeEmojiButtons()
         updateUI()

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -44,6 +44,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
         keyboardView!!.setKeyboard(keyboard!!)
         setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder()
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         keyboardView!!.mOnKeyboardActionListener = this
         initializeEmojiButtons()
         updateUI()

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -43,6 +43,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -42,6 +42,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
         Log.i("MY-TAG", "From Russian Keyboard IME")
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         setupCommandBarTheme(binding)
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -47,6 +47,7 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         setupCommandBarTheme(binding)
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this
         initializeEmojiButtons()

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -48,6 +48,7 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         keyboardView!!.setKeyboard(keyboard!!)
         setupCommandBarTheme(binding)
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this
         initializeEmojiButtons()

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -48,6 +48,7 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         keyboardView!!.setKeyboard(keyboard!!)
         setupCommandBarTheme(binding)
         keyboardView!!.setPreview = getIsPreviewEmabled()
+        keyboardView!!.setVibrate = getIsVibrateEnabled()
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this
         initializeEmojiButtons()

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -47,6 +47,7 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         keyboardView = binding.keyboardView
         keyboardView!!.setKeyboard(keyboard!!)
         setupCommandBarTheme(binding)
+        keyboardView!!.setPreview = getIsPreviewEmabled()
         keyboardView!!.setKeyboardHolder()
         keyboardView!!.mOnKeyboardActionListener = this
         initializeEmojiButtons()

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -70,6 +70,29 @@ fun LanguageSettingsScreen(
             )
         }
 
+
+    val popupOnKeyPressState =
+        remember {
+            mutableStateOf(
+                sharedPref.getBoolean(
+                    "popup_on_keypress_$language",
+                    false
+                )
+            )
+        }
+
+    val vibrateOnKeyPressState =
+        remember {
+            mutableStateOf(
+                sharedPref.getBoolean(
+                    "vibrate_on_keypress_$language",
+                    false
+                )
+            )
+        }
+
+
+
     val periodAndCommaState =
         remember {
             if (!sharedPref.contains("period_and_comma_$language")) {
@@ -106,6 +129,7 @@ fun LanguageSettingsScreen(
                             shouldDisableAccentCharacter,
                         )
                     },
+
                 ),
         )
     val functionalityList =
@@ -128,6 +152,24 @@ fun LanguageSettingsScreen(
                             context,
                             language,
                             shouldDoubleSpacePeriod,
+                        )
+                    },
+                    togglePopUpOnKeyPress = popupOnKeyPressState.value,
+                    onTogglePopUpOnKeyPress = { shouldDisablePopUpOnKeyPress ->
+                        popupOnKeyPressState.value = shouldDisablePopUpOnKeyPress
+                        PreferencesHelper.setShowPopupOnKeypress(
+                            context,
+                            language,
+                            shouldDisablePopUpOnKeyPress
+                        )
+                    },
+                    toggleVibrateOnKeyPress = vibrateOnKeyPressState.value,
+                    onToggleVibrateOnKeyPress = { shouldVibrateOnKeyPress ->
+                        vibrateOnKeyPressState.value = shouldVibrateOnKeyPress
+                        PreferencesHelper.setVibrateOnKeypress(
+                            context,
+                            language,
+                            shouldVibrateOnKeyPress
                         )
                     },
                 ),
@@ -168,6 +210,10 @@ private fun getFunctionalityListData(
     onTogglePeriodOnDoubleTap: (Boolean) -> Unit,
     emojiSuggestionsState: Boolean,
     onToggleEmojiSuggestions: (Boolean) -> Unit,
+    togglePopUpOnKeyPress: Boolean,
+    onTogglePopUpOnKeyPress: (Boolean) -> Unit ,
+    toggleVibrateOnKeyPress : Boolean,
+    onToggleVibrateOnKeyPress: (Boolean) -> Unit
 ): List<ScribeItem> {
     val list =
         listOf(
@@ -183,8 +229,19 @@ private fun getFunctionalityListData(
                 state = emojiSuggestionsState,
                 onToggle = onToggleEmojiSuggestions,
             ),
+            ScribeItem.SwitchItem(
+                title = R.string.app_settings_keyboard_keypress_vibration,
+                desc =  R.string.app_settings_keyboard_keypress_vibration_description,
+                state = toggleVibrateOnKeyPress,
+                onToggle = onToggleVibrateOnKeyPress
+            ),
+            ScribeItem.SwitchItem(
+                title = R.string.app_settings_keyboard_functionality_popup_on_keypress,
+                desc =  R.string.app_settings_keyboard_functionality_popup_on_keypress_description,
+                state = togglePopUpOnKeyPress,
+                onToggle = onTogglePopUpOnKeyPress
+            )
         )
-
     return list
 }
 

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -70,14 +70,13 @@ fun LanguageSettingsScreen(
             )
         }
 
-
     val popupOnKeyPressState =
         remember {
             mutableStateOf(
                 sharedPref.getBoolean(
                     "popup_on_keypress_$language",
-                    false
-                )
+                    true,
+                ),
             )
         }
 
@@ -86,12 +85,10 @@ fun LanguageSettingsScreen(
             mutableStateOf(
                 sharedPref.getBoolean(
                     "vibrate_on_keypress_$language",
-                    false
-                )
+                    true,
+                ),
             )
         }
-
-
 
     val periodAndCommaState =
         remember {
@@ -129,7 +126,6 @@ fun LanguageSettingsScreen(
                             shouldDisableAccentCharacter,
                         )
                     },
-
                 ),
         )
     val functionalityList =
@@ -160,7 +156,7 @@ fun LanguageSettingsScreen(
                         PreferencesHelper.setShowPopupOnKeypress(
                             context,
                             language,
-                            shouldDisablePopUpOnKeyPress
+                            shouldDisablePopUpOnKeyPress,
                         )
                     },
                     toggleVibrateOnKeyPress = vibrateOnKeyPressState.value,
@@ -169,7 +165,7 @@ fun LanguageSettingsScreen(
                         PreferencesHelper.setVibrateOnKeypress(
                             context,
                             language,
-                            shouldVibrateOnKeyPress
+                            shouldVibrateOnKeyPress,
                         )
                     },
                 ),
@@ -211,9 +207,9 @@ private fun getFunctionalityListData(
     emojiSuggestionsState: Boolean,
     onToggleEmojiSuggestions: (Boolean) -> Unit,
     togglePopUpOnKeyPress: Boolean,
-    onTogglePopUpOnKeyPress: (Boolean) -> Unit ,
-    toggleVibrateOnKeyPress : Boolean,
-    onToggleVibrateOnKeyPress: (Boolean) -> Unit
+    onTogglePopUpOnKeyPress: (Boolean) -> Unit,
+    toggleVibrateOnKeyPress: Boolean,
+    onToggleVibrateOnKeyPress: (Boolean) -> Unit,
 ): List<ScribeItem> {
     val list =
         listOf(
@@ -231,16 +227,16 @@ private fun getFunctionalityListData(
             ),
             ScribeItem.SwitchItem(
                 title = R.string.app_settings_keyboard_keypress_vibration,
-                desc =  R.string.app_settings_keyboard_keypress_vibration_description,
+                desc = R.string.app_settings_keyboard_keypress_vibration_description,
                 state = toggleVibrateOnKeyPress,
-                onToggle = onToggleVibrateOnKeyPress
+                onToggle = onToggleVibrateOnKeyPress,
             ),
             ScribeItem.SwitchItem(
                 title = R.string.app_settings_keyboard_functionality_popup_on_keypress,
-                desc =  R.string.app_settings_keyboard_functionality_popup_on_keypress_description,
+                desc = R.string.app_settings_keyboard_functionality_popup_on_keypress_description,
                 state = togglePopUpOnKeyPress,
-                onToggle = onTogglePopUpOnKeyPress
-            )
+                onToggle = onTogglePopUpOnKeyPress,
+            ),
         )
     return list
 }

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
@@ -92,22 +92,6 @@ fun SettingsScreen(
                             onDarkModeChange(newDarkMode)
                         },
                     ),
-                    ScribeItem.SwitchItem(
-                        title = R.string.app_settings_keyboard_keypress_vibration,
-                        desc = R.string.app_settings_keyboard_keypress_vibration_description,
-                        state = vibrateOnKeypress,
-                        onToggle = { shouldVibrateOnKeypress ->
-                            viewModel.setVibrateOnKeypress(context, shouldVibrateOnKeypress)
-                        },
-                    ),
-                    ScribeItem.SwitchItem(
-                        title = R.string.app_settings_keyboard_functionality_popup_on_keypress,
-                        desc = R.string.app_settings_keyboard_functionality_popup_on_keypress_description,
-                        state = popupOnKeypress,
-                        onToggle = { shouldPopUpOnKeypress ->
-                            viewModel.setPopupOnKeypress(context, shouldPopUpOnKeypress)
-                        },
-                    ),
                 ),
         )
 

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
@@ -44,22 +44,6 @@ class SettingsViewModel(
         _isKeyboardInstalled.value = SettingsUtil.checkKeyboardInstallation(context)
     }
 
-    fun setVibrateOnKeypress(
-        context: Context,
-        value: Boolean,
-    ) {
-        _vibrateOnKeypress.value = value
-        PreferencesHelper.setVibrateOnKeypress(context, value)
-    }
-
-    fun setPopupOnKeypress(
-        context: Context,
-        value: Boolean,
-    ) {
-        _popupOnKeypress.value = value
-        PreferencesHelper.setShowPopupOnKeypress(context, value)
-    }
-
     fun setLightDarkMode(value: Boolean) {
         _isUserDarkMode.value = value
     }

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
@@ -9,7 +9,6 @@ package be.scri.ui.screens.settings
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import be.scri.helpers.PreferencesHelper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -271,6 +271,11 @@ class KeyboardView
                 return _popupBinding!!
             }
 
+
+        var setPreview: Boolean = true
+
+
+
         fun setEnterKeyColor(
             color: Int? = null,
             isDarkMode: Boolean? = null,
@@ -810,7 +815,7 @@ class KeyboardView
         }
 
         private fun showPreview(keyIndex: Int) {
-            if (!context.config.showPopupOnKeypress) {
+            if (!setPreview) {
                 return
             }
 

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -271,10 +271,8 @@ class KeyboardView
                 return _popupBinding!!
             }
 
-
         var setPreview: Boolean = true
-
-
+        var setVibrate: Boolean = true
 
         fun setEnterKeyColor(
             color: Int? = null,
@@ -490,7 +488,7 @@ class KeyboardView
         }
 
         fun vibrateIfNeeded() {
-            if (context.config.vibrateOnKeypress) {
+            if (setVibrate) {
                 performHapticFeedback()
             }
         }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR moves the vibrate on keypress and show pop up on keypress to the respective language keyboard settings. The PR also fixes the disabling for the popup on keypress and it was currently not working.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #141 
