### PR TITLE
Added translation source language option to language setting screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -194,7 +194,7 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("androidx.viewpager2:viewpager2:1.1.0")
-    implementation("com.google.android.play:core:1.10.0")
+    implementation("com.google.android.play:core:1.10.3")
     implementation("androidx.navigation:navigation-compose:2.6.0")
 
     // Jetpack Compose BOM

--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -31,6 +31,7 @@ import be.scri.ui.common.bottombar.ScribeBottomBar
 import be.scri.ui.screens.InstallationScreen
 import be.scri.ui.screens.LanguageSettingsScreen
 import be.scri.ui.screens.PrivacyPolicyScreen
+import be.scri.ui.screens.SelectTranslationSourceLanguageScreen
 import be.scri.ui.screens.ThirdPartyScreen
 import be.scri.ui.screens.WikimediaScreen
 import be.scri.ui.screens.about.AboutScreen
@@ -170,9 +171,7 @@ fun ScribeApp(
                     }
                 }
 
-                composable(
-                    route = "${Screen.LanguageSettings.route}/{languageName}",
-                ) {
+                composable("${Screen.LanguageSettings.route}/{languageName}") {
                     val language = it.arguments?.getString("languageName")
                     if (language != null) {
                         LanguageSettingsScreen(
@@ -181,9 +180,24 @@ fun ScribeApp(
                                 navController.popBackStack()
                             },
                             modifier = Modifier.padding(innerPadding),
+                            onTranslationLanguageSelect = {
+                                navController.navigate("translation_language_detail/$language")
+                            }
                         )
                     }
                 }
+
+                composable("translation_language_detail" + "/{languageName}") { backStackEntry ->
+                    val language = backStackEntry.arguments?.getString("languageName") ?: ""
+                    SelectTranslationSourceLanguageScreen(
+                        onBackNavigation = {
+                            navController.popBackStack()
+                        },
+                        modifier = Modifier.padding(innerPadding),
+                        currentLanguage = language,
+                    )
+                }
+
 
                 composable(Screen.WikimediaScribe.route) {
                     WikimediaScreen(

--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -182,7 +182,7 @@ fun ScribeApp(
                             modifier = Modifier.padding(innerPadding),
                             onTranslationLanguageSelect = {
                                 navController.navigate("translation_language_detail/$language")
-                            }
+                            },
                         )
                     }
                 }
@@ -197,7 +197,6 @@ fun ScribeApp(
                         currentLanguage = language,
                     )
                 }
-
 
                 composable(Screen.WikimediaScribe.route) {
                     WikimediaScreen(

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -13,10 +13,28 @@ import android.content.res.Configuration
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity.UI_MODE_SERVICE
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.edit
 import be.scri.extensions.config
 
 @Suppress("TooManyFunctions")
 object PreferencesHelper {
+    fun setTranslationSourceLanguage(
+        context: Context,
+        language: String,
+        translationSource: String,
+    ) {
+        val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        sharedPref.edit { putString("translation_source_$language", translationSource) }
+    }
+
+    fun getTranslationSourceLanguage(
+        context: Context,
+        language: String,
+    ): String {
+        val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        return sharedPref.getString("translation_source_$language", "English") ?: "English"
+    }
+
     fun setPeriodOnSpaceBarDoubleTapPreference(
         context: Context,
         language: String,

--- a/app/src/main/java/be/scri/navigation/Screen.kt
+++ b/app/src/main/java/be/scri/navigation/Screen.kt
@@ -18,4 +18,6 @@ sealed class Screen(
     data object WikimediaScribe : Screen("wikimedia_scribe_screen")
 
     data object ThirdParty : Screen("third_party_screen")
+
+    data object TranslationSource : Screen("select_language_screen")
 }

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -8,6 +8,7 @@ package be.scri.ui.screens
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -30,11 +31,7 @@ import be.scri.ui.models.ScribeItemList
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun LanguageSettingsScreen(
-    language: String,
-    onBackNavigation: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
+fun LanguageSettingsScreen(language: String, onBackNavigation: () -> Unit, onTranslationLanguageSelect: () -> Unit, modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
 
@@ -103,13 +100,12 @@ fun LanguageSettingsScreen(
             )
         }
 
-    val onTranslationLanguageSelect = {}
 
     val translationSourceLanguageList =
         ScribeItemList(
             items =
                 getTranslationSourceLanguageListData {
-                    onTranslationLanguageSelect
+                    onTranslationLanguageSelect()
                 },
         )
 
@@ -311,8 +307,12 @@ private fun getTranslationSourceLanguageListData(onTranslationLanguageSelect: ()
         ScribeItem.ClickableItem(
             title = R.string.app_settings_keyboard_translation_select_source,
             desc = R.string.translation_source_language_description,
-            action = onTranslationLanguageSelect,
-        ),
+            action = {
+                Log.d("Navigation", "onTranslationLanguageSelect clicked")
+                onTranslationLanguageSelect()
+            }
+        )
+
     )
 
     return list

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -31,7 +31,12 @@ import be.scri.ui.models.ScribeItemList
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun LanguageSettingsScreen(language: String, onBackNavigation: () -> Unit, onTranslationLanguageSelect: () -> Unit, modifier: Modifier = Modifier) {
+fun LanguageSettingsScreen(
+    language: String,
+    onBackNavigation: () -> Unit,
+    onTranslationLanguageSelect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
     val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
 
@@ -99,7 +104,6 @@ fun LanguageSettingsScreen(language: String, onBackNavigation: () -> Unit, onTra
                 ),
             )
         }
-
 
     val translationSourceLanguageList =
         ScribeItemList(
@@ -189,7 +193,7 @@ fun LanguageSettingsScreen(language: String, onBackNavigation: () -> Unit, onTra
                     .verticalScroll(scrollState),
         ) {
             ItemCardContainerWithTitle(
-                title = stringResource(R.string.translation_source_language_title),
+                title = stringResource(R.string.app_settings_keyboard_translation_select_source),
                 cardItemsList = translationSourceLanguageList,
             )
             ItemCardContainerWithTitle(
@@ -306,13 +310,12 @@ private fun getTranslationSourceLanguageListData(onTranslationLanguageSelect: ()
     list.add(
         ScribeItem.ClickableItem(
             title = R.string.app_settings_keyboard_translation_select_source,
-            desc = R.string.translation_source_language_description,
+            desc = R.string.app_settings_keyboard_translation_select_source_description,
             action = {
                 Log.d("Navigation", "onTranslationLanguageSelect clicked")
                 onTranslationLanguageSelect()
-            }
-        )
-
+            },
+        ),
     )
 
     return list

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -103,6 +103,16 @@ fun LanguageSettingsScreen(
             )
         }
 
+    val onTranslationLanguageSelect = {}
+
+    val translationSourceLanguageList =
+        ScribeItemList(
+            items =
+                getTranslationSourceLanguageListData {
+                    onTranslationLanguageSelect
+                },
+        )
+
     val layoutList =
         ScribeItemList(
             items =
@@ -182,6 +192,10 @@ fun LanguageSettingsScreen(
                 Modifier
                     .verticalScroll(scrollState),
         ) {
+            ItemCardContainerWithTitle(
+                title = stringResource(R.string.translation_source_language_title),
+                cardItemsList = translationSourceLanguageList,
+            )
             ItemCardContainerWithTitle(
                 title = stringResource(R.string.app_settings_keyboard_layout_title),
                 cardItemsList = layoutList,
@@ -288,4 +302,18 @@ fun getLanguageStringFromi18n(language: String): Int {
             "Swedish" to R.string.app__global_swedish,
         )
     return languageMap[language] ?: R.string.app__global_english
+}
+
+@Composable
+private fun getTranslationSourceLanguageListData(onTranslationLanguageSelect: () -> Unit): List<ScribeItem> {
+    val list: MutableList<ScribeItem> = mutableListOf()
+    list.add(
+        ScribeItem.ClickableItem(
+            title = R.string.app_settings_keyboard_translation_select_source,
+            desc = R.string.translation_source_language_description,
+            action = onTranslationLanguageSelect,
+        ),
+    )
+
+    return list
 }

--- a/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
@@ -1,85 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * The Select Languages subpage is for selecting the translation source language.
+ */
 package be.scri.ui.screens
 
 import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.edit
 import be.scri.R
 import be.scri.ui.common.ScribeBaseScreen
-import androidx.core.content.edit
 
 @Composable
 fun SelectTranslationSourceLanguageScreen(
     currentLanguage: String,
     onBackNavigation: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-    var selectedLanguage by remember {
-        mutableStateOf(sharedPref.getString("translation_source_$currentLanguage", "English") ?: "English")
-    }
+    var selectedLanguage =
+        remember {
+            mutableStateOf(sharedPref.getString("translation_source_$currentLanguage", "English") ?: "English")
+        }
 
     val scrollState = rememberScrollState()
-    val options = listOf("English", "German", "French", "Spanish", "Italian", "Russian", "Portuguese", "Swedish")
-        .filterNot { it == getDisplayLanguageName(currentLanguage) }
+    val options =
+        listOf("English", "German", "French", "Spanish", "Italian", "Russian", "Portuguese", "Swedish")
+            .filterNot { it == getDisplayLanguageName(currentLanguage) }
     ScribeBaseScreen(
         pageTitle = stringResource(R.string.app_settings_keyboard_translation_select_source_title),
-        lastPage = stringResource(id = getLanguageStringFromi18n(currentLanguage)), 
+        lastPage = stringResource(id = getLanguageStringFromi18n(currentLanguage)),
         onBackNavigation = onBackNavigation,
         modifier = modifier,
     ) {
         Column(
-            modifier = Modifier
-                .padding(16.dp)
-                .verticalScroll(scrollState)
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .padding(16.dp)
+                    .verticalScroll(scrollState)
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             Text(
                 text = stringResource(R.string.app_settings_keyboard_translation_select_source_caption),
                 style = MaterialTheme.typography.headlineMedium,
-                modifier = Modifier.padding(bottom = 12.dp)
+                modifier = Modifier.padding(bottom = 12.dp),
             )
 
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(10.dp),
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
             ) {
                 Column(modifier = Modifier.padding(8.dp)) {
                     options.forEachIndexed { index, option ->
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    selectedLanguage = option
-                                    sharedPref.edit { putString("translation_source_$currentLanguage", option) }
-                                }
-                                .padding(vertical = 5.dp, horizontal = 8.dp)
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        selectedLanguage.value = option
+                                        sharedPref.edit { putString("translation_source_$currentLanguage", option) }
+                                    }.padding(vertical = 5.dp, horizontal = 8.dp),
                         ) {
                             Text(
                                 text = getDisplayLanguageName(option),
-                                style = MaterialTheme.typography.bodyLarge
+                                style = MaterialTheme.typography.bodyLarge,
                             )
                             Spacer(modifier = Modifier.weight(1f))
                             RadioButton(
-                                selected = (option == selectedLanguage),
+                                selected = (option == selectedLanguage.value),
                                 onClick = {
-                                    selectedLanguage = option
+                                    selectedLanguage.value = option
                                     sharedPref.edit { putString("translation_source_$currentLanguage", option) }
-                                }
+                                },
                             )
                         }
 
@@ -89,14 +108,13 @@ fun SelectTranslationSourceLanguageScreen(
                     }
                 }
             }
-
         }
     }
 }
 
 @Composable
-private fun getDisplayLanguageName(language: String): String {
-    return when (language) {
+private fun getDisplayLanguageName(language: String): String =
+    when (language) {
         "English" -> stringResource(R.string.app__global_english)
         "German" -> stringResource(R.string.app__global_german)
         "French" -> stringResource(R.string.app__global_french)
@@ -107,4 +125,3 @@ private fun getDisplayLanguageName(language: String): String {
         "Swedish" -> stringResource(R.string.app__global_swedish)
         else -> language
     }
-}

--- a/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
@@ -1,0 +1,110 @@
+package be.scri.ui.screens
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import be.scri.R
+import be.scri.ui.common.ScribeBaseScreen
+import androidx.core.content.edit
+
+@Composable
+fun SelectTranslationSourceLanguageScreen(
+    currentLanguage: String,
+    onBackNavigation: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+    var selectedLanguage by remember {
+        mutableStateOf(sharedPref.getString("translation_source_$currentLanguage", "English") ?: "English")
+    }
+
+    val scrollState = rememberScrollState()
+    val options = listOf("English", "German", "French", "Spanish", "Italian", "Russian", "Portuguese", "Swedish")
+        .filterNot { it == getDisplayLanguageName(currentLanguage) }
+    ScribeBaseScreen(
+        pageTitle = stringResource(R.string.app_settings_keyboard_translation_select_source_title),
+        lastPage = stringResource(id = getLanguageStringFromi18n(currentLanguage)), 
+        onBackNavigation = onBackNavigation,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .verticalScroll(scrollState)
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            Text(
+                text = stringResource(R.string.app_settings_keyboard_translation_select_source_caption),
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(10.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            ) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    options.forEachIndexed { index, option ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    selectedLanguage = option
+                                    sharedPref.edit { putString("translation_source_$currentLanguage", option) }
+                                }
+                                .padding(vertical = 5.dp, horizontal = 8.dp)
+                        ) {
+                            Text(
+                                text = getDisplayLanguageName(option),
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            RadioButton(
+                                selected = (option == selectedLanguage),
+                                onClick = {
+                                    selectedLanguage = option
+                                    sharedPref.edit { putString("translation_source_$currentLanguage", option) }
+                                }
+                            )
+                        }
+
+                        if (index < options.lastIndex) {
+                            Divider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+}
+
+@Composable
+private fun getDisplayLanguageName(language: String): String {
+    return when (language) {
+        "English" -> stringResource(R.string.app__global_english)
+        "German" -> stringResource(R.string.app__global_german)
+        "French" -> stringResource(R.string.app__global_french)
+        "Spanish" -> stringResource(R.string.app__global_spanish)
+        "Italian" -> stringResource(R.string.app__global_italian)
+        "Russian" -> stringResource(R.string.app__global_russian)
+        "Portuguese" -> stringResource(R.string.app__global_portuguese)
+        "Swedish" -> stringResource(R.string.app__global_swedish)
+        else -> language
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1528,6 +1528,10 @@
     <string name="wikimedia_logo">Wikimedia Logo</string>
     <string name="suggestion">Suggestion</string>
 
+<!--    Translation source language -->
+    <string name="translation_source_language_title">Translation source language</string>
+    <string name="translation_source_language_description">Select the language to translate from.</string>
+
     <string-array name="months">
         <item>@string/january</item>
         <item>@string/february</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1527,11 +1527,7 @@
     <string name="wikimedia_and_scribe_title">How we work together</string>
     <string name="wikimedia_logo">Wikimedia Logo</string>
     <string name="suggestion">Suggestion</string>
-
-<!--    Translation source language -->
-    <string name="translation_source_language_title">Translation source language</string>
-    <string name="translation_source_language_description">Select the language to translate from.</string>
-
+    
     <string-array name="months">
         <item>@string/january</item>
         <item>@string/february</item>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Added translation source language option to language settings screen
The actual selection does not work (just a clickable ui item)

I ran my code in Android Studio and saw the option in Settings > Select Installed Keyboard > English
I also ran the ./gradlew lintKotlin detekt test to check my code

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #149
