### PR TITLE
Fix command keys color mismatch with Scribe key in dark mode.

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -153,13 +153,24 @@ abstract class GeneralKeyboardIME(
         setupCommandBarTheme(binding)
     }
 
-    private fun updateCommandBarHintandPrompt() {
+    private fun updateCommandBarHintandPrompt(isUserDarkMode: Boolean? = null) {
         val commandBarButton = keyboardBinding.commandBar
         val hintMessage = HintUtils.getCommandBarHint(currentState, language)
         val promptText = HintUtils.getPromptText(currentState, language)
         val promptTextView = keyboardBinding.promptText
         promptTextView?.text = promptText
         commandBarButton.hint = hintMessage
+
+        if (isUserDarkMode == true) {
+            commandBarButton.setBackgroundColor(getColor(R.color.special_key_dark))
+            promptTextView?.setBackgroundColor(getColor(R.color.special_key_dark))
+            keyboardBinding.promptTextBorder?.setBackgroundColor(getColor(R.color.special_key_dark))
+        } else {
+            commandBarButton.setBackgroundColor(getColor(white))
+            promptTextView?.setBackgroundColor(getColor(white))
+            keyboardBinding.promptTextBorder?.setBackgroundColor(getColor(white))
+        }
+
         Log.d(
             "KeyboardUpdate",
             "CommandBar Hint Updated: [State: $currentState, Language: $language, Hint: $hintMessage]",
@@ -167,7 +178,20 @@ abstract class GeneralKeyboardIME(
     }
 
     private fun updateKeyboardMode(isCommandMode: Boolean = false) {
-        updateCommandBarHintandPrompt()
+        val sharedPref = getSharedPreferences("app_preferences", MODE_PRIVATE)
+        val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val isSystemDarkMode = currentNightMode == Configuration.UI_MODE_NIGHT_YES
+        val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkMode)
+
+        if (isUserDarkMode) {
+            val color = ContextCompat.getColorStateList(this, R.color.light_key_color)
+            keyboardBinding.scribeKey.foregroundTintList = color
+        } else {
+            val colorLight = ContextCompat.getColorStateList(this, R.color.light_key_text_color)
+            keyboardBinding.scribeKey.foregroundTintList = colorLight
+        }
+
+        updateCommandBarHintandPrompt(isUserDarkMode)
         enterKeyType =
             if (isCommandMode) {
                 KeyboardBase.MyCustomActions.IME_ACTION_COMMAND

--- a/app/src/main/res/drawable/button_background_rounded.xml
+++ b/app/src/main/res/drawable/button_background_rounded.xml
@@ -4,7 +4,7 @@
         <layer-list>
             <item android:id="@+id/button_background_shape">
                 <shape android:shape="rectangle">
-                    <solid android:color="@color/light_scribe_blue"/>
+                    <solid android:color="@color/color_primary"/>
                     <corners android:radius="12dp"/>
                 </shape>
             </item>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
Fix command key colour inconsistency with Scribe key in dark mode. Now command keys colour matches with the scribe key in both light and dark mode. Tested by switching the dark mode in app. Also tested by switching the device's theme on Samsung A34 5G.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #161
