### PR TITLE
Fix dark mode coloration of command bar, X symbol and command keys.

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -461,11 +461,17 @@ abstract class GeneralKeyboardIME(
         commandBarButton.hint = hintMessage
 
         if (isUserDarkMode == true) {
+            commandBarButton.setHintTextColor(getColor(R.color.hint_white))
+            commandBarButton.setTextColor(getColor(white))
             commandBarButton.backgroundTintList = ContextCompat.getColorStateList(this, R.color.command_bar_color_dark)
+            promptTextView.setTextColor(getColor(white))
             promptTextView.setBackgroundColor(getColor(R.color.command_bar_color_dark))
             keyboardBinding.promptTextBorder.setBackgroundColor(getColor(R.color.command_bar_color_dark))
         } else {
+            commandBarButton.setHintTextColor(getColor(R.color.hint_black))
+            commandBarButton.setTextColor(Color.BLACK)
             commandBarButton.backgroundTintList = ContextCompat.getColorStateList(this, R.color.white)
+            promptTextView.setTextColor(Color.BLACK)
             promptTextView.setBackgroundColor(getColor(white))
             keyboardBinding.promptTextBorder.setBackgroundColor(getColor(white))
         }

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -452,13 +452,24 @@ abstract class GeneralKeyboardIME(
      * This function is responsible for modifying the UI elements of the command bar
      * to provide appropriate hints and prompts to the user.
      */
-    private fun updateCommandBarHintAndPrompt() {
+    private fun updateCommandBarHintAndPrompt(isUserDarkMode: Boolean? = null) {
         val commandBarButton = keyboardBinding.commandBar
         val hintMessage = HintUtils.getCommandBarHint(currentState, language)
         val promptText = HintUtils.getPromptText(currentState, language)
         val promptTextView = keyboardBinding.promptText
         promptTextView.text = promptText
         commandBarButton.hint = hintMessage
+
+        if (isUserDarkMode == true) {
+            commandBarButton.backgroundTintList = ContextCompat.getColorStateList(this, R.color.command_bar_color_dark)
+            promptTextView.setBackgroundColor(getColor(R.color.command_bar_color_dark))
+            keyboardBinding.promptTextBorder.setBackgroundColor(getColor(R.color.command_bar_color_dark))
+        } else {
+            commandBarButton.backgroundTintList = ContextCompat.getColorStateList(this, R.color.white)
+            promptTextView.setBackgroundColor(getColor(white))
+            keyboardBinding.promptTextBorder.setBackgroundColor(getColor(white))
+        }
+
         Log.d(
             "KeyboardUpdate",
             "CommandBar Hint Updated: [State: $currentState, Language: $language, Hint: $hintMessage]",
@@ -524,10 +535,14 @@ abstract class GeneralKeyboardIME(
         when (isUserDarkMode) {
             true -> {
                 keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(R.color.special_key_dark))
+                val color = ContextCompat.getColorStateList(this, R.color.light_key_color)
+                keyboardBinding.scribeKey.foregroundTintList = color
             }
 
             false -> {
                 keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(R.color.special_key_light))
+                val colorLight = ContextCompat.getColorStateList(this, R.color.light_key_text_color)
+                keyboardBinding.scribeKey.foregroundTintList = colorLight
             }
         }
         handleModeChange(keyboardSymbols, keyboardView, this)
@@ -541,7 +556,7 @@ abstract class GeneralKeyboardIME(
             updateUI()
         }
         setInputView(keyboardHolder)
-        updateCommandBarHintAndPrompt()
+        updateCommandBarHintAndPrompt(isUserDarkMode)
     }
 
     /**

--- a/app/src/main/res/drawable/button_background_rounded.xml
+++ b/app/src/main/res/drawable/button_background_rounded.xml
@@ -4,7 +4,7 @@
         <layer-list>
             <item android:id="@+id/button_background_shape">
                 <shape android:shape="rectangle">
-                    <solid android:color="@color/light_scribe_blue"/>
+                    <solid android:color="@color/color_primary"/>
                     <corners android:radius="12dp"/>
                 </shape>
             </item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,6 +16,7 @@
     <color name="transparent">@android:color/transparent</color>
     <color name="special_key_light">#aeb3be</color>
     <color name="special_key_dark">#202020</color>
+    <color name="command_bar_color_dark">#2E2E2E</color>
 
     <color name="nav_bar_selected_color_light">@color/dark_scribe_color</color>
     <color name="nav_bar_selected_color_dark">@color/light_scribe_color</color>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
Fix command key color inconsistency with Scribe key in dark mode. Now command keys color matches with the scribe key in both light and dark mode. Also fixed the X icon to cancel the command and the command bar color in dark mode. Tested by switching the dark/light modes in app. Also tested by switching the device's theme on Samsung A34 5G. 

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   ##161
