### PR TITLE
App hints tooltips

### DIFF
--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.PagerState
@@ -26,6 +27,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -98,6 +102,9 @@ fun HintDialogContent(
         } else {
             colorResource(R.color.light_scribe_blue)
         }
+
+    val shadowColor = colorResource(R.color.light_key_shadow_color)
+
     Box(
         modifier =
             modifier.padding(horizontal = 12.dp).background(
@@ -106,7 +113,7 @@ fun HintDialogContent(
                         colors =
                             listOf(
                                 Color.Transparent,
-                                colorResource(R.color.light_key_shadow_color),
+                                shadowColor,
                             ),
                     ),
                 shape = RoundedCornerShape(10.dp),
@@ -147,18 +154,15 @@ fun HintDialogContent(
                     modifier =
                         Modifier
                             .weight(0.15f)
-                            .padding(end = 8.dp)
-                            .background(
-                                brush =
-                                    Brush.verticalGradient(
-                                        colors =
-                                            listOf(
-                                                Color.Transparent,
-                                                colorResource(R.color.light_key_shadow_color),
-                                            ),
-                                    ),
-                                shape = RoundedCornerShape(8.dp),
-                            ),
+                            .background(Color.Transparent)
+                            .drawBehind {
+                                drawRoundRect(
+                                    color = shadowColor,
+                                    topLeft = Offset.Zero.copy(y = size.height - 16.dp.toPx()),
+                                    size = size.copy(height = 14.dp.toPx()),
+                                    cornerRadius = CornerRadius(8.dp.toPx()),
+                                )
+                            },
                 ) {
                     Button(
                         onClick = onDismiss,

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -3,6 +3,8 @@
 package be.scri.ui.common.appcomponents
 
 import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -24,8 +26,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -113,26 +117,40 @@ fun HintDialogContent(
                 modifier = Modifier.weight(0.85f),
             )
 
-            Button(
-                onClick = onDismiss,
-                colors =
-                    ButtonColors(
-                        containerColor = MaterialTheme.colorScheme.secondary,
-                        contentColor = Color.White,
-                        disabledContainerColor = MaterialTheme.colorScheme.secondary,
-                        disabledContentColor = Color.White,
-                    ),
-                contentPadding = PaddingValues(0.dp),
-                shape = RoundedCornerShape(8.dp),
+            Box(
                 modifier =
                     Modifier
-                        .weight(0.15f),
+                        .weight(0.15f)
+                        .background(
+                            brush =
+                                Brush.verticalGradient(
+                                    colors =
+                                        listOf(
+                                            Color.Transparent,
+                                            colorResource(R.color.light_key_shadow_color),
+                                        ),
+                                ),
+                            shape = RoundedCornerShape(8.dp),
+                        ),
             ) {
-                Text(
-                    text = "OK",
-                    fontSize = 12.sp,
-                    modifier = Modifier,
-                )
+                Button(
+                    onClick = onDismiss,
+                    colors =
+                        ButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondary,
+                            contentColor = Color.White,
+                            disabledContainerColor = MaterialTheme.colorScheme.secondary,
+                            disabledContentColor = Color.White,
+                        ),
+                    contentPadding = PaddingValues(0.dp),
+                    shape = RoundedCornerShape(8.dp),
+                ) {
+                    Text(
+                        text = "OK",
+                        fontSize = 20.sp,
+                        modifier = Modifier,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -79,7 +79,7 @@ fun HintDialog(
             isUserDarkMode = isUserDarkMode,
             modifier =
                 modifier
-                    .padding(top = 8.dp),
+                    .padding(top = 20.dp),
         )
     }
 }
@@ -98,70 +98,86 @@ fun HintDialogContent(
         } else {
             colorResource(R.color.light_scribe_blue)
         }
-    Surface(
-        shape = RoundedCornerShape(10.dp),
-        color = MaterialTheme.colorScheme.surface,
-        modifier = modifier,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(vertical = 8.dp, horizontal = 6.dp),
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.light_bulb_icon),
-                contentDescription = "Hint",
-                tint = Color(0xFFFDAD0D),
-                modifier =
-                    Modifier
-                        .padding(start = 8.dp, end = 12.dp)
-                        .size(30.dp),
-            )
-
-            Text(
-                text = text,
-                color = MaterialTheme.colorScheme.onSurface,
-                fontSize = 14.sp,
-                style =
-                    MaterialTheme.typography.labelMedium.copy(
-                        fontWeight = FontWeight.Normal,
+    Box(
+        modifier =
+            modifier.padding(horizontal = 12.dp).background(
+                brush =
+                    Brush.verticalGradient(
+                        colors =
+                            listOf(
+                                Color.Transparent,
+                                colorResource(R.color.light_key_shadow_color),
+                            ),
                     ),
-                modifier = Modifier.weight(0.85f),
-            )
-
-            Box(
-                modifier =
-                    Modifier
-                        .weight(0.15f)
-                        .padding(end = 8.dp)
-                        .background(
-                            brush =
-                                Brush.verticalGradient(
-                                    colors =
-                                        listOf(
-                                            Color.Transparent,
-                                            colorResource(R.color.light_key_shadow_color),
-                                        ),
-                                ),
-                            shape = RoundedCornerShape(8.dp),
-                        ),
+                shape = RoundedCornerShape(10.dp),
+            ),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(10.dp),
+            color = MaterialTheme.colorScheme.surface,
+            shadowElevation = 4.dp,
+            modifier = Modifier.padding(bottom = 6.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 6.dp),
             ) {
-                Button(
-                    onClick = onDismiss,
-                    colors =
-                        ButtonColors(
-                            containerColor = buttonColor,
-                            contentColor = Color.White,
-                            disabledContainerColor = MaterialTheme.colorScheme.secondary,
-                            disabledContentColor = Color.White,
+                Icon(
+                    painter = painterResource(R.drawable.light_bulb_icon),
+                    contentDescription = "Hint",
+                    tint = Color(0xFFFDAD0D),
+                    modifier =
+                        Modifier
+                            .padding(start = 8.dp, end = 12.dp)
+                            .size(30.dp),
+                )
+
+                Text(
+                    text = text,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 14.sp,
+                    style =
+                        MaterialTheme.typography.labelMedium.copy(
+                            fontWeight = FontWeight.Normal,
                         ),
-                    contentPadding = PaddingValues(0.dp),
-                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.weight(0.85f),
+                )
+
+                Box(
+                    modifier =
+                        Modifier
+                            .weight(0.15f)
+                            .padding(end = 8.dp)
+                            .background(
+                                brush =
+                                    Brush.verticalGradient(
+                                        colors =
+                                            listOf(
+                                                Color.Transparent,
+                                                colorResource(R.color.light_key_shadow_color),
+                                            ),
+                                    ),
+                                shape = RoundedCornerShape(8.dp),
+                            ),
                 ) {
-                    Text(
-                        text = "OK",
-                        fontSize = 20.sp,
-                        modifier = Modifier,
-                    )
+                    Button(
+                        onClick = onDismiss,
+                        colors =
+                            ButtonColors(
+                                containerColor = buttonColor,
+                                contentColor = Color.White,
+                                disabledContainerColor = MaterialTheme.colorScheme.secondary,
+                                disabledContentColor = Color.White,
+                            ),
+                        contentPadding = PaddingValues(0.dp),
+                        shape = RoundedCornerShape(8.dp),
+                    ) {
+                        Text(
+                            text = "OK",
+                            fontSize = 20.sp,
+                            modifier = Modifier,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import be.scri.R
+import be.scri.helpers.PreferencesHelper.getIsDarkModeOrNot
 
 @Composable
 fun HintDialog(
@@ -59,6 +60,8 @@ fun HintDialog(
         derivedStateOf { pagerState.currentPage == currentPageIndex }
     }
 
+    val isUserDarkMode = remember { getIsDarkModeOrNot(context.applicationContext) }
+
     LaunchedEffect(isPageVisible) {
         if (isPageVisible && !isHintShown) {
             isHintShown = false
@@ -73,6 +76,7 @@ fun HintDialog(
                 isHintShown = true
                 onDismiss(currentPageIndex)
             },
+            isUserDarkMode = isUserDarkMode,
             modifier =
                 modifier
                     .padding(top = 8.dp),
@@ -85,8 +89,15 @@ fun HintDialog(
 fun HintDialogContent(
     text: String,
     onDismiss: () -> Unit,
+    isUserDarkMode: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val buttonColor =
+        if (isUserDarkMode) {
+            colorResource(R.color.dark_scribe_blue)
+        } else {
+            colorResource(R.color.light_scribe_blue)
+        }
     Surface(
         shape = RoundedCornerShape(10.dp),
         color = MaterialTheme.colorScheme.surface,
@@ -102,7 +113,7 @@ fun HintDialogContent(
                 tint = Color(0xFFFDAD0D),
                 modifier =
                     Modifier
-                        .padding(end = 8.dp)
+                        .padding(start = 8.dp, end = 12.dp)
                         .size(30.dp),
             )
 
@@ -121,6 +132,7 @@ fun HintDialogContent(
                 modifier =
                     Modifier
                         .weight(0.15f)
+                        .padding(end = 8.dp)
                         .background(
                             brush =
                                 Brush.verticalGradient(
@@ -137,7 +149,7 @@ fun HintDialogContent(
                     onClick = onDismiss,
                     colors =
                         ButtonColors(
-                            containerColor = MaterialTheme.colorScheme.secondary,
+                            containerColor = buttonColor,
                             contentColor = Color.White,
                             disabledContainerColor = MaterialTheme.colorScheme.secondary,
                             disabledContentColor = Color.White,

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -79,7 +79,7 @@ fun HintDialog(
             isUserDarkMode = isUserDarkMode,
             modifier =
                 modifier
-                    .padding(top = 20.dp),
+                    .padding(top = 24.dp),
         )
     }
 }
@@ -116,7 +116,7 @@ fun HintDialogContent(
             shape = RoundedCornerShape(10.dp),
             color = MaterialTheme.colorScheme.surface,
             shadowElevation = 4.dp,
-            modifier = Modifier.padding(bottom = 6.dp),
+            modifier = Modifier.padding(bottom = 4.dp),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request is to improve styling of app hints tooltips as described in issue #323
I have:
- changed the button color
- add shadow to button and tooltips
- added horizontal padding
- placed the tooltips slightly lower
- increased font size of OK
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #323 
