### PR TITLE
Fix Caps Lock Icon Theming and Improve Shift Key Behavior

### DIFF
--- a/app/src/main/res/drawable/ic_caps_lock_off.xml
+++ b/app/src/main/res/drawable/ic_caps_lock_off.xml
@@ -6,18 +6,16 @@
     android:viewportHeight="960">
 
     <path
-        android:strokeColor="#000000"
+        android:strokeColor="@color/icon_color"
         android:strokeWidth="80"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:fillColor="#00000000"
-        android:pathData="M480,100 l-340,340 M480,100 l340,340" />
+        android:pathData="M480,140 l-300,300 M480,140 l300,300" />
 
     <path
-        android:strokeColor="#000000"
+        android:strokeColor="@color/icon_color"
         android:strokeWidth="80"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M100,669 h760" />
-
+        android:pathData="M180,680 h600" />
 </vector>

--- a/app/src/main/res/drawable/ic_caps_lock_on.xml
+++ b/app/src/main/res/drawable/ic_caps_lock_on.xml
@@ -6,18 +6,18 @@
     android:viewportHeight="960">
 
     <path
-        android:fillColor="#000000"
-        android:strokeColor="#000000"
+        android:fillColor="@color/icon_color"
+        android:strokeColor="@color/icon_color"
         android:strokeWidth="80"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M480,60 L60,480 L480,480 L900,480 L480,60Z" />
+        android:pathData="M480,140 L180,440 L480,440 L780,440 L480,140Z" />
 
     <path
-        android:strokeColor="#000000"
+        android:strokeColor="@color/icon_color"
         android:strokeWidth="80"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M100,669 h760" />
+        android:pathData="M180,680 h600" />
 
 </vector>


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR addresses theming issues with the keyboard icons and improves the visual feedback for shift key states. The main improvements include:

1. Fixed the caps lock icon to properly respect the system/user theme in both light and dark modes
2. Applied consistent color filtering to all special keys including caps lock
3. Improved the visual consistency between caps lock on/off states by aligning their dimensions
4. Enhanced the shift key behavior to provide clear visual feedback when locked

These changes improve the overall user experience by providing consistent visual feedback across the keyboard interface and ensuring proper theme compliance for all UI elements.

## Related issue

- Fixes #322 

## Technical details

- Applied color filtering to caps lock icons in the `onBufferDraw()` method
- Updated drawable XML files to use theme-aware color resources
- Aligned dimensions between caps lock on/off states for visual consistency
- Implemented proper visual feedback for shift locked state using the key pressed color

## Testing

Tested on multiple devices in both light and dark modes to ensure proper theming across all conditions.
