### PR TITLE
Set Return key color in command mode to match the scribe key in dark m…

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -434,7 +434,7 @@ abstract class GeneralKeyboardIME(
                 earlierValue = keyboardView?.setEnterKeyIcon(ScribeState.SELECT_COMMAND)
             }
             else -> {
-                keyboardView?.setEnterKeyColor(getColor(R.color.dark_scribe_blue))
+                keyboardView?.setEnterKeyColor(getColor(R.color.color_primary))
                 keyboardView?.setEnterKeyIcon(ScribeState.PLURAL, earlierValue)
             }
         }


### PR DESCRIPTION
…ode.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Set Return key color in command mode to match the scribe key and the command keys in the dark mode. Tested this by switching dark mode in scribe app and the device dark/light modes.

### Related issue
-   #316
