### PR TITLE
Standardize the size of the Scribe key icons.

### DIFF
--- a/app/src/main/res/drawable/close.xml
+++ b/app/src/main/res/drawable/close.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="29dp"
+    android:height="29dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path

--- a/app/src/main/res/drawable/ic_scribe_icon_vector.xml
+++ b/app/src/main/res/drawable/ic_scribe_icon_vector.xml
@@ -1,5 +1,5 @@
-<vector android:height="24dp" android:viewportHeight="420"
-    android:viewportWidth="799" android:width="45.657143dp" xmlns:android="http://schemas.android.com/apk/res/android">
+<vector android:height="21dp" android:viewportHeight="420"
+    android:viewportWidth="799" android:width="37.657143dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#00000000"
         android:pathData="M125.25,146.57H557.92M26,394.99H606.42C606.7,394.99 606.97,394.87 607.16,394.66L773.64,210.66C773.98,210.28 773.98,209.7 773.64,209.32L607.16,25.33C606.97,25.12 606.7,25 606.42,25H26C25.45,25 25,25.45 25,26V393.99C25,394.54 25.45,394.99 26,394.99Z"
         android:strokeColor="#ffffff" android:strokeWidth="30"/>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Standardize the size of the Scribe key icons. The scribe key icon size is reduced and the size of the X icon to cancel the commands is increased.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #341
