### PR TITLE
fixed scribe key animation

### DIFF
--- a/app/src/main/res/drawable/cmd_key_background_rounded.xml
+++ b/app/src/main/res/drawable/cmd_key_background_rounded.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@color/light_key_press_color">
-    <item android:id="@+id/button_background_holder">
-        <layer-list>
-            <item android:id="@+id/button_background_shape">
-                <shape android:shape="rectangle">
-                    <solid android:color="@color/color_primary" />
-                    <corners android:radius="10dp" />
-                </shape>
-            </item>
-        </layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/light_key_press_color" />
+            <corners android:radius="10dp" />
+        </shape>
     </item>
-</ripple>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/color_primary" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/scribe_key_background_left_rounded.xml
+++ b/app/src/main/res/drawable/scribe_key_background_left_rounded.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@color/light_key_press_color">
-    <item android:id="@+id/button_background_holder">
-        <layer-list>
-            <item android:id="@+id/button_background_shape">
-                <shape android:shape="rectangle">
-                    <solid android:color="@color/color_primary" />
-                    <corners
-                        android:bottomLeftRadius="@dimen/command_button_corner_radius"
-                        android:bottomRightRadius="0dp"
-                        android:topLeftRadius="@dimen/command_button_corner_radius"
-                        android:topRightRadius="0dp" />
-                </shape>
-            </item>
-        </layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/light_key_press_color" />
+            <corners
+                android:bottomLeftRadius="@dimen/command_button_corner_radius"
+                android:bottomRightRadius="0dp"
+                android:topLeftRadius="@dimen/command_button_corner_radius"
+                android:topRightRadius="0dp" />
+        </shape>
     </item>
-</ripple>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/color_primary" />
+            <corners
+                android:bottomLeftRadius="@dimen/command_button_corner_radius"
+                android:bottomRightRadius="0dp"
+                android:topLeftRadius="@dimen/command_button_corner_radius"
+                android:topRightRadius="0dp" />
+        </shape>
+    </item>
+</selector>


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Refined the animation so that it no longer spreads outward from the user's click location. Instead, it now features a subtle, uniform change to indicate the click, aligning with the issue's requirements.


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #318 

### Demo


https://github.com/user-attachments/assets/9b2ef300-2cda-4c08-a84a-088958eacbc1


