### PR TITLE
fixed the click animation on the settings and about page 

### DIFF
--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
@@ -7,6 +7,7 @@
 package be.scri.ui.common.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,44 +35,50 @@ fun AboutPageItemComp(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(
-                    start = 12.dp,
-                    end = 20.dp,
-                    top = 10.dp,
-                    bottom = 10.dp,
-                ).clip(RoundedCornerShape(12.dp))
                 .clickable(onClick = onClick),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
-            painter = painterResource(leadingIcon),
+        Row(
             modifier =
                 Modifier
-                    .padding(start = 2.dp)
-                    .size(22.dp),
-            tint = MaterialTheme.colorScheme.onSurface,
-            contentDescription = "Right Arrow",
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = title,
-            modifier = Modifier.weight(1f).padding(start = 4.dp),
-            fontSize = 16.sp,
-            color = MaterialTheme.colorScheme.onSurface,
-            style = MaterialTheme.typography.bodyMedium,
-        )
-        Icon(
-            painter = painterResource(trailingIcon),
-            modifier =
-                Modifier
-                    .padding(start = 6.dp)
-                    .size(24.dp),
-            contentDescription = "Right Arrow",
-            tint = Color.Gray,
-        )
+                    .fillMaxWidth()
+                    .padding(
+                        start = 12.dp,
+                        end = 20.dp,
+                        top = 10.dp,
+                        bottom = 10.dp,
+                    ).clip(RoundedCornerShape(12.dp)),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(leadingIcon),
+                modifier =
+                    Modifier
+                        .padding(start = 2.dp)
+                        .size(22.dp),
+                tint = MaterialTheme.colorScheme.onSurface,
+                contentDescription = "Leading Icon",
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = title,
+                modifier = Modifier.weight(1f).padding(start = 4.dp),
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Icon(
+                painter = painterResource(trailingIcon),
+                modifier =
+                    Modifier
+                        .padding(start = 6.dp)
+                        .size(24.dp),
+                contentDescription = "Trailing Icon",
+                tint = Color.Gray,
+            )
+        }
     }
 }

--- a/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
@@ -7,6 +7,7 @@
 package be.scri.ui.common.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,46 +34,52 @@ fun ClickableItemComp(
     modifier: Modifier = Modifier,
     desc: String? = null,
 ) {
-    Column(
+    Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(
-                    horizontal = 12.dp,
-                    vertical = 10.dp,
-                ).clip(RoundedCornerShape(8.dp))
                 .clickable(onClick = onClick),
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = 12.dp,
+                        vertical = 10.dp,
+                    ).clip(RoundedCornerShape(8.dp)),
         ) {
-            Text(
-                text = title,
-                modifier = Modifier.weight(1f),
-                fontSize = 16.sp,
-                color = MaterialTheme.colorScheme.onSurface,
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Icon(
-                painter = painterResource(R.drawable.right_arrow),
-                modifier =
-                    Modifier
-                        .padding(start = 6.dp)
-                        .size(17.dp),
-                tint = MaterialTheme.colorScheme.onSurface,
-                contentDescription = "Right Arrow",
-            )
-        }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = title,
+                    modifier = Modifier.weight(1f),
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Icon(
+                    painter = painterResource(R.drawable.right_arrow),
+                    modifier =
+                        Modifier
+                            .padding(start = 6.dp)
+                            .size(17.dp),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    contentDescription = "Right Arrow",
+                )
+            }
 
-        if (!desc.isNullOrEmpty()) {
-            Text(
-                text = desc,
-                fontSize = 12.sp,
-                color = Color.Gray,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(top = 4.dp),
-            )
+            if (!desc.isNullOrEmpty()) {
+                Text(
+                    text = desc,
+                    fontSize = 12.sp,
+                    color = Color.Gray,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Fixed animations to span the whole option instead of text and icons

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #324

### Demo

https://github.com/user-attachments/assets/238de915-5aa9-45cb-bee5-6bb05472a17a


