### PR TITLE
Increase the vertical spacing between key rows

### DIFF
--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -249,6 +249,7 @@ class KeyboardView
             private const val MARGIN_ADJUSTMENT = 10
             private const val PROXIMITY_SCALING_FACTOR = 1.4f
             private const val KEY_MARGIN = 8
+            private const val V_KEY_MARGIN = 16
             private const val SHADOW_OFFSET = 3
             private const val ALPHA_ADJUSTMENT_FACTOR = 0.8f
             private const val SHADOW_ALPHA = 100
@@ -595,6 +596,7 @@ class KeyboardView
         @SuppressLint("UseCompatLoadingForDrawables")
         private fun onBufferDraw() {
             val keyMargin = KEY_MARGIN
+            val vKeyMargin = V_KEY_MARGIN
             val shadowOffset = SHADOW_OFFSET
             if (mBuffer == null || mKeyboardChanged) {
                 if (mBuffer?.let { buffer -> buffer.width != width || buffer.height != height } != false) {
@@ -691,7 +693,7 @@ class KeyboardView
                         (key.x + keyMargin + padding).toFloat(),
                         (key.y + keyMargin + padding + shadowOffsetY).toFloat(),
                         (key.x + key.width - keyMargin - padding).toFloat(),
-                        (key.y + key.height - keyMargin - padding + shadowOffsetY).toFloat(),
+                        (key.y + key.height - vKeyMargin - padding + shadowOffsetY).toFloat(),
                     )
 
                 val keyRect =
@@ -699,7 +701,7 @@ class KeyboardView
                         (key.x + keyMargin - shadowOffset + padding).toFloat(),
                         (key.y + keyMargin - shadowOffset + padding).toFloat(),
                         (key.x + key.width - keyMargin + shadowOffset - padding).toFloat(),
-                        (key.y + key.height - keyMargin + shadowOffset - padding).toFloat(),
+                        (key.y + key.height - vKeyMargin + shadowOffset - padding).toFloat(),
                     )
                 canvas.drawRoundRect(shadowRect, rectRadius, rectRadius, shadowPaint)
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This fix increases the vertical space between key rows, aligning their style with Scribe-iOS and other keyboards.

### Screenshots
| Before | After |
|------- | ------|
| ![WhatsApp Image 2025-03-24 at 10 13 30](https://github.com/user-attachments/assets/1a674690-62b7-4941-aaf4-f5d58ce5a4a7) | ![WhatsApp Image 2025-03-24 at 10 13 29](https://github.com/user-attachments/assets/810c5056-8175-4c04-b9fe-576cab7690b6)

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #320 
