### PR TITLE
Add spacing between the scribe key and translate key

### DIFF
--- a/app/src/main/res/layout/keyboard_view_command_options.xml
+++ b/app/src/main/res/layout/keyboard_view_command_options.xml
@@ -18,6 +18,7 @@
             android:layout_width="@dimen/scribe_key_width"
             android:layout_height="37dp"
             android:layout_marginStart="@dimen/small_margin"
+            android:layout_marginEnd="4dp"
             android:background="@drawable/cmd_key_background_rounded"
             android:contentDescription="@string/scribe_key"
             android:foreground="@drawable/ic_scribe_icon_vector"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This fix adds spacing between the scribe key and translate key

### Screenshots

| Before | After |
|--------|--------|
| ![WhatsApp Image 2025-03-24 at 17 44 45](https://github.com/user-attachments/assets/d5fa95b8-6379-40ac-baae-f9a2ebd61db3) | ![WhatsApp Image 2025-03-24 at 17 44 46](https://github.com/user-attachments/assets/70878b96-cc25-4636-86af-036dc11b93c7)|

### Related Issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #317
