### PR TITLE
 Fix Emoji Separator Visibility and Layout Issues

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -572,44 +572,44 @@ abstract class GeneralKeyboardIME(
      */
     private fun setupIdleView() {
         binding.translateBtn.textSize = SUGGESTION_SIZE
-        var isUserDarkMode = getIsDarkModeOrNot(applicationContext)
-        if (isUserDarkMode) {
-            binding.translateBtn.setTextColor(getColor(white))
-        } else {
-            binding.translateBtn.setTextColor(getColor(md_grey_black_dark))
+        val isUserDarkMode = getIsDarkModeOrNot(applicationContext)
+
+        // Set common properties for buttons
+        val textColor = if (isUserDarkMode) Color.WHITE else Color.parseColor("#1E1E1E")
+        val separatorColor = Color.parseColor(if (isUserDarkMode) DARK_THEME else LIGHT_THEME)
+
+        // Apply to all buttons
+        listOf(binding.translateBtn, binding.conjugateBtn, binding.pluralBtn).forEach { button ->
+            button.setBackgroundColor(getColor(R.color.transparent))
+            button.setTextColor(textColor)
+            button.text = getString(R.string.suggestion)
         }
 
-        when (isUserDarkMode) {
-            true -> {
-                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
-                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
-                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
-                binding.translateBtn.setTextColor(Color.WHITE)
-                binding.conjugateBtn.setTextColor(Color.WHITE)
-                binding.pluralBtn.setTextColor(Color.WHITE)
-                binding.separator2.setBackgroundColor(Color.parseColor(DARK_THEME))
-                binding.separator3.setBackgroundColor(Color.parseColor(DARK_THEME))
-                binding.separator4.setBackgroundColor(Color.parseColor(DARK_THEME))
-            }
-            else -> {
-                binding.translateBtn.setBackgroundColor(getColor(R.color.transparent))
-                binding.conjugateBtn.setBackgroundColor(getColor(R.color.transparent))
-                binding.pluralBtn.setBackgroundColor(getColor(R.color.transparent))
-                binding.translateBtn.setTextColor(Color.parseColor("#1E1E1E"))
-                binding.conjugateBtn.setTextColor(Color.parseColor("#1E1E1E"))
-                binding.pluralBtn.setTextColor(Color.parseColor("#1E1E1E"))
-                binding.separator2.setBackgroundColor(Color.parseColor(LIGHT_THEME))
-                binding.separator3.setBackgroundColor(Color.parseColor(LIGHT_THEME))
-                binding.separator4.setBackgroundColor(Color.parseColor(LIGHT_THEME))
-            }
+        // Apply to all separators
+        listOf(
+            binding.separator2,
+            binding.separator3,
+            binding.separator4,
+            binding.separator5,
+            binding.separator6,
+        ).forEach { separator ->
+            separator.setBackgroundColor(separatorColor)
         }
 
-        setupCommandBarTheme(binding)
-        binding.translateBtn.text = getString(R.string.suggestion)
-        binding.conjugateBtn.text = getString(R.string.suggestion)
-        binding.pluralBtn.text = getString(R.string.suggestion)
+        // Set visibility
         binding.separator2.visibility = View.VISIBLE
         binding.separator3.visibility = View.VISIBLE
+
+        val isTablet =
+            (resources.configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK) >=
+                Configuration.SCREENLAYOUT_SIZE_LARGE
+
+        binding.separator4.visibility = if (isTablet) View.GONE else View.VISIBLE
+        binding.separator5.visibility = if (isTablet) View.VISIBLE else View.GONE
+        binding.separator6.visibility = if (isTablet) View.VISIBLE else View.GONE
+
+        setupCommandBarTheme(binding)
+
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.SELECT_COMMAND
             disableAutoSuggest()
@@ -617,11 +617,7 @@ abstract class GeneralKeyboardIME(
             Log.i("MY-TAG", "SELECT COMMAND STATE")
             binding.scribeKey.foreground = AppCompatResources.getDrawable(this, R.drawable.close)
             updateUI()
-            if (isUserDarkMode) {
-                binding.translateBtn.setTextColor(Color.WHITE)
-            } else {
-                binding.translateBtn.setTextColor(Color.BLACK)
-            }
+            binding.translateBtn.setTextColor(if (isUserDarkMode) Color.WHITE else Color.BLACK)
         }
     }
 
@@ -641,6 +637,9 @@ abstract class GeneralKeyboardIME(
         binding.pluralBtn.text = pluralPlaceholder[getLanguageAlias(language)] ?: "Plural"
         binding.separator2.visibility = View.GONE
         binding.separator3.visibility = View.GONE
+        binding.separator4.visibility = View.GONE
+        binding.separator5.visibility = View.GONE
+        binding.separator6.visibility = View.GONE
         setupCommandBarTheme(binding)
         binding.translateBtn.setTextColor(Color.BLACK)
         binding.scribeKey.setOnClickListener {

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -574,18 +574,18 @@ abstract class GeneralKeyboardIME(
         binding.translateBtn.textSize = SUGGESTION_SIZE
         val isUserDarkMode = getIsDarkModeOrNot(applicationContext)
 
-        // Set common properties for buttons
+        // Set common properties for buttons.
         val textColor = if (isUserDarkMode) Color.WHITE else Color.parseColor("#1E1E1E")
         val separatorColor = Color.parseColor(if (isUserDarkMode) DARK_THEME else LIGHT_THEME)
 
-        // Apply to all buttons
+        // Apply to all buttons.
         listOf(binding.translateBtn, binding.conjugateBtn, binding.pluralBtn).forEach { button ->
             button.setBackgroundColor(getColor(R.color.transparent))
             button.setTextColor(textColor)
             button.text = getString(R.string.suggestion)
         }
 
-        // Apply to all separators
+        // Apply to all separators.
         listOf(
             binding.separator2,
             binding.separator3,
@@ -596,7 +596,7 @@ abstract class GeneralKeyboardIME(
             separator.setBackgroundColor(separatorColor)
         }
 
-        // Set visibility
+        // Set visibility.
         binding.separator2.visibility = View.VISIBLE
         binding.separator3.visibility = View.VISIBLE
 

--- a/app/src/main/res/layout/keyboard_view_command_options.xml
+++ b/app/src/main/res/layout/keyboard_view_command_options.xml
@@ -169,17 +169,16 @@
 
         <View
             android:id="@+id/separator_4"
-            android:layout_width="1dp"
+            android:layout_width="0.5dp"
             android:layout_height="0dp"
             android:background="@color/special_key_light"
             android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="@+id/plural_btn"
+            app:layout_constraintBottom_toBottomOf="@+id/command_field"
             app:layout_constraintEnd_toStartOf="@+id/emoji_btn_phone_2"
             app:layout_constraintHeight_percent="0.8"
             app:layout_constraintHorizontal_weight="1"
             app:layout_constraintStart_toEndOf="@+id/emoji_btn_phone_1"
-
-            app:layout_constraintTop_toTopOf="@+id/plural_btn"
+            app:layout_constraintTop_toTopOf="@+id/command_field"
             app:layout_constraintVertical_bias="0.5" />
 
 
@@ -222,6 +221,20 @@
             app:layout_constraintHorizontal_weight="1"
             app:layout_constraintStart_toStartOf="@+id/plural_btn" />
 
+        <View
+            android:id="@+id/separator_5"
+            android:layout_width="0.5dp"
+            android:layout_height="0dp"
+            android:background="@color/special_key_light"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="@+id/command_field"
+            app:layout_constraintEnd_toStartOf="@+id/emoji_space_tablet_1"
+            app:layout_constraintHeight_percent="0.8"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/emoji_btn_tablet_1"
+            app:layout_constraintTop_toTopOf="@+id/command_field"
+            app:layout_constraintVertical_bias="0.5" />
+
         <TextView
             android:id="@+id/emoji_space_tablet_1"
             android:layout_width="wrap_content"
@@ -245,6 +258,20 @@
             app:layout_constraintEnd_toStartOf="@+id/emoji_space_tablet_2"
             app:layout_constraintHorizontal_weight="1"
             app:layout_constraintStart_toEndOf="@+id/emoji_space_tablet_1" />
+
+        <View
+            android:id="@+id/separator_6"
+            android:layout_width="0.5dp"
+            android:layout_height="0dp"
+            android:background="@color/special_key_light"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="@+id/command_field"
+            app:layout_constraintEnd_toStartOf="@+id/emoji_space_tablet_2"
+            app:layout_constraintHeight_percent="0.8"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/emoji_btn_tablet_2"
+            app:layout_constraintTop_toTopOf="@+id/command_field"
+            app:layout_constraintVertical_bias="0.5" />
 
         <TextView
             android:id="@+id/emoji_space_tablet_2"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
This pull request addresses several UI layout issues in the keyboard interface:

1. **Fixed emoji separator visibility**: Previously, only one separator was visible for three emoji buttons, causing emoji buttons to overlap with separators. This has been fixed by properly configuring all separators.

2. **Fixed separator_4 visibility**: Resolved an issue where separator_4 was overlapping with the plural button, causing UI conflicts.

3. **Refactored setupIdleView() function**: Improved code organization and readability by restructuring the function and applying proper Kotlin conventions.

## Testing

I have tested the changes on both medium phone and pixel tablet api 35 emulators also test on a physical device (smartphone)

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #321 

## Screenshots

**Mobile View with proper layouts**

![Screenshot_20250328_000634](https://github.com/user-attachments/assets/bc543641-afe2-424c-85db-3df8e8714279)

**Fixed the overlapping on plural button**
 
![Screenshot_20250328_000451](https://github.com/user-attachments/assets/eeca4601-1248-4bd5-9bb6-9c857370b9fe)

**Fixed Tablet layout with proper separator for each emoji**
 
![Screenshot_20250328_000436](https://github.com/user-attachments/assets/4634ad6b-7215-475f-9d1e-3e5018eb775f)
