### PR TITLE
Add detekt and ktlint rules for docstrings to project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,5 @@ ktlint_code_style = ktlint_official
 ktlint_standard = enabled
 ktlint_standard_final-newline = enabled
 ktlint_function_naming_ignore_when_annotated_with = Composable
+
+ktlint_standard_kdoc = enabled

--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Handles application-level initialization and sets the default night mode based on user configuration.
  */

--- a/app/src/main/java/be/scri/activities/MainActivity.kt
+++ b/app/src/main/java/be/scri/activities/MainActivity.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Implements the main activity with a custom action bar, ViewPager navigation, and dynamic UI adjustments.
  */

--- a/app/src/main/java/be/scri/extensions/CommonsContext.kt
+++ b/app/src/main/java/be/scri/extensions/CommonsContext.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Functions and properties for accessing shared preferences and BaseConfig.
  */

--- a/app/src/main/java/be/scri/extensions/Context.kt
+++ b/app/src/main/java/be/scri/extensions/Context.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Functions for retrieving configuration settings and calculating color based on theme and background preferences.
  */

--- a/app/src/main/java/be/scri/extensions/ContextStyling.kt
+++ b/app/src/main/java/be/scri/extensions/ContextStyling.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Functions for determining and retrieving proper text and colors based on user settings.
  */

--- a/app/src/main/java/be/scri/extensions/Drawable.kt
+++ b/app/src/main/java/be/scri/extensions/Drawable.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Extends the Drawable class to apply a color filter to a drawable using a specified color.
  */

--- a/app/src/main/java/be/scri/extensions/Int.kt
+++ b/app/src/main/java/be/scri/extensions/Int.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Functions for manipulating colors used within the application.
  */

--- a/app/src/main/java/be/scri/extensions/RecyclerView.kt
+++ b/app/src/main/java/be/scri/extensions/RecyclerView.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Adds a custom item decoration (divider) to a RecyclerView, using a specified drawable and custom margins.
  */

--- a/app/src/main/java/be/scri/extensions/View.kt
+++ b/app/src/main/java/be/scri/extensions/View.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Utility functions for managing visibility and haptic feedback in Android views.
  */

--- a/app/src/main/java/be/scri/helpers/CommonsConstants.kt
+++ b/app/src/main/java/be/scri/helpers/CommonsConstants.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Common constants that are used throughout helper classes and objects.
  */

--- a/app/src/main/java/be/scri/helpers/Constants.kt
+++ b/app/src/main/java/be/scri/helpers/Constants.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Constants that are used throughout helper classes and objects.
  */

--- a/app/src/main/java/be/scri/helpers/HintUtils.kt
+++ b/app/src/main/java/be/scri/helpers/HintUtils.kt
@@ -13,6 +13,11 @@ import be.scri.helpers.spanish.ESInterfaceVariables
 import be.scri.helpers.swedish.SVInterfaceVariables
 import be.scri.services.GeneralKeyboardIME
 
+/**
+ * Utility object for handling hint-related logic throughout the application.
+ *
+ * This may include methods for showing, formatting, or validating hints in forms or UI components.
+ */
 object HintUtils {
     /**
      * Resets the application hints, marking them as not shown in the shared preferences.

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Custom keyboard implementation for handling keyboard layouts, rows and keys with XML-based configuration.
  */

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -548,6 +548,9 @@ class KeyboardBase {
         a.recycle()
     }
 
+    /**
+     * Holds custom IME (Input Method Editor) action constants.
+     */
     object MyCustomActions {
         const val IME_ACTION_COMMAND = 0x00000008
     }

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-/**
- * A helper to facilitate setting preferences for individual language keyboards.
- */
-
 package be.scri.helpers
 
 import android.app.UiModeManager
@@ -16,6 +12,9 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import be.scri.extensions.config
 
+/**
+ * A helper to facilitate setting preferences for individual language keyboards.
+ */
 @Suppress("TooManyFunctions")
 object PreferencesHelper {
     /**

--- a/app/src/main/java/be/scri/helpers/RatingHelper.kt
+++ b/app/src/main/java/be/scri/helpers/RatingHelper.kt
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-/**
- * A helper to facilitate rating the application on Google Play or F-Droid.
- */
-
 package be.scri.helpers
 
 import android.content.Context
@@ -15,6 +11,9 @@ import android.widget.Toast
 import be.scri.activities.MainActivity
 import com.google.android.play.core.review.ReviewManagerFactory
 
+/**
+ * A helper to facilitate rating the application on Google Play or F-Droid.
+ */
 object RatingHelper {
     /**
      * Retrieves the source from which the application was installed.

--- a/app/src/main/java/be/scri/helpers/ShareHelper.kt
+++ b/app/src/main/java/be/scri/helpers/ShareHelper.kt
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-/**
- * A helper to facilitate sharing of the application and contacting the team.
- */
-
 package be.scri.helpers
 
 import android.content.ActivityNotFoundException
@@ -12,6 +8,9 @@ import android.content.Intent
 import android.util.Log
 import androidx.core.content.ContextCompat.startActivity
 
+/**
+ * A helper to facilitate sharing of the application and contacting the team.
+ */
 object ShareHelper {
     /**
      * Shares the link to the Scribe Android project repository.

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Interface variables for English language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+package be.scri.helpers.french
+
 /**
  * Interface variables for French language keyboards.
  */
-
-package be.scri.helpers.french
-
 object FRInterfaceVariables {
     // MARK: Currency Symbols
 

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Interface variables for German language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Interface variables for Italian language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Interface variables for Portuguese language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Interface variables for Russian language keyboards.
  */

--- a/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+package be.scri.helpers.spanish
+
 /**
  * Interface variables for Spanish language keyboards.
  */
-
-package be.scri.helpers.spanish
-
 object ESInterfaceVariables {
     // MARK: Currency Symbols
 

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Interface variables for Swedish language keyboards.
  */

--- a/app/src/main/java/be/scri/models/DataContract.kt
+++ b/app/src/main/java/be/scri/models/DataContract.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Data structure to hold various linguistic data for the Scribe keyboard.
  *

--- a/app/src/main/java/be/scri/models/ItemsViewModel.kt
+++ b/app/src/main/java/be/scri/models/ItemsViewModel.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The item view model class used in the application.
  */

--- a/app/src/main/java/be/scri/models/SwitchItem.kt
+++ b/app/src/main/java/be/scri/models/SwitchItem.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The switch item model class used in the application.
  */

--- a/app/src/main/java/be/scri/models/TextItem.kt
+++ b/app/src/main/java/be/scri/models/TextItem.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The text item model class used in the application.
  */

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the English language keyboard.
  */

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the French language keyboard.
  */

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The base keyboard input method (IME) imported into all language keyboards.
  */

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the German language keyboard.
  */

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the Italian language keyboard.
  */
+
 package be.scri.services
 
 import android.text.InputType

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the Portuguese language keyboard.
  */

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the Russian language keyboard.
  */

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the Spanish language keyboard.
  */

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The input method (IME) for the Swedish language keyboard.
  */

--- a/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * This is the base composable for all the screens.
  */

--- a/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Provides items to the navigation bar.
  */

--- a/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The bottom bar that is displayed at the bottom of the screen for navigation purposes.
  */

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * A composable component that displays a row with a title as well as leading and trailing icons.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  *  A composable component that displays a clickable item with a title, optional description and an arrow icon.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * A composable function for a screen layout in the main activity.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  *  A composable function that displays a list of items inside a card container.
  */

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  *  A composable function that displays a title above a list of items inside a card container.
  */

--- a/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * A composable component that displays a switch alongside a title and description.
  */

--- a/app/src/main/java/be/scri/ui/models/ScribeItem.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItem.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * A class defining different types of items used in the application interface.
  */

--- a/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * A class defining lists of ScribeItem elements.
  */

--- a/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The installation page of the application with details for installing Scribe keyboards and downloading data.
  */

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The settings sub menu page for languages that allows for customization of language keyboard interfaces.
  */

--- a/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The about screen that displays the privacy policy for the application.
  */

--- a/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The Select Languages subpage is for selecting the translation source language.
  */
+
 package be.scri.ui.screens
 
 import android.content.Context

--- a/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The about screen to display third-party legal information for software used in the application.
  */

--- a/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The about screen for describing the relationship between Scribe and the Wikimedia movement.
  */

--- a/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The about page of the application with links to the community as well as sub pages for detailed descriptions.
  */

--- a/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * This file provide utility functions for the about page
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The settings tab for the application including settings for language keyboards as sub menus.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * This file provides utility functions for settings page.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * This files handles the state and business logic for the settings screen.
  */

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * This file provides context for the the viewmodel to change the settings.
  */

--- a/app/src/main/java/be/scri/ui/theme/Colors.kt
+++ b/app/src/main/java/be/scri/ui/theme/Colors.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Custom colors for use throughout the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
+++ b/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Light and dark mode themes for the application.
  */

--- a/app/src/main/java/be/scri/ui/theme/Typography.kt
+++ b/app/src/main/java/be/scri/ui/theme/Typography.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Text styles for the application.
  */

--- a/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
+++ b/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * A custom divider for use in recycle views.
  */

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * The base keyboard view for Scribe language keyboards application.
  */

--- a/app/src/test/kotlin/be/scri/helpers/PreferencesHelperTest.kt
+++ b/app/src/test/kotlin/be/scri/helpers/PreferencesHelperTest.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Testing for PreferencesHelper.
  */

--- a/app/src/test/kotlin/helpers/AlphanumericComparatorTest.kt
+++ b/app/src/test/kotlin/helpers/AlphanumericComparatorTest.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
+@file:Suppress("ktlint:standard:kdoc")
 /**
  * Testing for AlphanumericComparator.
  */

--- a/detekt.yml
+++ b/detekt.yml
@@ -52,3 +52,23 @@ empty-blocks:
 performance:
     SpreadOperator:
         active: true
+
+comments:
+    UndocumentedPublicFunction:
+        active: true
+        excludes: &excludedFolders
+            - '**/activities/**'
+            - '**/extensions/**'
+            - '**/helpers/**/*Variables.kt'
+            - '**/models/**'
+            - '**/navigation/**'
+            - '**/services/**'
+            - '**/test/**'
+            - '**/ui/**'
+            - '**/views/**'
+            - '**/App.kt'
+    UndocumentedPublicClass:
+        active: true
+        excludes: *excludedFolders
+
+


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR integrates Detekt and Ktlint rules related to KDoc (Kotlin docstrings) into the project to enforce consistent documentation standards across the codebase.

✅ Changes include:
- Enabled KDoc formatting checks via ktlint
- Added relevant detekt rules for detecting missing documentation

Updated existing file headers and KDoc comments to comply with new rules

🛠️ Motivation:

- To improve code readability, maintainability, and enforce consistent documentation practices throughout the project.
### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #354
