### PR TITLE
Implement Translate Mode Keyboard Switch 

### DIFF
--- a/app/src/main/java/be/scri/helpers/HintUtils.kt
+++ b/app/src/main/java/be/scri/helpers/HintUtils.kt
@@ -126,9 +126,10 @@ object HintUtils {
     fun getPromptText(
         currentState: GeneralKeyboardIME.ScribeState,
         language: String,
+        context: Context,
     ): String =
         when (currentState) {
-            GeneralKeyboardIME.ScribeState.TRANSLATE -> getTranslationPrompt(language)
+            GeneralKeyboardIME.ScribeState.TRANSLATE -> getTranslationPrompt(language, context)
             GeneralKeyboardIME.ScribeState.CONJUGATE -> getConjugationPrompt(language)
             GeneralKeyboardIME.ScribeState.PLURAL -> getPluralPrompt(language)
             else -> ""
@@ -140,7 +141,10 @@ object HintUtils {
      * @param language The language code (e.g., "English", "French").
      * @return The translation prompt text for the given language.
      */
-    private fun getTranslationPrompt(language: String): String {
+    private fun getTranslationPrompt(
+        language: String,
+        context: Context,
+    ): String {
         val languageShorthand =
             mapOf(
                 "English" to "en",
@@ -152,8 +156,14 @@ object HintUtils {
                 "Spanish" to "es",
                 "Swedish" to "sv",
             )
-        val shorthand = languageShorthand[language] ?: "en" // default fallback to "en"
-        return "en -> $shorthand"
+        val preferredLanguage =
+            PreferencesHelper.getPreferredTranslationLanguage(
+                context = context,
+                language = language,
+            )
+        val keyboardLanguage = languageShorthand[preferredLanguage]
+        val sourceLanguage = languageShorthand[language] ?: "en" // default fallback to "en"
+        return "$keyboardLanguage -> $sourceLanguage"
     }
 
     /**

--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+@file:Suppress("ktlint:standard:kdoc")
+
 package be.scri.helpers
 
 import android.util.Log

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -356,4 +356,15 @@ object PreferencesHelper {
         val isEnabled = sharedPref.getBoolean(getLanguageSpecificPreferenceKey(EMOJI_SUGGESTIONS, language), true)
         return isEnabled
     }
+
+    fun getPreferredTranslationLanguage(
+        context: Context,
+        language: String,
+    ): String? {
+        val prefs = context.getSharedPreferences("app_preferences", MODE_PRIVATE)
+        return prefs.getString(
+            PreferencesHelper.getLanguageSpecificPreferenceKey(TRANSLATION_SOURCE, language),
+            "English",
+        )
+    }
 }

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+@file:Suppress("ktlint:standard:kdoc")
 
 package be.scri.helpers
 

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -357,6 +357,14 @@ object PreferencesHelper {
         return isEnabled
     }
 
+    /**
+     * Retrieves the preferred translation language for a given language.
+     *
+     * @param context The application context.
+     * @param language The language for which to get the preferred translation language.
+     *
+     * @return The preferred translation language.
+     * */
     fun getPreferredTranslationLanguage(
         context: Context,
         language: String,

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -40,6 +40,7 @@ import be.scri.helpers.PERIOD_ON_DOUBLE_TAP
 import be.scri.helpers.PreferencesHelper
 import be.scri.helpers.PreferencesHelper.getIsDarkModeOrNot
 import be.scri.helpers.PreferencesHelper.getIsEmojiSuggestionsEnabled
+import be.scri.helpers.PreferencesHelper.getPreferredTranslationLanguage
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
 import be.scri.helpers.SHIFT_ON_PERMANENT
@@ -519,6 +520,8 @@ abstract class GeneralKeyboardIME(
                 setupIdleView()
                 handleTextSizeForSuggestion(binding)
                 initializeEmojiButtons()
+                keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType)
+                keyboardView!!.setKeyboard(keyboard!!)
                 updateButtonVisibility(emojiAutoSuggestionEnabled)
                 updateButtonText(emojiAutoSuggestionEnabled, autoSuggestEmojis)
             }
@@ -537,37 +540,64 @@ abstract class GeneralKeyboardIME(
      * to have toolbar interface, allowing the user to interact with the toolbar.
      */
     private fun switchToToolBar() {
-        this.keyboardBinding = initializeKeyboardBinding()
+        keyboardBinding = initializeKeyboardBinding()
         val keyboardHolder = keyboardBinding.root
+
         setupToolBarTheme(keyboardBinding)
         handleTextSizeForSuggestion(binding)
-        var isUserDarkMode = getIsDarkModeOrNot(applicationContext)
         binding.translateBtn.textSize = SUGGESTION_SIZE
-        when (isUserDarkMode) {
-            true -> {
-                keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(R.color.special_key_dark))
-                val color = ContextCompat.getColorStateList(this, R.color.light_key_color)
-                keyboardBinding.scribeKey.foregroundTintList = color
+
+        val isDarkMode = getIsDarkModeOrNot(applicationContext)
+        updateToolBarTheme(isDarkMode)
+
+        handleModeChange(keyboardSymbols, keyboardView, this)
+
+        val keyboardXmlId =
+            if (currentState == ScribeState.TRANSLATE) {
+                val language = getPreferredTranslationLanguage(this, language)
+                baseKeyboardOfAnyLanguage(language)
+            } else {
+                getKeyboardLayoutXML()
             }
 
-            false -> {
-                keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(R.color.special_key_light))
-                val colorLight = ContextCompat.getColorStateList(this, R.color.light_key_text_color)
-                keyboardBinding.scribeKey.foregroundTintList = colorLight
+        keyboard = KeyboardBase(this, keyboardXmlId, enterKeyType)
+        keyboardView =
+            keyboardBinding.keyboardView.apply {
+                setKeyboard(keyboard!!)
+                mOnKeyboardActionListener = this@GeneralKeyboardIME
             }
-        }
-        handleModeChange(keyboardSymbols, keyboardView, this)
-        keyboardView = keyboardBinding.keyboardView
-        keyboardView!!.setKeyboard(keyboard!!)
-        keyboardView!!.mOnKeyboardActionListener = this
+
         keyboardBinding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             switchToCommandToolBar()
             handleTextSizeForSuggestion(binding)
             updateUI()
         }
+
         setInputView(keyboardHolder)
-        updateCommandBarHintAndPrompt(isUserDarkMode)
+        updateCommandBarHintAndPrompt(isDarkMode)
+    }
+
+    /**
+     * Updates the toolbar theme based on the current system theme (dark or light).
+     *
+     * This function adjusts the toolbar's visual elements such as the top divider color
+     * and the tint of the custom scribe key, depending on whether dark mode is enabled.
+     *
+     * @param isDarkMode A boolean indicating if the system is in dark mode.
+     */
+    private fun updateToolBarTheme(isDarkMode: Boolean) {
+        val dividerColor = if (isDarkMode) R.color.special_key_dark else R.color.special_key_light
+        keyboardBinding.topKeyboardDivider.setBackgroundColor(getColor(dividerColor))
+
+        val tintColor =
+            if (isDarkMode) {
+                ContextCompat.getColorStateList(this, R.color.light_key_color)
+            } else {
+                ContextCompat.getColorStateList(this, R.color.light_key_text_color)
+            }
+
+        keyboardBinding.scribeKey.foregroundTintList = tintColor
     }
 
     /**
@@ -1641,6 +1671,19 @@ abstract class GeneralKeyboardIME(
             keyboardView!!.invalidateAllKeys()
         }
     }
+
+    private fun baseKeyboardOfAnyLanguage(language: String?): Int =
+        when (language) {
+            "English" -> R.xml.keys_letters_english
+            "French" -> R.xml.keys_letters_french
+            "German" -> R.xml.keys_letters_german
+            "Italian" -> R.xml.keys_letters_italian
+            "Portuguese" -> R.xml.keys_letters_portuguese
+            "Russian" -> R.xml.keys_letters_russian
+            "Spanish" -> R.xml.keys_letters_spanish
+            "Swedish" -> R.xml.keys_letters_swedish
+            else -> R.xml.keys_letters_english
+        }
 
     internal companion object {
         const val DEFAULT_SHIFT_PERM_TOGGLE_SPEED = 500

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -461,7 +461,7 @@ abstract class GeneralKeyboardIME(
     private fun updateCommandBarHintAndPrompt(isUserDarkMode: Boolean? = null) {
         val commandBarButton = keyboardBinding.commandBar
         val hintMessage = HintUtils.getCommandBarHint(currentState, language)
-        val promptText = HintUtils.getPromptText(currentState, language)
+        val promptText = HintUtils.getPromptText(currentState, language, context = this)
         val promptTextView = keyboardBinding.promptText
         promptTextView.text = promptText
         commandBarButton.hint = hintMessage

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1672,6 +1672,19 @@ abstract class GeneralKeyboardIME(
         }
     }
 
+    /**
+     * Returns the XML layout resource ID for the base keyboard of the specified language.
+     *
+     * This function maps a given language name to its corresponding keyboard layout XML file.
+     * If the provided language is `null` or doesn't match any of the predefined options,
+     * the function defaults to returning the English keyboard layout.
+     *
+     * @param language The name of the language for which the base keyboard layout is requested.
+     *                 Expected values are: "English", "French", "German", "Italian",
+     *                 "Portuguese", "Russian", "Spanish", and "Swedish".
+     *
+     * @return The resource ID of the XML layout file for the corresponding keyboard.
+     */
     private fun baseKeyboardOfAnyLanguage(language: String?): Int =
         when (language) {
             "English" -> R.xml.keys_letters_english


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

The PR introduces the feature to switch the keyboard to the keyboard language selected to be translated from for each language keyboard. The keyboard switches to the selected language from the settings when present in translate mode. 

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

Closes #265
