### PR TITLE
fix: Add width to tooltips box

### DIFF
--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -107,7 +107,7 @@ fun HintDialogContent(
 
     Box(
         modifier =
-            modifier.padding(horizontal = 12.dp).background(
+            modifier.padding(horizontal = 4.dp).background(
                 brush =
                     Brush.verticalGradient(
                         colors =


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This fix added width to tooltips box

### Screenshots

| Before | After |
|--------|--------|
| ![WhatsApp Image 2025-04-12 at 08 46 38](https://github.com/user-attachments/assets/096b57a0-9352-423e-8b91-18d931d310c3) | ![WhatsApp Image 2025-04-12 at 08 46 38 (1)](https://github.com/user-attachments/assets/c164dbdc-670f-4e72-8b33-cf362a970fa2)| 

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #361
