### PR TITLE
Implement Translate feature for the keyboard

### DIFF
--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -3,6 +3,7 @@
 package be.scri.helpers
 
 import DataContract
+import android.annotation.SuppressLint
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
@@ -15,6 +16,7 @@ import android.database.sqlite.SQLiteOpenHelper
  *
  * @param context The context used to access the app's resources and database.
  */
+@Suppress("TooManyFunctions")
 class DatabaseHelper(
     context: Context,
 ) : SQLiteOpenHelper(
@@ -148,4 +150,23 @@ class DatabaseHelper(
             getRequiredData(language),
             noun,
         )
+
+    /**
+     * Retrieves the translation of a given word between the source and destination languages.
+     *
+     * This function determines the source and destination language ISO codes based on the provided
+     * language name, and then fetches the translation of the specified word using those language codes.
+     *
+     * @param language The language name (e.g., "english") to determine the source and destination languages.
+     * @param word The word whose translation is to be fetched.
+     * @return The translation of the given word in the destination language,
+     * or an empty string if no translation is found.
+     */
+    fun getTranslationSourceAndDestination(
+        language: String,
+        word: String,
+    ): String {
+        val sourceAndDestination = dbManagers.translationDataManager.getSourceAndDestinationLanguage(language)
+        return dbManagers.translationDataManager.getTranslationDataForAWord(sourceAndDestination, word)
+    }
 }

--- a/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseHelper.kt
@@ -3,7 +3,6 @@
 package be.scri.helpers
 
 import DataContract
-import android.annotation.SuppressLint
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper

--- a/app/src/main/java/be/scri/helpers/DatabaseManagers.kt
+++ b/app/src/main/java/be/scri/helpers/DatabaseManagers.kt
@@ -8,6 +8,7 @@ import GenderDataManager
 import PluralFormsManager
 import android.content.Context
 import be.scri.helpers.keyboardDBHelper.PrepositionDataManager
+import be.scri.helpers.keyboardDBHelper.TranslationDataManager
 
 /**
  * A helper class that manages various database-related operations
@@ -27,4 +28,5 @@ class DatabaseManagers(
     val genderManager = GenderDataManager(context)
     val pluralManager = PluralFormsManager(context)
     val prepositionManager = PrepositionDataManager(context)
+    val translationDataManager = TranslationDataManager(context)
 }

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -371,7 +371,7 @@ object PreferencesHelper {
     ): String? {
         val prefs = context.getSharedPreferences("app_preferences", MODE_PRIVATE)
         return prefs.getString(
-            PreferencesHelper.getLanguageSpecificPreferenceKey(TRANSLATION_SOURCE, language),
+            getLanguageSpecificPreferenceKey(TRANSLATION_SOURCE, language),
             "English",
         )
     }

--- a/app/src/main/java/be/scri/helpers/keyboardDBHelper/TranslationDataManager.kt
+++ b/app/src/main/java/be/scri/helpers/keyboardDBHelper/TranslationDataManager.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package be.scri.helpers.keyboardDBHelper
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import be.scri.helpers.PreferencesHelper
+import java.io.FileOutputStream
+
+/**
+ * A helper class to manage translations from a local SQLite database.
+ *
+ * This class provides methods to fetch translations between different languages
+ * by querying the `TranslationData.sqlite` database stored locally. It handles
+ * the source and destination language code generation based on user preferences.
+ *
+ * @property context The application context used to access resources and the database.
+ */
+class TranslationDataManager(
+    private val context: Context,
+) {
+    /**
+     * Retrieves the source and destination language ISO codes based on the provided language.
+     *
+     * This function fetches the preferred translation language from the preferences
+     * and generates the corresponding ISO codes for the source and destination languages.
+     *
+     * @param language The language name (e.g., "english") for which the source and destination
+     *                 ISO codes need to be determined.
+     * @return A pair of ISO codes: the source language and the destination language.
+     */
+    fun getSourceAndDestinationLanguage(language: String): Pair<String?, String?> {
+        val sourceLanguage = PreferencesHelper.getPreferredTranslationLanguage(context, language)
+        return Pair(generateISOCodeForLanguage(sourceLanguage.toString()), generateISOCodeForLanguage(language))
+    }
+
+    /**
+     * Generates the ISO code for a given language name.
+     *
+     * This function maps the full name of a language (e.g., "english") to its corresponding
+     * ISO 639-1 code (e.g., "en").
+     *
+     * @param languageName The name of the language (e.g., "english").
+     * @return The ISO 639-1 code for the given language, or "en" if the language is unrecognized.
+     */
+    private fun generateISOCodeForLanguage(languageName: String): String? =
+        when (languageName.lowercase()) {
+            "english" -> "en"
+            "french" -> "fr"
+            "german" -> "de"
+            "spanish" -> "es"
+            "italian" -> "it"
+            "portuguese" -> "pt"
+            "russian" -> "ru"
+            else -> "en"
+        }
+
+    /**
+     * Generates the full language name for a given ISO code.
+     *
+     * This function maps an ISO 639-1 language code (e.g., "en") to the corresponding full
+     * language name (e.g., "english").
+     *
+     * @param isoCode The ISO 639-1 code for the language (e.g., "en").
+     * @return The full name of the language, or "english" if the ISO code is unrecognized.
+     */
+    private fun generateLanguageNameForISOCode(isoCode: String): String? =
+        when (isoCode.lowercase()) {
+            "en" -> "english"
+            "fr" -> "french"
+            "de" -> "german"
+            "es" -> "spanish"
+            "it" -> "italian"
+            "pt" -> "portuguese"
+            "ru" -> "russian"
+            else -> "english"
+        }
+
+    /**
+     * Retrieves the translation data for a given word from the database.
+     *
+     * This function queries the database for the translation of the given word from the source
+     * language to the destination language, using the source and destination language ISO codes.
+     *
+     * @param sourceAndDestination A pair of ISO codes representing the source and destination languages.
+     * @param word The word for which the translation is to be fetched.
+     * @return The translation of the word in the destination language, or an empty string if not found.
+     */
+    fun getTranslationDataForAWord(
+        sourceAndDestination: Pair<String?, String?>,
+        word: String,
+    ): String {
+        val sourceLanguage = generateLanguageNameForISOCode(sourceAndDestination.first!!)
+        val destinationColumn = sourceAndDestination.second!!
+        val dbPath = context.getDatabasePath("TranslationData.sqlite")
+
+        if (!dbPath.exists()) {
+            dbPath.parentFile?.mkdirs()
+            context.assets.open("data/TranslationData.sqlite").use { inputStream ->
+                FileOutputStream(dbPath).use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                }
+            }
+        }
+        val db = SQLiteDatabase.openDatabase(dbPath.path, null, SQLiteDatabase.OPEN_READONLY)
+        var result = ""
+
+        db.use { database ->
+            val query = "SELECT $destinationColumn FROM `$sourceLanguage` WHERE word = ?"
+            val cursor = database.rawQuery(query, arrayOf(word))
+
+            cursor.use {
+                if (it.moveToFirst()) {
+                    result = it.getString(it.getColumnIndexOrThrow(destinationColumn))
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -690,6 +690,7 @@ abstract class GeneralKeyboardIME(
             keyboardView?.invalidateAllKeys()
             updateCommandBarHintAndPrompt()
             currentState = ScribeState.TRANSLATE
+
             updateUI()
         }
         binding.conjugateBtn.setOnClickListener {
@@ -1415,6 +1416,21 @@ abstract class GeneralKeyboardIME(
     }
 
     /**
+     * Safely retrieves the translation of a word between source and destination languages.
+     *
+     * This function calls `getTranslationSourceAndDestination` and handles the null case
+     * by returning an empty string if the translation is null.
+     *
+     * @param language The language name (e.g., "english") to determine the source and destination languages.
+     * @param commandBarInput The word whose translation is to be fetched.
+     * @return The translation of the word in the destination language, or an empty string if no translation is found.
+     */
+    fun getTranslation(
+        language: String,
+        commandBarInput: String,
+    ): String = dbHelper.getTranslationSourceAndDestination(language, commandBarInput) ?: ""
+
+    /**
      * Retrieves the action ID associated with the IME (Input Method Editor) options.
      *
      * @return The action ID as an integer.
@@ -1456,6 +1472,7 @@ abstract class GeneralKeyboardIME(
             commandModeOutput =
                 when (currentState) {
                     ScribeState.PLURAL -> getPluralRepresentation(commandBarInput) ?: ""
+                    ScribeState.TRANSLATE -> getTranslation(language, commandBarInput)
                     else -> commandBarInput
                 }
             if (commandModeOutput.length > commandBarInput.length) {

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -204,7 +204,7 @@ fun LanguageSettingsScreen(
                     .verticalScroll(scrollState),
         ) {
             ItemCardContainerWithTitle(
-                title = stringResource(R.string.app_settings_keyboard_translation_select_source),
+                title = stringResource(R.string.app_settings_keyboard_translation_title),
                 cardItemsList = translationSourceLanguageList,
             )
             ItemCardContainerWithTitle(


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

The PR implements the translate feature. When the user is in the translate mode. The users text on click of the enter gets translated to the destination language from the user selected source language. 
### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

Closes #266 
