### PR TITLE
 Add unit tests for settingsUtil functions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -244,6 +244,7 @@ dependencies {
     // Android testing framework
     androidTestImplementation("androidx.test:core-ktx:1.6.1")
     androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-intents:3.6.1")
 
     // JUnit 5 dependencies
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5Version")
@@ -251,7 +252,7 @@ dependencies {
 
     //  AndroidJUnit4 is included
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test:runner:1.6.1")
     androidTestImplementation("io.mockk:mockk-android:1.13.5")
 
     // Other libraries

--- a/app/src/androidTest/kotlin/be/scri/ui/screens/settings/SettingsUtilTest.kt
+++ b/app/src/androidTest/kotlin/be/scri/ui/screens/settings/SettingsUtilTest.kt
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 package be.scri.ui.screens.settings
 
 import android.content.Context

--- a/app/src/androidTest/kotlin/be/scri/ui/screens/settings/SettingsUtilTest.kt
+++ b/app/src/androidTest/kotlin/be/scri/ui/screens/settings/SettingsUtilTest.kt
@@ -1,0 +1,123 @@
+package be.scri.ui.screens.settings
+
+import android.content.Context
+import android.provider.Settings
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SettingsUtilTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        Intents.init()
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+    }
+
+    @Test
+    fun testSetLightDarkMode_SetsDarkModeCorrectly() {
+        SettingsUtil.setLightDarkMode(true, context)
+
+        val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val savedPref = sharedPref.getBoolean("dark_mode", false)
+        assertTrue(savedPref)
+
+        val currentMode = AppCompatDelegate.getDefaultNightMode()
+        assertEquals(AppCompatDelegate.MODE_NIGHT_YES, currentMode)
+    }
+
+    @Test
+    fun testSetLightDarkMode_SetsLightModeCorrectly() {
+        SettingsUtil.setLightDarkMode(false, context)
+
+        val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+        val savedPref = sharedPref.getBoolean("dark_mode", true)
+        assertFalse(savedPref)
+
+        val currentMode = AppCompatDelegate.getDefaultNightMode()
+        assertEquals(AppCompatDelegate.MODE_NIGHT_NO, currentMode)
+    }
+
+    @Test
+    fun testNavigateToKeyboardSettings_LaunchesCorrectIntent() {
+        SettingsUtil.navigateToKeyboardSettings(context)
+
+        Intents.intended(hasAction(Settings.ACTION_INPUT_METHOD_SETTINGS))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_English() {
+        val result = SettingsUtil.getLocalizedLanguageName("English")
+
+        assertEquals("English", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_French() {
+        val result = SettingsUtil.getLocalizedLanguageName("French")
+
+        assertEquals("French", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_German() {
+        val result = SettingsUtil.getLocalizedLanguageName("German")
+
+        assertEquals("German", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_Russian() {
+        val result = SettingsUtil.getLocalizedLanguageName("Russian")
+
+        assertEquals("Russian", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_Spanish() {
+        val result = SettingsUtil.getLocalizedLanguageName("Spanish")
+
+        assertEquals("Spanish", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_Italian() {
+        val result = SettingsUtil.getLocalizedLanguageName("Italian")
+
+        assertEquals("Italian", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_Portuguese() {
+        val result = SettingsUtil.getLocalizedLanguageName("Portuguese")
+
+        assertEquals("Portuguese", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_Swedish() {
+        val result = SettingsUtil.getLocalizedLanguageName("Swedish")
+
+        assertEquals("Swedish", context.getString(result))
+    }
+
+    @Test
+    fun testGetLocalizedLanguageName_Undeclared() {
+        val result = SettingsUtil.getLocalizedLanguageName("Yoruba")
+
+        assertEquals("Language", context.getString(result))
+    }
+}

--- a/app/src/androidTest/kotlin/be/scri/ui/screens/settings/SettingsUtilTest.kt
+++ b/app/src/androidTest/kotlin/be/scri/ui/screens/settings/SettingsUtilTest.kt
@@ -29,6 +29,20 @@ class SettingsUtilTest {
     }
 
     @Test
+    fun testCheckKeyboardInstallation_False() {
+        val packageName = SettingsUtil.checkKeyboardInstallation(context)
+
+        assertFalse(packageName)
+    }
+
+    @Test
+    fun testGetKeyboardLanguage_Empty() {
+        val keyboardLanguages = SettingsUtil.getKeyboardLanguages(context)
+        val list = arrayListOf<String>()
+        assertEquals(list, keyboardLanguages)
+    }
+
+    @Test
     fun testSetLightDarkMode_SetsDarkModeCorrectly() {
         SettingsUtil.setLightDarkMode(true, context)
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request introduces unit tests for the utility functions in the SettingsUtil class.


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #356
