### PR TITLE
Fix dangling top-level kdoc comments

### DIFF
--- a/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
+++ b/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 @file:Suppress("ktlint:standard:kdoc")
-/**
- * A custom divider for use in recycle views.
- */
 
 import android.graphics.Canvas
 import android.graphics.Rect
@@ -10,6 +7,9 @@ import android.graphics.drawable.Drawable
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 
+/**
+ * A custom divider for use in recycle views.
+ */
 class CustomDividerItemDecoration(
     private val drawable: Drawable,
     private val width: Int,

--- a/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
+++ b/app/src/main/java/be/scri/views/CustomDividerItemDecoration.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
 
 import android.graphics.Canvas
 import android.graphics.Rect

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 @file:Suppress("ktlint:standard:kdoc")
-/**
- * The base keyboard view for Scribe language keyboards application.
- */
 
 package be.scri.views
 
@@ -71,6 +68,9 @@ import be.scri.services.GeneralKeyboardIME.ScribeState
 import java.util.Arrays
 import java.util.Locale
 
+/**
+ * The base keyboard view for Scribe language keyboards application.
+ */
 @SuppressLint("UseCompatLoadingForDrawables")
 @Suppress("LargeClass", "LongMethod", "TooManyFunctions", "NestedBlockDepth", "CyclomaticComplexMethod")
 class KeyboardView

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
 
 package be.scri.views
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request fixes dangling top-level KDoc comments.


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #368
