### PR TITLE
Fix dangling top-level kdoc comments

### DIFF
--- a/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/ScribeBaseScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * This is the base composable for all the screens.
- */
 
 package be.scri.ui.common
 
@@ -18,6 +14,9 @@ import androidx.compose.ui.unit.dp
 import be.scri.ui.common.appcomponents.ActionBar
 import be.scri.ui.common.appcomponents.PageTitle
 
+/**
+ * This is the base composable for all the screens.
+ */
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun ScribeBaseScreen(

--- a/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/BottomBarScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Provides items to the navigation bar.
- */
 
 package be.scri.ui.common.bottombar
 
@@ -10,6 +6,9 @@ import androidx.annotation.DrawableRes
 import be.scri.R
 import be.scri.navigation.Screen
 
+/**
+ * Provides items to the navigation bar.
+ */
 sealed class BottomBarScreen(
     val route: String,
     @DrawableRes val icon: Int,

--- a/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
+++ b/app/src/main/java/be/scri/ui/common/bottombar/ScribeBottomBar.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The bottom bar that is displayed at the bottom of the screen for navigation purposes.
- */
 
 package be.scri.ui.common.bottombar
 
@@ -26,6 +22,9 @@ import androidx.compose.ui.unit.sp
 import be.scri.R
 import kotlinx.coroutines.flow.MutableSharedFlow
 
+/**
+ * The bottom bar that is displayed at the bottom of the screen for navigation purposes.
+ */
 @Composable
 fun ScribeBottomBar(
     onItemClick: (Int) -> Unit,

--- a/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/AboutPageItemComp.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * A composable component that displays a row with a title as well as leading and trailing icons.
- */
 
 package be.scri.ui.common.components
 
@@ -27,6 +23,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+/**
+ * A composable component that displays a row with a title as well as leading and trailing icons.
+ */
 @Composable
 fun AboutPageItemComp(
     title: String,

--- a/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ClickableItemComp.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- *  A composable component that displays a clickable item with a title, optional description and an arrow icon.
- */
 
 package be.scri.ui.common.components
 
@@ -27,6 +23,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import be.scri.R
 
+/**
+ *  A composable component that displays a clickable item with a title, optional description and an arrow icon.
+ */
 @Composable
 fun ClickableItemComp(
     title: String,

--- a/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ComposeScaffoldContainer.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * A composable function for a screen layout in the main activity.
- */
 
 package be.scri.ui.common.components
 
@@ -27,6 +23,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import be.scri.ui.theme.ScribeTypography
 
+/**
+ * A composable function for a screen layout in the main activity.
+ */
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MainActivityComposeScreen(

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainer.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- *  A composable function that displays a list of items inside a card container.
- */
 
 package be.scri.ui.common.components
 
@@ -20,6 +16,9 @@ import androidx.compose.ui.unit.dp
 import be.scri.ui.models.ScribeItem
 import be.scri.ui.models.ScribeItemList
 
+/**
+ *  A composable function that displays a list of items inside a card container.
+ */
 @Composable
 fun ItemsCardContainer(
     cardItemsList: ScribeItemList,

--- a/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
+++ b/app/src/main/java/be/scri/ui/common/components/ItemCardContainerWithTitle.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- *  A composable function that displays a title above a list of items inside a card container.
- */
 
 package be.scri.ui.common.components
 
@@ -18,6 +14,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import be.scri.ui.models.ScribeItemList
 
+/**
+ *  A composable function that displays a title above a list of items inside a card container.
+ */
 @Composable
 fun ItemCardContainerWithTitle(
     title: String,

--- a/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/SwitchableItemComp.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * A composable component that displays a switch alongside a title and description.
- */
 
 package be.scri.ui.common.components
 
@@ -26,6 +22,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+/**
+ * A composable component that displays a switch alongside a title and description.
+ */
 @Composable
 fun SwitchableItemComp(
     title: String,

--- a/app/src/main/java/be/scri/ui/models/ScribeItem.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItem.kt
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * A class defining different types of items used in the application interface.
- */
 
 package be.scri.ui.models
 
 import androidx.annotation.DrawableRes
 
+/**
+ * A class defining different types of items used in the application interface.
+ */
 sealed class ScribeItem(
     open val title: Int,
     open val desc: Int?,

--- a/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
+++ b/app/src/main/java/be/scri/ui/models/ScribeItemList.kt
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * A class defining lists of ScribeItem elements.
- */
 
 package be.scri.ui.models
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * A class defining lists of ScribeItem elements.
+ */
 @Immutable
 data class ScribeItemList(
     val items: List<ScribeItem>,

--- a/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/InstallationScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The installation page of the application with details for installing Scribe keyboards and downloading data.
- */
 
 package be.scri.ui.screens
 
@@ -52,6 +48,9 @@ import androidx.compose.ui.unit.sp
 import be.scri.R
 import be.scri.ui.common.ScribeBaseScreen
 
+/**
+ * The installation page of the application with details for installing Scribe keyboards and downloading data.
+ */
 @Suppress("MagicNumber")
 @Composable
 fun InstallationScreen(

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The settings sub menu page for languages that allows for customization of language keyboard interfaces.
- */
 
 package be.scri.ui.screens
 
@@ -35,6 +31,9 @@ import be.scri.ui.common.components.ItemCardContainerWithTitle
 import be.scri.ui.models.ScribeItem
 import be.scri.ui.models.ScribeItemList
 
+/**
+ * The settings sub menu page for languages that allows for customization of language keyboard interfaces.
+ */
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun LanguageSettingsScreen(

--- a/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/PrivacyPolicyScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The about screen that displays the privacy policy for the application.
- */
 
 package be.scri.ui.screens
 
@@ -27,6 +23,9 @@ import be.scri.R
 import be.scri.ui.common.ScribeBaseScreen
 import be.scri.ui.theme.ScribeTypography
 
+/**
+ * The about screen that displays the privacy policy for the application.
+ */
 @Composable
 fun PrivacyPolicyScreen(
     onBackNavigation: () -> Unit,

--- a/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/SelectLanguageScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The Select Languages subpage is for selecting the translation source language.
- */
 
 package be.scri.ui.screens
 
@@ -35,6 +31,9 @@ import androidx.core.content.edit
 import be.scri.R
 import be.scri.ui.common.ScribeBaseScreen
 
+/**
+ * The Select Languages subpage is for selecting the translation source language.
+ */
 @Composable
 fun SelectTranslationSourceLanguageScreen(
     currentLanguage: String,

--- a/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ThirdPartyScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The about screen to display third-party legal information for software used in the application.
- */
 
 package be.scri.ui.screens
 
@@ -28,6 +24,9 @@ import be.scri.R
 import be.scri.ui.common.ScribeBaseScreen
 import be.scri.ui.theme.ScribeTypography
 
+/**
+ * The about screen to display third-party legal information for software used in the application.
+ */
 @SuppressLint("ComposeModifierReused")
 @Composable
 fun ThirdPartyScreen(

--- a/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/WikimediaScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The about screen for describing the relationship between Scribe and the Wikimedia movement.
- */
 
 package be.scri.ui.screens
 
@@ -34,6 +30,9 @@ import be.scri.R
 import be.scri.ui.common.ScribeBaseScreen
 import be.scri.ui.theme.ScribeTypography
 
+/**
+ * The about screen for describing the relationship between Scribe and the Wikimedia movement.
+ */
 @Composable
 fun WikimediaScreen(
     onBackNavigation: () -> Unit,

--- a/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The about page of the application with links to the community as well as sub pages for detailed descriptions.
- */
 
 package be.scri.ui.screens.about
 
@@ -27,6 +23,9 @@ import be.scri.ui.screens.about.AboutUtil.getCommunityList
 import be.scri.ui.screens.about.AboutUtil.getFeedbackAndSupportList
 import be.scri.ui.screens.about.AboutUtil.getLegalListItems
 
+/**
+ * The about page of the application with links to the community as well as sub pages for detailed descriptions.
+ */
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun AboutScreen(

--- a/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/about/AboutUtil.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * This file provide utility functions for the about page
- */
 
 package be.scri.ui.screens.about
 
@@ -18,6 +14,9 @@ import be.scri.helpers.ShareHelper
 import be.scri.ui.models.ScribeItem
 import be.scri.ui.models.ScribeItemList
 
+/**
+ * This file provide utility functions for the about page
+ */
 object AboutUtil {
     fun onShareScribeClick(context: Context) {
         ShareHelper.shareScribe(context)

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsScreen.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The settings tab for the application including settings for language keyboards as sub menus.
- */
 
 package be.scri.ui.screens.settings
 
@@ -39,6 +35,9 @@ import be.scri.ui.models.ScribeItem
 import be.scri.ui.models.ScribeItemList
 import be.scri.ui.screens.settings.SettingsUtil.getLocalizedLanguageName
 
+/**
+ * The settings tab for the application including settings for language keyboards as sub menus.
+ */
 @Composable
 fun SettingsScreen(
     onDarkModeChange: (Boolean) -> Unit,

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsUtil.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * This file provides utility functions for settings page.
- */
 
 package be.scri.ui.screens.settings
 
@@ -19,6 +15,9 @@ import androidx.core.content.ContextCompat.startActivity
 import be.scri.R
 import be.scri.helpers.PreferencesHelper
 
+/**
+ * This file provides utility functions for settings page.
+ */
 object SettingsUtil {
     fun checkKeyboardInstallation(context: Context): Boolean {
         val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModel.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * This files handles the state and business logic for the settings screen.
- */
 
 package be.scri.ui.screens.settings
 
@@ -13,6 +9,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+/**
+ * This files handles the state and business logic for the settings screen.
+ */
 class SettingsViewModel(
     context: Context,
 ) : ViewModel() {

--- a/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
+++ b/app/src/main/java/be/scri/ui/screens/settings/SettingsViewModelFactory.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * This file provides context for the the viewmodel to change the settings.
- */
 
 package be.scri.ui.screens.settings
 
@@ -10,6 +6,9 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 
+/**
+ * This file provides context for the the viewmodel to change the settings.
+ */
 class SettingsViewModelFactory(
     private val context: Context,
 ) : ViewModelProvider.Factory {

--- a/app/src/main/java/be/scri/ui/theme/Colors.kt
+++ b/app/src/main/java/be/scri/ui/theme/Colors.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Custom colors for use throughout the application.
- */
 
 package be.scri.ui.theme
 
@@ -31,6 +27,9 @@ val theme_dark_switch_selector_color = Color(color = 0xFF2A1903)
 val theme_dark_unchecked_switch_selector_color = Color(color = 0xFF2D2D2D)
 val theme_dark_corner_button_color = Color(color = 0xFF2A1903)
 
+/**
+ * Custom colors for use throughout the application.
+ */
 @Suppress("MagicNumber")
 val BlueSky = Color(0xFF4478a9)
 

--- a/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
+++ b/app/src/main/java/be/scri/ui/theme/ScribeTheme.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Light and dark mode themes for the application.
- */
 
 package be.scri.ui.theme
 
@@ -43,6 +39,9 @@ private val DarkColors =
         surfaceContainer = theme_dark_corner_button_color,
     )
 
+/**
+ * Light and dark mode themes for the application.
+ */
 @Composable
 fun ScribeTheme(
     useDarkTheme: Boolean,

--- a/app/src/main/java/be/scri/ui/theme/Typography.kt
+++ b/app/src/main/java/be/scri/ui/theme/Typography.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Text styles for the application.
- */
 
 package be.scri.ui.theme
 
@@ -12,6 +8,9 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
+/**
+ * Text styles for the application.
+ */
 val ScribeTypography =
     Typography(
         bodyMedium =


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request fixes dangling top-level KDoc comments.




### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #367
