### PR TITLE
Fix dangling top-level kdoc comments

### DIFF
--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Handles application-level initialization and sets the default night mode based on user configuration.
- */
 
 package be.scri
 
@@ -40,6 +36,9 @@ import be.scri.ui.theme.ScribeTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+/**
+ * Handles application-level initialization and sets the default night mode based on user configuration.
+ */
 @SuppressLint("ComposeModifierMissing")
 @Composable
 fun ScribeApp(

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the English language keyboard.
- */
 
 package be.scri.services
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the French language keyboard.
- */
 
 package be.scri.services
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The base keyboard input method (IME) imported into all language keyboards.
- */
 
 package be.scri.services
 
@@ -56,6 +52,9 @@ import be.scri.views.KeyboardView
 
 // based on https://www.androidauthority.com/lets-build-custom-keyboard-android-832362/
 
+/**
+ * The base keyboard input method (IME) imported into all language keyboards.
+ */
 @Suppress("TooManyFunctions", "LargeClass")
 abstract class GeneralKeyboardIME(
     var language: String,

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the German language keyboard.
- */
 
 package be.scri.services
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the Italian language keyboard.
- */
 
 package be.scri.services
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the Portuguese language keyboard.
- */
 
 package be.scri.services
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the Russian language keyboard.
- */
 
 package be.scri.services
 

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the Spanish language keyboard.
- */
 
 package be.scri.services
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * The input method (IME) for the Swedish language keyboard.
- */
 
 package be.scri.services
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request fixes dangling top-level KDoc comments.




### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #366
