### PR TITLE
Fix dangling top-level kdoc comments

### DIFF
--- a/app/src/main/java/be/scri/helpers/CommonsConstants.kt
+++ b/app/src/main/java/be/scri/helpers/CommonsConstants.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Common constants that are used throughout helper classes and objects.
- */
 
 package be.scri.helpers
 
+/**
+ * Constants that are used throughout helper classes and objects.
+ */
 val DARK_GREY = 0xFF333333.toInt()
 
 // Shared preferences.

--- a/app/src/main/java/be/scri/helpers/Constants.kt
+++ b/app/src/main/java/be/scri/helpers/Constants.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Constants that are used throughout helper classes and objects.
- */
 
 package be.scri.helpers
 
+/**
+ * Constants that are used throughout helper classes and objects.
+ */
 const val SHIFT_OFF = 0
 const val SHIFT_ON_ONE_CHAR = 1
 const val SHIFT_ON_PERMANENT = 2

--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
 
 package be.scri.helpers
 

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Custom keyboard implementation for handling keyboard layouts, rows and keys with XML-based configuration.
- */
 
 package be.scri.helpers
 
@@ -294,7 +290,7 @@ class KeyboardBase {
             a.recycle()
         }
 
-        /** Create an empty key with no attributes.  */
+        // Create an empty key with no attributes.
         init {
             height = parent.defaultHeight
             width = parent.defaultWidth

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
 
 package be.scri.helpers
 

--- a/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Interface variables for English language keyboards.
- */
 
 package be.scri.helpers.english
 
+/**
+ * Interface variables for English language keyboards.
+ */
 object ENInterfaceVariables {
     // MARK: Currency Symbols
 

--- a/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Interface variables for German language keyboards.
- */
 
 package be.scri.helpers.german
 
+/**
+ * Interface variables for German language keyboards.
+ */
 object DEInterfaceVariables {
     // MARK: Currency Symbols
 

--- a/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Interface variables for Italian language keyboards.
- */
 
 package be.scri.helpers.italian
 
+/**
+ * Interface variables for Italian language keyboards.
+ */
 object ITInterfaceVariables {
     // MARK: Currency Symbols
 

--- a/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Interface variables for Portuguese language keyboards.
- */
 
 package be.scri.helpers.portuguese
 
+/**
+ * Interface variables for Portuguese language keyboards.
+ */
 object PTInterfaceVariables {
     // MARK: Currency Symbols
 

--- a/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Interface variables for Russian language keyboards.
- */
 
 package be.scri.helpers.russian
 
+/**
+ * Interface variables for Russian language keyboards.
+ */
 object RUInterfaceVariables {
     // MARK: Currency Symbols
 

--- a/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/main/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Interface variables for Swedish language keyboards.
- */
 
 package be.scri.helpers.swedish
 
+/**
+ * Interface variables for Swedish language keyboards.
+ */
 object SVInterfaceVariables {
     // MARK: Currency Symbols
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request fixes dangling top-level KDoc comments.


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #365
