### PR TITLE
Fix dangling top-level kdoc comments

### DIFF
--- a/app/src/main/java/be/scri/extensions/CommonsContext.kt
+++ b/app/src/main/java/be/scri/extensions/CommonsContext.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Functions and properties for accessing shared preferences and BaseConfig.
- */
 
 package be.scri.extensions
 

--- a/app/src/main/java/be/scri/extensions/Context.kt
+++ b/app/src/main/java/be/scri/extensions/Context.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Functions for retrieving configuration settings and calculating color based on theme and background preferences.
- */
 
 package be.scri.extensions
 

--- a/app/src/main/java/be/scri/extensions/ContextStyling.kt
+++ b/app/src/main/java/be/scri/extensions/ContextStyling.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Functions for determining and retrieving proper text and colors based on user settings.
- */
 
 package be.scri.extensions
 

--- a/app/src/main/java/be/scri/extensions/Drawable.kt
+++ b/app/src/main/java/be/scri/extensions/Drawable.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Extends the Drawable class to apply a color filter to a drawable using a specified color.
- */
 
 package be.scri.extensions
 

--- a/app/src/main/java/be/scri/extensions/Int.kt
+++ b/app/src/main/java/be/scri/extensions/Int.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Functions for manipulating colors used within the application.
- */
 
 package be.scri.extensions
 

--- a/app/src/main/java/be/scri/extensions/View.kt
+++ b/app/src/main/java/be/scri/extensions/View.kt
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-@file:Suppress("ktlint:standard:kdoc")
-/**
- * Utility functions for managing visibility and haptic feedback in Android views.
- */
 
 package be.scri.extensions
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request fixes dangling top-level KDoc comments.



### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #364 
