### PR TITLE
docs(models): add KDoc for all public classes in be.scri.models package

### DIFF
--- a/app/src/main/java/be/scri/models/DataContract.kt
+++ b/app/src/main/java/be/scri/models/DataContract.kt
@@ -14,7 +14,6 @@ import kotlinx.serialization.Serializable
  * Holds language-specific linguistic data used by the Scribe keyboard, such as number representations,
  * gender categories, and verb conjugation forms.
  */
-
 @Serializable
 data class DataContract(
     val numbers: Map<String, String>,
@@ -37,7 +36,6 @@ data class Genders(
 /**
  * Represents verb conjugations by person (1st, 2nd, 3rd) and number (singular/plural).
  */
-
 @Serializable
 data class Conjugation(
     val title: String = "",

--- a/app/src/main/java/be/scri/models/DataContract.kt
+++ b/app/src/main/java/be/scri/models/DataContract.kt
@@ -10,6 +10,11 @@
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Holds language-specific linguistic data used by the Scribe keyboard, such as number representations,
+ * gender categories, and verb conjugation forms.
+ */
+
 @Serializable
 data class DataContract(
     val numbers: Map<String, String>,
@@ -17,6 +22,9 @@ data class DataContract(
     val conjugations: Map<String, Conjugation>,
 )
 
+/**
+ * Represents different grammatical gender groupings.
+ */
 @Serializable
 data class Genders(
     val canonical: List<String>,
@@ -25,6 +33,10 @@ data class Genders(
     val commons: List<String>,
     val neuters: List<String>,
 )
+
+/**
+ * Represents verb conjugations by person (1st, 2nd, 3rd) and number (singular/plural).
+ */
 
 @Serializable
 data class Conjugation(

--- a/app/src/main/java/be/scri/models/ItemsViewModel.kt
+++ b/app/src/main/java/be/scri/models/ItemsViewModel.kt
@@ -9,6 +9,9 @@ package be.scri.models
 import android.app.Activity
 import androidx.annotation.StringRes
 
+/**
+ * ViewModel representing an item with optional actions and associated resources like images and URLs.
+ */
 data class ItemsViewModel(
     val image: Int,
     val text: Text,
@@ -17,6 +20,9 @@ data class ItemsViewModel(
     val activity: Class<out Activity>? = null,
     val action: (() -> Unit)? = null,
 ) : Item() {
+    /**
+     * ViewModel representing an item with optional actions and associated resources like images and URLs.
+     */
     class Text(
         @StringRes
         val resId: Int,

--- a/app/src/main/java/be/scri/models/SwitchItem.kt
+++ b/app/src/main/java/be/scri/models/SwitchItem.kt
@@ -6,8 +6,14 @@
 
 package be.scri.models
 
+/**
+ * Base class for defining UI items in the application.
+ */
 sealed class Item
 
+/**
+ * Model representing a switch-based item with optional actions.
+ */
 data class SwitchItem(
     val title: String,
     val description: String? = null,

--- a/app/src/main/java/be/scri/models/TextItem.kt
+++ b/app/src/main/java/be/scri/models/TextItem.kt
@@ -8,6 +8,9 @@ package be.scri.models
 
 import androidx.fragment.app.Fragment
 
+/**
+ * Model for a text-based item in the UI with optional action and navigation fragment.
+ */
 data class TextItem(
     val text: Int,
     val image: Int,

--- a/detekt.yml
+++ b/detekt.yml
@@ -59,7 +59,6 @@ comments:
         excludes: &excludedFolders
             - '**/activities/**'
             - '**/helpers/**/*Variables.kt'
-            - '**/models/**'
             - '**/test/**'
             - '**/ui/**'
             - '**/services/**'


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

- [x] This PR is on a separate branch: `doc/be.scri.models`
- [x] Ran `./gradlew lintKotlin detekt test` successfully
- [x] KDoc added for all undocumented public classes flagged by Detekt

---

### Description

This pull request documents all public classes within the `be.scri.models` package. The documented classes include:

- `DataContract`, `Genders`, `Conjugation`
- `ItemsViewModel` and its nested `Text` class
- `SwitchItem`, `TextItem`, and base sealed class `Item`

These changes were made to improve maintainability and satisfy Detekt’s documentation requirements. All code style and lint checks were passed successfully.

---

### Related issue

- #372 
