### PR TITLE
Fix Translate button text color in SELECT_COMMAND state

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -699,7 +699,6 @@ abstract class GeneralKeyboardIME(
         binding.separator5.visibility = View.GONE
         binding.separator6.visibility = View.GONE
         setupCommandBarTheme(binding)
-        binding.translateBtn.setTextColor(Color.BLACK)
         binding.scribeKey.setOnClickListener {
             currentState = ScribeState.IDLE
             Log.i("MY-TAG", "IDLE STATE")


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
**Problem:**
When the Scribe key is clicked and the user enters the `SELECT_COMMAND` state, the text color of the "Translate" button incorrectly changes to black, especially noticeable as the user begins typing. This behavior is inconsistent with the expected UI, where the "Translate" button's text color should remain unchanged (i.e., respect the current dark/light theme) regardless of user input in this state.


https://github.com/user-attachments/assets/b550c8f7-472f-44fd-aa39-6037482d78bb



**Solution:**
The root cause was identified as an explicit call to `binding.translateBtn.setTextColor(Color.BLACK)` within the `setupSelectCommandView()` method. This call occurred *after* `setupCommandBarTheme(binding)` had already set the appropriate theme-based text color, effectively overriding it.

This PR removes the erroneous `setTextColor(Color.BLACK)` line. As a result, the "Translate" button's text color will now correctly adhere to the theme (e.g., white in dark mode, dark grey in light mode) as determined by the `setupCommandBarTheme()` function when in the `SELECT_COMMAND` state.


https://github.com/user-attachments/assets/f6e35039-b910-4646-ad0c-7a4807e4a92a



-   Fix #397 
