### PR TITLE
feat: Add invalid state to keyboard commands and show localized Not in Wikidata

### DIFF
--- a/app/src/main/java/be/scri/helpers/HintUtils.kt
+++ b/app/src/main/java/be/scri/helpers/HintUtils.kt
@@ -18,6 +18,7 @@ import be.scri.services.GeneralKeyboardIME
  *
  * This may include methods for showing, formatting, or validating hints in forms or UI components.
  */
+@Suppress("TooManyFunctions")
 object HintUtils {
     /**
      * Resets the application hints, marking them as not shown in the shared preferences.
@@ -114,6 +115,27 @@ object HintUtils {
             "Spanish" to ESInterfaceVariables.PLURAL_PLACEHOLDER,
             "Swedish" to SVInterfaceVariables.PLURAL_PLACEHOLDER,
         )
+
+    /**
+     * Provides invalid hint for selected language.
+     *
+     * @return A hint string for invalid commands.
+     */
+    fun getInvalidHint(
+        language: String,
+        defaultHint: String = ENInterfaceVariables.INVALID_COMMAND_MSG,
+    ): String =
+        when (language) {
+            "English" -> ENInterfaceVariables.INVALID_COMMAND_MSG
+            "French" -> FRInterfaceVariables.INVALID_COMMAND_MSG
+            "German" -> DEInterfaceVariables.INVALID_COMMAND_MSG
+            "Italian" -> ITInterfaceVariables.INVALID_COMMAND_MSG
+            "Portuguese" -> PTInterfaceVariables.INVALID_COMMAND_MSG
+            "Russian" -> RUInterfaceVariables.INVALID_COMMAND_MSG
+            "Spanish" -> ESInterfaceVariables.INVALID_COMMAND_MSG
+            "Swedish" -> SVInterfaceVariables.INVALID_COMMAND_MSG
+            else -> defaultHint
+        }
 
     /**
      * Retrieves the prompt text for the given state and language.

--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -50,9 +50,9 @@ class KeyHandler(
         ime.autoSuggestEmojis = ime.findEmojisForLastWord(ime.emojiKeywords, ime.lastWord)
         ime.checkIfPluralWord = ime.findWhetherWordIsPlural(ime.pluralWords, ime.lastWord)
 
-        Log.i("MY-TAG", "${ime.checkIfPluralWord}")
+        Log.i(TAG, "${ime.checkIfPluralWord}")
         Log.d("Debug", "${ime.autoSuggestEmojis}")
-        Log.d("MY-TAG", "${ime.nounTypeSuggestion}")
+        Log.d(TAG, "${ime.nounTypeSuggestion}")
         ime.updateButtonText(ime.emojiAutoSuggestionEnabled, ime.autoSuggestEmojis)
         if (code != KeyboardBase.KEYCODE_SHIFT) {
             ime.updateShiftKeyState()
@@ -82,11 +82,17 @@ class KeyHandler(
      * @param code the key code of the pressed key.
      */
     private fun handleDefaultKey(code: Int) {
-        if (ime.currentState == ScribeState.IDLE || ime.currentState == ScribeState.SELECT_COMMAND) {
-            ime.handleElseCondition(code, ime.keyboardMode, binding = null)
-        } else {
-            ime.handleElseCondition(code, ime.keyboardMode, ime.keyboardBinding, commandBarState = true)
+        when (ime.currentState) {
+            ScribeState.IDLE,
+            ScribeState.SELECT_COMMAND,
+            -> ime.handleElseCondition(code, ime.keyboardMode, binding = null)
+            ScribeState.INVALID -> {
+                ime.moveToIdleState()
+                ime.handleElseCondition(code, ime.keyboardMode, ime.keyboardBinding)
+            }
+            else -> ime.handleElseCondition(code, ime.keyboardMode, ime.keyboardBinding, commandBarState = true)
         }
+
         ime.disableAutoSuggest()
     }
 
@@ -120,13 +126,14 @@ class KeyHandler(
      * Executes different actions depending on the current state of the keyboard.
      */
     private fun handleEnterKey() {
-        if (ime.currentState == ScribeState.IDLE || ime.currentState == ScribeState.SELECT_COMMAND) {
+        Log.d(TAG, "handleEnterKey ${ime.currentState}")
+        if (ime.currentState == ScribeState.IDLE ||
+            ime.currentState == ScribeState.SELECT_COMMAND ||
+            ime.currentState == ScribeState.INVALID
+        ) {
             ime.handleKeycodeEnter(ime.keyboardBinding, false)
         } else {
             ime.handleKeycodeEnter(ime.keyboardBinding, true)
-            ime.currentState = ScribeState.IDLE
-            ime.switchToCommandToolBar()
-            ime.updateUI()
         }
         ime.disableAutoSuggest()
     }
@@ -172,5 +179,9 @@ class KeyHandler(
             ime.handleElseCondition(code, ime.keyboardMode, ime.keyboardBinding, commandBarState = true)
             ime.disableAutoSuggest()
         }
+    }
+
+    private companion object {
+        const val TAG = "KeyHandler"
     }
 }

--- a/app/src/main/res/layout/keyboard_view_command_options.xml
+++ b/app/src/main/res/layout/keyboard_view_command_options.xml
@@ -15,7 +15,7 @@
 
         <Button
             android:id="@+id/scribe_key"
-            android:layout_width="@dimen/scribe_key_width"
+            android:layout_width="@dimen/select_command_scribe_key_width"
             android:layout_height="37dp"
             android:layout_marginStart="@dimen/small_margin"
             android:layout_marginEnd="4dp"

--- a/app/src/main/res/layout/keyboard_view_keyboard.xml
+++ b/app/src/main/res/layout/keyboard_view_keyboard.xml
@@ -17,7 +17,7 @@
 
         <Button
             android:id="@+id/scribe_key"
-            android:layout_width="0dp"
+            android:layout_width="@dimen/command_state_scribe_key_width"
             android:layout_height="36dp"
             android:layout_marginStart="@dimen/small_margin"
             android:background="@drawable/scribe_key_background_left_rounded"
@@ -42,7 +42,6 @@
             android:textSize="16sp"
             android:gravity="center"
             android:minWidth="48dp"
-            android:maxWidth="120dp"
             android:paddingStart="8dp"
             android:paddingTop="4dp"
             android:paddingEnd="8dp"
@@ -90,6 +89,17 @@
             app:layout_constraintHorizontal_weight="50"
             app:layout_constraintStart_toEndOf="@+id/prompt_text"
             app:layout_constraintTop_toTopOf="@+id/command_field" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/iv_info"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_info_vector"
+            android:tint="@color/you_primary_color"
+            app:layout_constraintBottom_toBottomOf="@+id/command_bar"
+            app:layout_constraintEnd_toEndOf="@+id/command_bar"
+            app:layout_constraintTop_toTopOf="@+id/command_bar"
+            android:layout_marginEnd="8dp"/>
 
         <ImageView
             android:id="@+id/top_keyboard_divider"

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -71,5 +71,6 @@
     <dimen name="cab_popup_menu_min_width">160dp</dimen>
     <dimen name="cab_item_min_width">80dp</dimen>
     <dimen name="fab_margin">14dp</dimen>
-    <dimen name="scribe_key_width">107dp</dimen>
+    <dimen name="select_command_scribe_key_width">107dp</dimen>
+    <dimen name="command_state_scribe_key_width">127dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -75,5 +75,6 @@
     <dimen name="cab_popup_menu_min_width">168dp</dimen>
     <dimen name="cab_item_min_width">85dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
-    <dimen name="scribe_key_width">65dp</dimen>
+    <dimen name="select_command_scribe_key_width">65dp</dimen>
+    <dimen name="command_state_scribe_key_width">75dp</dimen>
 </resources>


### PR DESCRIPTION
https://github.com/scribe-org/Scribe-Android/issues/273


### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request implement functionality described in related issue

Other changes:
- Fix scribe key's variable width in command mode
- Move log tag to constants, remove "MY-TAG"
- Extract moving to command and idle states into separate functions to avoid code duplication

### Related issue


-   #273 
