### PR TITLE
Show PL Auto-Suggestion After Committing Word in Plural Mode

### DIFF
--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -54,6 +54,11 @@ class KeyHandler(
         Log.d("Debug", "${ime.autoSuggestEmojis}")
         Log.d("MY-TAG", "${ime.nounTypeSuggestion}")
         ime.updateButtonText(ime.emojiAutoSuggestionEnabled, ime.autoSuggestEmojis)
+
+        if (ime.currentState == ScribeState.IDLE || ime.currentState == ScribeState.SELECT_COMMAND) {
+            ime.updateAutoSuggestText(isPlural = ime.checkIfPluralWord)
+        }
+
         if (code != KeyboardBase.KEYCODE_SHIFT) {
             ime.updateShiftKeyState()
         }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request fixes a bug where plural auto-suggestions (PL) were not being triggered after committing text in Plural Mode. The issue was due to the auto-suggestion logic not being updated during space key events if the keyboard was in a non-command state.

The fix ensures that plural suggestions are properly triggered after any word is typed and committed by modifying the handleKeycodeSpace() function in KeyHandler.kt.

Tested manually by:

Typing in Plural Mode

Verifying that PL suggestions appear after typing and committing a word

[Screen_recording_20250529_105420.webm](https://github.com/user-attachments/assets/76e0768d-4a4a-46f2-9068-c68944e90b73)


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #400
