### PR TITLE
Keyboard should load with keys being capitalized

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1,3 +1,5 @@
+
+
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package be.scri.services
@@ -388,6 +390,14 @@ abstract class GeneralKeyboardIME(
         updateButtonVisibility(emojiAutoSuggestionEnabled)
         setupIdleView()
         super.onStartInputView(editorInfo, restarting)
+        val textBefore =
+            currentInputConnection
+                ?.getTextBeforeCursor(1, 0)
+                ?.toString()
+                .orEmpty()
+        if (textBefore.isEmpty()) {
+            keyboard?.setShifted(SHIFT_ON_ONE_CHAR)
+        }
         setupCommandBarTheme(binding)
     }
 
@@ -1734,6 +1744,11 @@ abstract class GeneralKeyboardIME(
                 }
             } else {
                 inputConnection.commitText("", 1)
+            }
+            val before = inputConnection.getTextBeforeCursor(1, 0)?.isEmpty() ?: true
+            if (before) {
+                keyboard!!.mShiftState = SHIFT_ON_ONE_CHAR
+                keyboardView!!.invalidateAllKeys()
             }
         }
     }

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1,5 +1,3 @@
-
-
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package be.scri.services


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
I added SHIFT_ON_ONE_CHAR to the onStartInputView to capitalize first letter when opening keyboard and added check to capitalize first letter only when input is none. I also added handleDelete to apply SHIFT_ON_ONE_CHAR again when deleted whole input. 

### Related issue
<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   Closes #413 
