### PR TITLE
Add instrumentation test job to android_ci.yml

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -12,31 +12,31 @@ permissions:
 jobs:
     lint:
         runs-on: ubuntu-latest
-        name: Run lint and detekt
+        name: Run Ktlint and Detekt
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: prepare app
+            - name: Prepare App
               uses: ./.github/composite/prepareApp
 
-            - name: Run ktlint
+            - name: Run Ktlint
               run: ./gradlew lintKotlin
 
-            - name: Run detekt
+            - name: Run Detekt
               run: ./gradlew detekt
 
     test:
         runs-on: ubuntu-latest
-        name: Run tests
+        name: Run Tests
         steps:
-            - name: Checkout repository
+            - name: Checkout Repository
               uses: actions/checkout@v4
 
-            - name: prepare app
+            - name: Prepare App
               uses: ./.github/composite/prepareApp
 
-            - name: Run ktlint
+            - name: Run Ktlint
               run: ./gradlew test
 
     collect_coverage:
@@ -50,10 +50,10 @@ jobs:
               with:
                   java-version: 17
 
-            - name: Grant execute permission for gradlew
+            - name: Grant Execute Permission for Gradle Wrapper
               run: chmod +x gradlew
 
-            - name: Get coverage
+            - name: Get Coverage
               run: ./gradlew koverReport
 
             - name: Run File-wise Coverage Parser Script
@@ -63,16 +63,16 @@ jobs:
         runs-on: ubuntu-latest
         name: build app
         steps:
-            - name: Checkout repository
+            - name: Checkout Repository
               uses: actions/checkout@v4
 
-            - name: prepare app
+            - name: Prepare App
               uses: ./.github/composite/prepareApp
 
-            - name: build app
+            - name: Build App
               run: ./gradlew assembleDebug
 
-            - name: Upload Debug Apk
+            - name: Upload Debug APK
               uses: actions/upload-artifact@v4
               if: success()
               with:
@@ -80,41 +80,41 @@ jobs:
                   path: "app/build/outputs/apk/core/debug/app-core-debug.apk"
 
     instrumentation_test:
-      runs-on: ubuntu-latest
-      name: Run Android Instrumentation Tests
-      timeout-minutes: 30
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+        runs-on: ubuntu-latest
+        name: Run Android Instrumentation Tests
+        timeout-minutes: 30
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v4
 
-        - name: prepare app
-          uses: ./.github/composite/prepareApp
+            - name: Prepare App
+              uses: ./.github/composite/prepareApp
 
-        - name: Enable KVM group perms
-          run: |
-            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-            sudo udevadm control --reload-rules
-            sudo udevadm trigger --name-match=kvm
+            - name: Enable KVM Group Permissions
+              run: |
+                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+                  sudo udevadm control --reload-rules
+                  sudo udevadm trigger --name-match=kvm
 
-        - name: Run UI tests on Emulator
-          uses: reactivecircus/android-emulator-runner@v2
-          with:
-              api-level: 29
-              target: google_apis
-              arch: x86_64
-              profile: Nexus 6
-              ram-size: 2048M
-              heap-size: 512M
-              disk-size: 6000M
-              emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
-              disable-animations: true
-              force-avd-creation: false
-              script: |
-                  adb wait-for-device
-                  sleep 30
-                  adb shell input keyevent 82
-                  adb shell settings put global window_animation_scale 0.0
-                  adb shell settings put global transition_animation_scale 0.0
-                  adb shell settings put global animator_duration_scale 0.0
-                  sleep 5
-                  ./gradlew connectedCoreDebugAndroidTest --stacktrace
+            - name: Run UI Tests on Emulator
+              uses: reactivecircus/android-emulator-runner@v2
+              with:
+                  api-level: 29
+                  target: google_apis
+                  arch: x86_64
+                  profile: Nexus 6
+                  ram-size: 2048M
+                  heap-size: 512M
+                  disk-size: 6000M
+                  emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
+                  disable-animations: true
+                  force-avd-creation: false
+                  script: |
+                      adb wait-for-device
+                      sleep 30
+                      adb shell input keyevent 82
+                      adb shell settings put global window_animation_scale 0.0
+                      adb shell settings put global transition_animation_scale 0.0
+                      adb shell settings put global animator_duration_scale 0.0
+                      sleep 5
+                      ./gradlew connectedCoreDebugAndroidTest --stacktrace

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -80,71 +80,63 @@ jobs:
                   path: "app/build/outputs/apk/core/debug/app-core-debug.apk"
 
     instrumentation_test:
-        runs-on: ubuntu-latest
-        name: Run Android Instrumentation Tests
-        timeout-minutes: 30
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
+      runs-on: ubuntu-latest
+      name: Run Android Instrumentation Tests
+      timeout-minutes: 30
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
 
-            - name: prepare app
-              uses: ./.github/composite/prepareApp
+        - name: prepare app
+          uses: ./.github/composite/prepareApp
 
-            # Enable hardware acceleration for better emulator performance
-            - name: Enable KVM group perms
-              run: |
-                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-                  sudo udevadm control --reload-rules
-                  sudo udevadm trigger --name-match=kvm
+        - name: Enable KVM group perms
+          run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
 
-            - name: Run UI tests on Emulator
-              uses: reactivecircus/android-emulator-runner@v2
-              with:
-                  api-level: 29
-                  target: google_apis
-                  arch: x86_64
-                  profile: Nexus 6
-                  ram-size: 2048M
-                  heap-size: 512M
-                  disk-size: 6000M
-                  emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
-                  disable-animations: true
-                  force-avd-creation: false
-                  script: |
-                      echo "Waiting for emulator to be ready..."
-                      
-                      # Wait for device with timeout
-                      timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
-                      
-                      # Additional wait for system to be fully ready
-                      echo "Device detected, waiting for system to be ready..."
-                      while [ "`adb shell getprop sys.boot_completed 2>/dev/null`" != "1" ]; do
-                          echo "Waiting for boot completion..."
-                          sleep 5
-                      done
-                      
-                      # Wait for package manager
-                      while [ "`adb shell getprop init.svc.bootanim 2>/dev/null`" != "stopped" ]; do
-                          echo "Waiting for boot animation to stop..."
-                          sleep 2
-                      done
-                      
-                      echo "Emulator is ready! Setting up test environment..."
-                      
-                      # Unlock the device
-                      adb shell input keyevent 82
-                      
-                      # Disable animations completely
-                      adb shell settings put global window_animation_scale 0.0
-                      adb shell settings put global transition_animation_scale 0.0
-                      adb shell settings put global animator_duration_scale 0.0
-                      
-                      # Additional emulator setup
-                      adb shell settings put secure show_ime_with_hard_keyboard 0
-                      adb shell settings put system screen_off_timeout 1800000
-                      
-                      # Wait a bit more for settings to take effect
-                      sleep 3
-                      
-                      echo "Starting instrumented tests..."
-                      ./gradlew connectedCoreDebugAndroidTest --stacktrace --info
+        - name: Start emulator
+          uses: reactivecircus/android-emulator-runner@v2
+          with:
+            api-level: 29
+            target: google_apis
+            arch: x86_64
+            profile: Nexus 6
+            ram-size: 2048M
+            heap-size: 512M
+            disk-size: 6000M
+            emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
+            disable-animations: true
+            force-avd-creation: false
+            script: echo "Emulator started"
+
+        - name: Wait for emulator and run instrumented tests
+          shell: bash
+          run: |
+            echo "Waiting for emulator to be ready..."
+
+            timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
+
+            echo "Device detected, waiting for system to be ready..."
+            while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+              echo "Waiting for boot completion..."
+              sleep 5
+            done
+
+            while [ "$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')" != "stopped" ]; do
+              echo "Waiting for boot animation to stop..."
+              sleep 2
+            done
+
+            echo "Unlocking device and disabling animations..."
+            adb shell input keyevent 82
+            adb shell settings put global window_animation_scale 0
+            adb shell settings put global transition_animation_scale 0
+            adb shell settings put global animator_duration_scale 0
+            adb shell settings put secure show_ime_with_hard_keyboard 0
+            adb shell settings put system screen_off_timeout 1800000
+            sleep 3
+
+            echo "Starting instrumented tests..."
+            ./gradlew connectedCoreDebugAndroidTest --stacktrace --info

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -98,41 +98,49 @@ jobs:
 
         - name: Run UI tests on Emulator
           uses: reactivecircus/android-emulator-runner@v2
+
+        - name: Run UI tests on Emulator
+          uses: reactivecircus/android-emulator-runner@v2
           with:
-            api-level: 29
-            target: google_apis
-            arch: x86_64
-            profile: Nexus 6
-            ram-size: 2048M
-            heap-size: 512M
-            disk-size: 6000M
-            emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
-            disable-animations: true
-            force-avd-creation: false
-            script: |
-              echo "Waiting for emulator to be ready..."
+              api-level: 29
+              target: google_apis
+              arch: x86_64
+              profile: Nexus 6
+              ram-size: 2048M
+              heap-size: 512M
+              disk-size: 6000M
+              emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
+              disable-animations: true
+              force-avd-creation: false
+              script: |
+                  #!/bin/bash
+                  echo "Waiting for emulator to be ready..."
 
-              timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
+                  timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
 
-              echo "Device detected, waiting for system to be ready..."
-              while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
-                echo "Waiting for boot completion..."
-                sleep 5
-              done
+                  echo "Device detected, waiting for system to be ready..."
+                  while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+                      echo "Waiting for boot completion..."
+                      sleep 5
+                  done
 
-              while [ "$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')" != "stopped" ]; do
-                echo "Waiting for boot animation to stop..."
-                sleep 2
-              done
+                  while [ "$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')" != "stopped" ]; do
+                      echo "Waiting for boot animation to stop..."
+                      sleep 2
+                  done
 
-              echo "Unlocking device and disabling animations..."
-              adb shell input keyevent 82
-              adb shell settings put global window_animation_scale 0
-              adb shell settings put global transition_animation_scale 0
-              adb shell settings put global animator_duration_scale 0
-              adb shell settings put secure show_ime_with_hard_keyboard 0
-              adb shell settings put system screen_off_timeout 1800000
-              sleep 3
+                  echo "Emulator is ready! Setting up test environment..."
 
-              echo "Starting instrumented tests..."
-              ./gradlew connectedCoreDebugAndroidTest --stacktrace --info
+                  adb shell input keyevent 82
+
+                  adb shell settings put global window_animation_scale 0.0
+                  adb shell settings put global transition_animation_scale 0.0
+                  adb shell settings put global animator_duration_scale 0.0
+
+                  adb shell settings put secure show_ime_with_hard_keyboard 0
+                  adb shell settings put system screen_off_timeout 1800000
+
+                  sleep 3
+
+                  echo "Starting instrumented tests..."
+                  ./gradlew connectedCoreDebugAndroidTest --stacktrace --info

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -89,13 +89,20 @@ jobs:
             - name: prepare app
               uses: ./.github/composite/prepareApp
 
+            - name: Debug ADB Devices
+              run: |
+                adb devices
+                adb shell getprop ro.build.fingerprint
+
             - name: Run UI tests on Emulator
               uses: reactivecircus/android-emulator-runner@v2
               with:
                   api-level: 30
-                  target: google_apis
+                  target: google_apis_playstore
                   arch: x86_64
                   profile: pixel_4
-                  emulator-options: "-no-window -no-audio -no-boot-anim"
+                  ram-size: 3072M
+                  heap-size: 512M
+                  emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect"
                   disable-animations: true
-                  script: ./gradlew connectedCoreDebugAndroidTest
+                  script: adb wait-for-device && adb shell settings put global window_animation_scale 0 && ./gradlew connectedCoreDebugAndroidTest

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -14,67 +14,89 @@ jobs:
         runs-on: ubuntu-latest
         name: Run lint and detekt
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
+            -   name: Checkout repository
+                uses: actions/checkout@v4
 
-            - name: prepare app
-              uses: ./.github/composite/prepareApp
+            -   name: prepare app
+                uses: ./.github/composite/prepareApp
 
-            - name: Run ktlint
-              run: ./gradlew lintKotlin
+            -   name: Run ktlint
+                run: ./gradlew lintKotlin
 
-            - name: Run detekt
-              run: ./gradlew detekt
+            -   name: Run detekt
+                run: ./gradlew detekt
 
     test:
         runs-on: ubuntu-latest
         name: Run tests
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
+            -   name: Checkout repository
+                uses: actions/checkout@v4
 
-            - name: prepare app
-              uses: ./.github/composite/prepareApp
+            -   name: prepare app
+                uses: ./.github/composite/prepareApp
 
-            - name: Run ktlint
-              run: ./gradlew test
+            -   name: Run ktlint
+                run: ./gradlew test
 
     collect_coverage:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout Repository
-              uses: actions/checkout@v4
+            -   name: Checkout Repository
+                uses: actions/checkout@v4
 
-            - name: Set up JDK
-              uses: actions/setup-java@v1
-              with:
-                  java-version: 17
+            -   name: Set up JDK
+                uses: actions/setup-java@v1
+                with:
+                    java-version: 17
 
-            - name: Grant execute permission for gradlew
-              run: chmod +x gradlew
+            -   name: Grant execute permission for gradlew
+                run: chmod +x gradlew
 
-            - name: Get coverage
-              run: ./gradlew koverReport
+            -   name: Get coverage
+                run: ./gradlew koverReport
 
-            - name: Run File-wise Coverage Parser Script
-              run: python3 scripts/coverage_parser.py
+            -   name: Run File-wise Coverage Parser Script
+                run: python3 scripts/coverage_parser.py
 
     build:
         runs-on: ubuntu-latest
         name: build app
         steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v4
+
+            -   name: prepare app
+                uses: ./.github/composite/prepareApp
+
+            -   name: build app
+                run: ./gradlew assembleDebug
+
+            -   name: Upload Debug Apk
+                uses: actions/upload-artifact@v4
+                if: success()
+                with:
+                    name: latest-apk
+                    path: "app/build/outputs/apk/core/debug/app-core-debug.apk"
+
+    instrumentation_test:
+        runs-on: ubuntu-latest
+        name: Run Android Instrumentation Tests
+        steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: checkout@v4
 
-            - name: prepare app
-              uses: ./.github/composite/prepareApp
+            - name: Prepare app
+              uses: ./.github/composite/prepare-app
 
-            - name: build app
-              run: ./gradlew assembleDebug
-
-            - name: Upload Debug Apk
-              uses: actions/upload-artifact@v4
-              if: success()
+            - name: Set up JDK 17
+              uses: actions/setup-java@v4
               with:
-                  name: latest-apk
-                  path: "app/build/outputs/apk/core/debug/app-core-debug.apk"
+                  java-version: 17
+
+            - name: Set up Android Emulator
+              uses: reactivecircus/android-emulator-runner@v2
+              with:
+                api-level: 30
+                arch: x86_64
+                script: ./gradlew connectedAndroidTest

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -98,9 +98,6 @@ jobs:
 
         - name: Run UI tests on Emulator
           uses: reactivecircus/android-emulator-runner@v2
-
-        - name: Run UI tests on Emulator
-          uses: reactivecircus/android-emulator-runner@v2
           with:
               api-level: 29
               target: google_apis

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -96,7 +96,7 @@ jobs:
             sudo udevadm control --reload-rules
             sudo udevadm trigger --name-match=kvm
 
-        - name: Start emulator
+        - name: Run UI tests on Emulator
           uses: reactivecircus/android-emulator-runner@v2
           with:
             api-level: 29
@@ -109,34 +109,30 @@ jobs:
             emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
             disable-animations: true
             force-avd-creation: false
-            script: echo "Emulator started"
+            script: |
+              echo "Waiting for emulator to be ready..."
 
-        - name: Wait for emulator and run instrumented tests
-          shell: bash
-          run: |
-            echo "Waiting for emulator to be ready..."
+              timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
 
-            timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
+              echo "Device detected, waiting for system to be ready..."
+              while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+                echo "Waiting for boot completion..."
+                sleep 5
+              done
 
-            echo "Device detected, waiting for system to be ready..."
-            while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
-              echo "Waiting for boot completion..."
-              sleep 5
-            done
+              while [ "$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')" != "stopped" ]; do
+                echo "Waiting for boot animation to stop..."
+                sleep 2
+              done
 
-            while [ "$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')" != "stopped" ]; do
-              echo "Waiting for boot animation to stop..."
-              sleep 2
-            done
+              echo "Unlocking device and disabling animations..."
+              adb shell input keyevent 82
+              adb shell settings put global window_animation_scale 0
+              adb shell settings put global transition_animation_scale 0
+              adb shell settings put global animator_duration_scale 0
+              adb shell settings put secure show_ime_with_hard_keyboard 0
+              adb shell settings put system screen_off_timeout 1800000
+              sleep 3
 
-            echo "Unlocking device and disabling animations..."
-            adb shell input keyevent 82
-            adb shell settings put global window_animation_scale 0
-            adb shell settings put global transition_animation_scale 0
-            adb shell settings put global animator_duration_scale 0
-            adb shell settings put secure show_ime_with_hard_keyboard 0
-            adb shell settings put system screen_off_timeout 1800000
-            sleep 3
-
-            echo "Starting instrumented tests..."
-            ./gradlew connectedCoreDebugAndroidTest --stacktrace --info
+              echo "Starting instrumented tests..."
+              ./gradlew connectedCoreDebugAndroidTest --stacktrace --info

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -110,34 +110,11 @@ jobs:
               disable-animations: true
               force-avd-creation: false
               script: |
-                  #!/bin/bash
-                  echo "Waiting for emulator to be ready..."
-
-                  timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
-
-                  echo "Device detected, waiting for system to be ready..."
-                  while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
-                      echo "Waiting for boot completion..."
-                      sleep 5
-                  done
-
-                  while [ "$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')" != "stopped" ]; do
-                      echo "Waiting for boot animation to stop..."
-                      sleep 2
-                  done
-
-                  echo "Emulator is ready! Setting up test environment..."
-
+                  adb wait-for-device
+                  sleep 30
                   adb shell input keyevent 82
-
                   adb shell settings put global window_animation_scale 0.0
                   adb shell settings put global transition_animation_scale 0.0
                   adb shell settings put global animator_duration_scale 0.0
-
-                  adb shell settings put secure show_ime_with_hard_keyboard 0
-                  adb shell settings put system screen_off_timeout 1800000
-
-                  sleep 3
-
-                  echo "Starting instrumented tests..."
-                  ./gradlew connectedCoreDebugAndroidTest --stacktrace --info
+                  sleep 5
+                  ./gradlew connectedCoreDebugAndroidTest --stacktrace

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -89,11 +89,6 @@ jobs:
             - name: prepare app
               uses: ./.github/composite/prepareApp
 
-            - name: Set up JDK 17
-              uses: actions/setup-java@v4
-              with:
-                  java-version: 17
-
             - name: Set up Android Emulator
               uses: reactivecircus/android-emulator-runner@v2
               with:

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -14,70 +14,70 @@ jobs:
         runs-on: ubuntu-latest
         name: Run lint and detekt
         steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v4
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-            -   name: prepare app
-                uses: ./.github/composite/prepareApp
+            - name: prepare app
+              uses: ./.github/composite/prepareApp
 
-            -   name: Run ktlint
-                run: ./gradlew lintKotlin
+            - name: Run ktlint
+              run: ./gradlew lintKotlin
 
-            -   name: Run detekt
-                run: ./gradlew detekt
+            - name: Run detekt
+              run: ./gradlew detekt
 
     test:
         runs-on: ubuntu-latest
         name: Run tests
         steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v4
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-            -   name: prepare app
-                uses: ./.github/composite/prepareApp
+            - name: prepare app
+              uses: ./.github/composite/prepareApp
 
-            -   name: Run ktlint
-                run: ./gradlew test
+            - name: Run ktlint
+              run: ./gradlew test
 
     collect_coverage:
         runs-on: ubuntu-latest
         steps:
-            -   name: Checkout Repository
-                uses: actions/checkout@v4
+            - name: Checkout Repository
+              uses: actions/checkout@v4
 
-            -   name: Set up JDK
-                uses: actions/setup-java@v1
-                with:
-                    java-version: 17
+            - name: Set up JDK
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 17
 
-            -   name: Grant execute permission for gradlew
-                run: chmod +x gradlew
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
 
-            -   name: Get coverage
-                run: ./gradlew koverReport
+            - name: Get coverage
+              run: ./gradlew koverReport
 
-            -   name: Run File-wise Coverage Parser Script
-                run: python3 scripts/coverage_parser.py
+            - name: Run File-wise Coverage Parser Script
+              run: python3 scripts/coverage_parser.py
 
     build:
         runs-on: ubuntu-latest
         name: build app
         steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v4
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-            -   name: prepare app
-                uses: ./.github/composite/prepareApp
+            - name: prepare app
+              uses: ./.github/composite/prepareApp
 
-            -   name: build app
-                run: ./gradlew assembleDebug
+            - name: build app
+              run: ./gradlew assembleDebug
 
-            -   name: Upload Debug Apk
-                uses: actions/upload-artifact@v4
-                if: success()
-                with:
-                    name: latest-apk
-                    path: "app/build/outputs/apk/core/debug/app-core-debug.apk"
+            - name: Upload Debug Apk
+              uses: actions/upload-artifact@v4
+              if: success()
+              with:
+                  name: latest-apk
+                  path: "app/build/outputs/apk/core/debug/app-core-debug.apk"
 
     instrumentation_test:
         runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
             - name: Checkout repository
               uses: checkout@v4
 
-            - name: Prepare app
+            - name: prepare app
               uses: ./.github/composite/prepare-app
 
             - name: Set up JDK 17
@@ -97,6 +97,6 @@ jobs:
             - name: Set up Android Emulator
               uses: reactivecircus/android-emulator-runner@v2
               with:
-                api-level: 30
-                arch: x86_64
-                script: ./gradlew connectedAndroidTest
+                  api-level: 30
+                  arch: x86_64
+                  script: ./gradlew connectedAndroidTest

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -89,9 +89,13 @@ jobs:
             - name: prepare app
               uses: ./.github/composite/prepareApp
 
-            - name: Set up Android Emulator
+            - name: Run UI tests on Emulator
               uses: reactivecircus/android-emulator-runner@v2
               with:
                   api-level: 30
+                  target: google_apis
                   arch: x86_64
-                  script: ./gradlew connectedAndroidTest
+                  profile: pixel_4
+                  emulator-options: "-no-window -no-audio -no-boot-anim"
+                  disable-animations: true
+                  script: ./gradlew connectedCoreDebugAndroidTest

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -82,6 +82,7 @@ jobs:
     instrumentation_test:
         runs-on: ubuntu-latest
         name: Run Android Instrumentation Tests
+        timeout-minutes: 30
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -89,15 +90,61 @@ jobs:
             - name: prepare app
               uses: ./.github/composite/prepareApp
 
+            # Enable hardware acceleration for better emulator performance
+            - name: Enable KVM group perms
+              run: |
+                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+                  sudo udevadm control --reload-rules
+                  sudo udevadm trigger --name-match=kvm
+
             - name: Run UI tests on Emulator
               uses: reactivecircus/android-emulator-runner@v2
               with:
-                  api-level: 30
-                  target: google_apis_playstore
+                  api-level: 29
+                  target: google_apis
                   arch: x86_64
-                  profile: pixel_4
-                  ram-size: 3072M
+                  profile: Nexus 6
+                  ram-size: 2048M
                   heap-size: 512M
-                  emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect"
+                  disk-size: 6000M
+                  emulator-options: "-no-window -no-audio -no-boot-anim -camera-back none -camera-front none -gpu swiftshader_indirect -no-snapshot -wipe-data -accel on"
                   disable-animations: true
-                  script: adb wait-for-device && adb shell settings put global window_animation_scale 0 && ./gradlew connectedCoreDebugAndroidTest
+                  force-avd-creation: false
+                  script: |
+                      echo "Waiting for emulator to be ready..."
+                      
+                      # Wait for device with timeout
+                      timeout 300 adb wait-for-device || { echo "Timeout waiting for device"; exit 1; }
+                      
+                      # Additional wait for system to be fully ready
+                      echo "Device detected, waiting for system to be ready..."
+                      while [ "`adb shell getprop sys.boot_completed 2>/dev/null`" != "1" ]; do
+                          echo "Waiting for boot completion..."
+                          sleep 5
+                      done
+                      
+                      # Wait for package manager
+                      while [ "`adb shell getprop init.svc.bootanim 2>/dev/null`" != "stopped" ]; do
+                          echo "Waiting for boot animation to stop..."
+                          sleep 2
+                      done
+                      
+                      echo "Emulator is ready! Setting up test environment..."
+                      
+                      # Unlock the device
+                      adb shell input keyevent 82
+                      
+                      # Disable animations completely
+                      adb shell settings put global window_animation_scale 0.0
+                      adb shell settings put global transition_animation_scale 0.0
+                      adb shell settings put global animator_duration_scale 0.0
+                      
+                      # Additional emulator setup
+                      adb shell settings put secure show_ime_with_hard_keyboard 0
+                      adb shell settings put system screen_off_timeout 1800000
+                      
+                      # Wait a bit more for settings to take effect
+                      sleep 3
+                      
+                      echo "Starting instrumented tests..."
+                      ./gradlew connectedCoreDebugAndroidTest --stacktrace --info

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -84,10 +84,10 @@ jobs:
         name: Run Android Instrumentation Tests
         steps:
             - name: Checkout repository
-              uses: checkout@v4
+              uses: actions/checkout@v4
 
             - name: prepare app
-              uses: ./.github/composite/prepare-app
+              uses: ./.github/composite/prepareApp
 
             - name: Set up JDK 17
               uses: actions/setup-java@v4

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -89,11 +89,6 @@ jobs:
             - name: prepare app
               uses: ./.github/composite/prepareApp
 
-            - name: Debug ADB Devices
-              run: |
-                adb devices
-                adb shell getprop ro.build.fingerprint
-
             - name: Run UI tests on Emulator
               uses: reactivecircus/android-emulator-runner@v2
               with:


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
Resolves #422 

This PR adds a new `instrumentation_test` job to `.github/workflows/android_ci.yml` to run instrumentation tests using `./gradlew connectedAndroidTest`.

**Testing**:
- Ran `./gradlew connectedAndroidTest` locally to confirm tests pass.
- Verified test reports in `app/build/reports/androidTests/connected/`.

**Notes**:
- Assumed tests exist in `app/src/androidTest`. 

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   closes #422 