### PR TITLE
fix enter key default behaviour

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -502,7 +502,7 @@ abstract class GeneralKeyboardIME(
         initializeKeyboard(getKeyboardLayoutXML())
         updateButtonVisibility(emojiAutoSuggestionEnabled)
         updateEmojiSuggestion(emojiAutoSuggestionEnabled, autoSuggestEmojis)
-
+        binding.commandBar.setText("")
         disableAutoSuggest()
     }
 
@@ -1539,7 +1539,7 @@ abstract class GeneralKeyboardIME(
             binding.commandBar.text
                 ?.toString()
                 ?.trim()
-                .takeIf { !it.isNullOrEmpty() }
+                ?.takeIf { it.isNotEmpty() }
 
         if (rawInput == null) {
             moveToIdleState()

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1526,6 +1526,15 @@ abstract class GeneralKeyboardIME(
      */
     fun handleKeycodeEnter() {
         val inputConnection = currentInputConnection ?: return
+
+        if (currentState == ScribeState.IDLE ||
+            currentState == ScribeState.SELECT_COMMAND ||
+            currentState == ScribeState.INVALID
+        ) {
+            handleDefaultEnter(inputConnection)
+            return
+        }
+
         val rawInput =
             binding.commandBar.text
                 ?.toString()
@@ -1534,13 +1543,12 @@ abstract class GeneralKeyboardIME(
 
         if (rawInput == null) {
             moveToIdleState()
-            return
-        }
-
-        when (currentState) {
-            ScribeState.PLURAL, ScribeState.TRANSLATE -> handlePluralOrTranslateState(rawInput, inputConnection)
-            ScribeState.CONJUGATE -> handleConjugateState(rawInput)
-            else -> handleDefaultEnter(inputConnection)
+        } else {
+            when (currentState) {
+                ScribeState.PLURAL, ScribeState.TRANSLATE -> handlePluralOrTranslateState(rawInput, inputConnection)
+                ScribeState.CONJUGATE -> handleConjugateState(rawInput)
+                else -> handleDefaultEnter(inputConnection)
+            }
         }
     }
 


### PR DESCRIPTION
### Contributor checklist


-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

If command input was empty, enter key was not handled even if keyboard was in non-command state (such as idle)

### Related issue


-   #427 
