### PR TITLE
feat(keyboard): add period key to search bar

### DIFF
--- a/.github/workflows/pr_maintainer_checklist.yaml
+++ b/.github/workflows/pr_maintainer_checklist.yaml
@@ -29,7 +29,8 @@ jobs:
 
                       The following is a checklist for maintainers to make sure this process goes as well as possible. Feel free to address the points below yourself in further commits if you realize that actions are needed :)
 
-                      - [ ] The linting and formatting workflows within the [PR checks](https://github.com/scribe-org/Scribe-Android/pull/${{ github.event.pull_request.number }}/checks) do not indicate new errors in the files changed
+                      - [ ] The linting, formatting and testing workflows within the [PR checks](https://github.com/scribe-org/Scribe-Android/pull/${{ github.event.pull_request.number }}/checks) do not indicate new errors in the files changed
+                          - Tests may need to be reran as they're at times not deterministic
 
                       - [ ] The [CHANGELOG](https://github.com/scribe-org/Scribe-Android/blob/main/CHANGELOG.md) has been updated with a description of the changes for the upcoming release and the corresponding issue (if necessary)
 

--- a/app/src/main/java/be/scri/helpers/EmojiUtils.kt
+++ b/app/src/main/java/be/scri/helpers/EmojiUtils.kt
@@ -2,6 +2,7 @@
 package be.scri.helpers
 
 import android.view.inputmethod.InputConnection
+import java.util.Locale
 
 /**
  * Utility object for handling emoji-related operations.
@@ -59,7 +60,7 @@ object EmojiUtils {
                 lastSpace != -1 -> {
                     val lastWord = prevText.substring(lastSpace + 1)
 
-                    if (emojiKeywords?.containsKey(lastWord.lowercase()) == true) {
+                    if (emojiKeywords?.containsKey(lastWord.lowercase(Locale.ROOT)) == true) {
                         ic.deleteSurroundingText(lastWord.length, 0)
                     }
 
@@ -67,7 +68,7 @@ object EmojiUtils {
                 }
 
                 else -> {
-                    if (emojiKeywords?.containsKey(prevText.lowercase()) == true) {
+                    if (emojiKeywords?.containsKey(prevText.lowercase(Locale.ROOT)) == true) {
                         ic.deleteSurroundingText(prevText.length, 0)
                     }
 

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -524,7 +524,7 @@ class KeyboardBase {
         var currentRow: Row? = null
         val res = context.resources
 
-        // Get the IME instance to check the current keyboard mode
+        // Get the IME instance to check the current keyboard mode.
         val imeInstance = context as? GeneralKeyboardIME
         val language = imeInstance?.language
         val currentKeyboardMode = imeInstance?.keyboardMode
@@ -538,7 +538,7 @@ class KeyboardBase {
                 true
             }
 
-        // ONLY hide the comma if we are on the main ABC keyboard in a search bar
+        // Only hide the comma if we are on the main ABC keyboard in a search bar.
         val hideComma =
             isSearchBar &&
                 !periodAndCommaEnabled &&

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -530,7 +530,7 @@ class KeyboardBase {
         val currentKeyboardMode = imeInstance?.keyboardMode
         val keyboardLettersMode = imeInstance?.keyboardLetters
 
-        val isSearchBar = mEnterKeyType == EditorInfo.IME_ACTION_SEARCH
+        val isSearchBar = imeInstance?.isSearchBar() == true
         val periodAndCommaEnabled: Boolean =
             if (language != null) {
                 PreferencesHelper.getEnablePeriodAndCommaABC(context, language)

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 
 /**
  * The EnglishKeyboardIME class provides the input method for the English language keyboard.
@@ -21,7 +20,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_english_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_english
+            isPeriodAndComaEnabled() -> R.xml.keys_letters_english
             else -> R.xml.keys_letters_english_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -20,7 +20,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_english_tablet
-            isPeriodAndComaEnabled() -> R.xml.keys_letters_english
+            isPeriodAndCommaEnabled() -> R.xml.keys_letters_english
             else -> R.xml.keys_letters_english_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -21,7 +21,7 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_english_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) -> R.xml.keys_letters_english
+            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_english
             else -> R.xml.keys_letters_english_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -20,7 +20,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_french_tablet
-            isPeriodAndComaEnabled() -> R.xml.keys_letters_french
+            isPeriodAndCommaEnabled() -> R.xml.keys_letters_french
             else -> R.xml.keys_letter_french_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 
 /**
  * The FrenchKeyboardIME class provides the input method for the French language keyboard.
@@ -21,7 +20,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_french_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_french
+            isPeriodAndComaEnabled() -> R.xml.keys_letters_french
             else -> R.xml.keys_letter_french_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/FrenchKeyboardIME.kt
@@ -21,7 +21,7 @@ class FrenchKeyboardIME : GeneralKeyboardIME("French") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_french_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) -> R.xml.keys_letters_french
+            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_french
             else -> R.xml.keys_letter_french_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -121,6 +121,13 @@ abstract class GeneralKeyboardIME(
 
     protected fun isSearchBar(): Boolean = enterKeyType == EditorInfo.IME_ACTION_SEARCH
 
+    protected fun isPeriodAndCommaEnabled(): Boolean {
+        val isPreferenceEnabled = PreferencesHelper.getEnablePeriodAndCommaABC(this, language)
+        val isInSearchBar = isSearchBar()
+
+        return isPreferenceEnabled || isInSearchBar
+    }
+
     enum class ScribeState { IDLE, SELECT_COMMAND, TRANSLATE, CONJUGATE, PLURAL, SELECT_VERB_CONJUNCTION, INVALID }
 
     /**

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -119,6 +119,8 @@ abstract class GeneralKeyboardIME(
     internal var currentState: ScribeState = ScribeState.IDLE
     private var earlierValue: Int? = keyboardView?.setEnterKeyIcon(ScribeState.IDLE)
 
+    protected fun isSearchBar(): Boolean = enterKeyType == EditorInfo.IME_ACTION_SEARCH
+
     enum class ScribeState { IDLE, SELECT_COMMAND, TRANSLATE, CONJUGATE, PLURAL, SELECT_VERB_CONJUNCTION, INVALID }
 
     /**

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -54,6 +54,7 @@ import be.scri.helpers.SHIFT_ON_PERMANENT
 import be.scri.helpers.SuggestionHandler
 import be.scri.helpers.ui.HintUtils
 import be.scri.views.KeyboardView
+import java.util.Locale
 
 private const val DATA_SIZE_2 = 2
 private const val DATA_CONSTANT_3 = 3
@@ -130,7 +131,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return `true` if the current input field is likely a search or address bar, `false` otherwise.
      */
-    protected fun isSearchBar(): Boolean {
+    fun isSearchBar(): Boolean {
         val editorInfo = currentInputEditorInfo
 
         val isActionSearch = (enterKeyType == EditorInfo.IME_ACTION_SEARCH)
@@ -141,7 +142,7 @@ abstract class GeneralKeyboardIME(
             } ?: false
 
         val hasSearchHint =
-            editorInfo?.hintText?.toString()?.lowercase()?.let {
+            editorInfo?.hintText?.toString()?.lowercase(Locale.ROOT)?.let {
                 it.contains("search") || it.contains("address")
             } ?: false
 

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -23,15 +23,16 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         if (isTablet()) {
             R.xml.keys_letters_german_tablet
         } else if (getIsAccentCharacterDisabled(applicationContext, language) &&
-            !getEnablePeriodAndCommaABC(applicationContext, language)
+            !getEnablePeriodAndCommaABC(applicationContext, language) &&
+            !isSearchBar()
         ) {
             R.xml.keys_letter_german_without_accent_characters_and_without_period_and_comma
         } else if (!getIsAccentCharacterDisabled(applicationContext, language) &&
-            getEnablePeriodAndCommaABC(applicationContext, language)
+            (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar())
         ) {
             R.xml.keys_letters_german
         } else if (getIsAccentCharacterDisabled(applicationContext, language) &&
-            getEnablePeriodAndCommaABC(applicationContext, language)
+            (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar())
         ) {
             R.xml.keys_letter_german_without_accent_characters
         } else {

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 import be.scri.helpers.PreferencesHelper.getIsAccentCharacterDisabled
 
 /**
@@ -23,16 +22,15 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         if (isTablet()) {
             R.xml.keys_letters_german_tablet
         } else if (getIsAccentCharacterDisabled(applicationContext, language) &&
-            !getEnablePeriodAndCommaABC(applicationContext, language) &&
-            !isSearchBar()
+            !isPeriodAndComaEnabled()
         ) {
             R.xml.keys_letter_german_without_accent_characters_and_without_period_and_comma
         } else if (!getIsAccentCharacterDisabled(applicationContext, language) &&
-            (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar())
+            isPeriodAndComaEnabled()
         ) {
             R.xml.keys_letters_german
         } else if (getIsAccentCharacterDisabled(applicationContext, language) &&
-            (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar())
+            isPeriodAndComaEnabled()
         ) {
             R.xml.keys_letter_german_without_accent_characters
         } else {

--- a/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GermanKeyboardIME.kt
@@ -22,15 +22,15 @@ class GermanKeyboardIME : GeneralKeyboardIME("German") {
         if (isTablet()) {
             R.xml.keys_letters_german_tablet
         } else if (getIsAccentCharacterDisabled(applicationContext, language) &&
-            !isPeriodAndComaEnabled()
+            !isPeriodAndCommaEnabled()
         ) {
             R.xml.keys_letter_german_without_accent_characters_and_without_period_and_comma
         } else if (!getIsAccentCharacterDisabled(applicationContext, language) &&
-            isPeriodAndComaEnabled()
+            isPeriodAndCommaEnabled()
         ) {
             R.xml.keys_letters_german
         } else if (getIsAccentCharacterDisabled(applicationContext, language) &&
-            isPeriodAndComaEnabled()
+            isPeriodAndCommaEnabled()
         ) {
             R.xml.keys_letter_german_without_accent_characters
         } else {

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -21,7 +21,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_italian_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) -> R.xml.keys_letters_italian
+            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_italian
             else -> R.xml.keys_letter_italian_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 
 /**
  * The ItalianKeyboardIME class provides the input method for the Italian language keyboard.
@@ -21,7 +20,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_italian_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_italian
+            isPeriodAndComaEnabled() -> R.xml.keys_letters_italian
             else -> R.xml.keys_letter_italian_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -20,7 +20,7 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_italian_tablet
-            isPeriodAndComaEnabled() -> R.xml.keys_letters_italian
+            isPeriodAndCommaEnabled() -> R.xml.keys_letters_italian
             else -> R.xml.keys_letter_italian_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -20,7 +20,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_portuguese_tablet
-            isPeriodAndComaEnabled() -> R.xml.keys_letters_portuguese
+            isPeriodAndCommaEnabled() -> R.xml.keys_letters_portuguese
             else -> R.xml.keys_letters_portuguese_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -21,7 +21,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_portuguese_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) -> R.xml.keys_letters_portuguese
+            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_portuguese
             else -> R.xml.keys_letters_portuguese_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/PortugueseKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 
 /**
  * The PortugueseKeyboardIME class provides the input method for the Portuguese language keyboard.
@@ -21,7 +20,7 @@ class PortugueseKeyboardIME : GeneralKeyboardIME("Portuguese") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_portuguese_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_portuguese
+            isPeriodAndComaEnabled() -> R.xml.keys_letters_portuguese
             else -> R.xml.keys_letters_portuguese_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -20,7 +20,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_russian_tablet
-            isPeriodAndComaEnabled() -> R.xml.keys_letters_russian
+            isPeriodAndCommaEnabled() -> R.xml.keys_letters_russian
             else -> R.xml.keys_letters_russian_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 
 /**
  * The RussianKeyboardIME class provides the input method for the Russian language keyboard.
@@ -21,7 +20,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_russian_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_russian
+            isPeriodAndComaEnabled() -> R.xml.keys_letters_russian
             else -> R.xml.keys_letters_russian_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -21,7 +21,7 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
     override fun getKeyboardLayoutXML(): Int =
         when {
             isTablet() -> R.xml.keys_letters_russian_tablet
-            getEnablePeriodAndCommaABC(applicationContext, language) -> R.xml.keys_letters_russian
+            getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar() -> R.xml.keys_letters_russian
             else -> R.xml.keys_letters_russian_without_period_and_comma
         }
 

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 import be.scri.helpers.PreferencesHelper.getIsAccentCharacterDisabled
 
 /**
@@ -23,14 +22,13 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         when {
             isTablet() -> R.xml.keys_letters_spanish_tablet
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                !getEnablePeriodAndCommaABC(applicationContext, language) &&
-                !isSearchBar() ->
+                !isPeriodAndComaEnabled() ->
                 R.xml.keys_letter_spanish_without_accent_characters_and_without_period_and_comma
             !getIsAccentCharacterDisabled(applicationContext, language) &&
-                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
+                isPeriodAndComaEnabled() ->
                 R.xml.keys_letters_spanish
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
+                isPeriodAndComaEnabled() ->
                 R.xml.keys_letter_spanish_without_accent_character
             else ->
                 R.xml.keys_letter_spanish_without_period_and_comma

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -22,13 +22,13 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         when {
             isTablet() -> R.xml.keys_letters_spanish_tablet
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                !isPeriodAndComaEnabled() ->
+                !isPeriodAndCommaEnabled() ->
                 R.xml.keys_letter_spanish_without_accent_characters_and_without_period_and_comma
             !getIsAccentCharacterDisabled(applicationContext, language) &&
-                isPeriodAndComaEnabled() ->
+                isPeriodAndCommaEnabled() ->
                 R.xml.keys_letters_spanish
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                isPeriodAndComaEnabled() ->
+                isPeriodAndCommaEnabled() ->
                 R.xml.keys_letter_spanish_without_accent_character
             else ->
                 R.xml.keys_letter_spanish_without_period_and_comma

--- a/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SpanishKeyboardIME.kt
@@ -23,13 +23,14 @@ class SpanishKeyboardIME : GeneralKeyboardIME("Spanish") {
         when {
             isTablet() -> R.xml.keys_letters_spanish_tablet
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                !getEnablePeriodAndCommaABC(applicationContext, language) ->
+                !getEnablePeriodAndCommaABC(applicationContext, language) &&
+                !isSearchBar() ->
                 R.xml.keys_letter_spanish_without_accent_characters_and_without_period_and_comma
             !getIsAccentCharacterDisabled(applicationContext, language) &&
-                getEnablePeriodAndCommaABC(applicationContext, language) ->
+                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
                 R.xml.keys_letters_spanish
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                getEnablePeriodAndCommaABC(applicationContext, language) ->
+                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
                 R.xml.keys_letter_spanish_without_accent_character
             else ->
                 R.xml.keys_letter_spanish_without_period_and_comma

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -22,13 +22,13 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         when {
             isTablet() -> R.xml.keys_letters_swedish_tablet
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                !isPeriodAndComaEnabled() ->
+                !isPeriodAndCommaEnabled() ->
                 R.xml.keys_letter_swedish_without_accent_characters_and_without_period_and_comma
             !getIsAccentCharacterDisabled(applicationContext, language) &&
-                isPeriodAndComaEnabled() ->
+                isPeriodAndCommaEnabled() ->
                 R.xml.keys_letters_swedish
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                isPeriodAndComaEnabled() ->
+                isPeriodAndCommaEnabled() ->
                 R.xml.keys_letter_swedish_without_accent_characters
             else ->
                 R.xml.keys_letter_swedish_without_period_and_comma

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -6,7 +6,6 @@ import android.text.InputType
 import android.view.inputmethod.EditorInfo.IME_ACTION_NONE
 import be.scri.R
 import be.scri.helpers.KeyHandler
-import be.scri.helpers.PreferencesHelper.getEnablePeriodAndCommaABC
 import be.scri.helpers.PreferencesHelper.getIsAccentCharacterDisabled
 
 /**
@@ -23,14 +22,13 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         when {
             isTablet() -> R.xml.keys_letters_swedish_tablet
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                !getEnablePeriodAndCommaABC(applicationContext, language) &&
-                !isSearchBar() ->
+                !isPeriodAndComaEnabled() ->
                 R.xml.keys_letter_swedish_without_accent_characters_and_without_period_and_comma
             !getIsAccentCharacterDisabled(applicationContext, language) &&
-                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
+                isPeriodAndComaEnabled() ->
                 R.xml.keys_letters_swedish
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
+                isPeriodAndComaEnabled() ->
                 R.xml.keys_letter_swedish_without_accent_characters
             else ->
                 R.xml.keys_letter_swedish_without_period_and_comma

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -23,13 +23,14 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
         when {
             isTablet() -> R.xml.keys_letters_swedish_tablet
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                !getEnablePeriodAndCommaABC(applicationContext, language) ->
+                !getEnablePeriodAndCommaABC(applicationContext, language) &&
+                !isSearchBar() ->
                 R.xml.keys_letter_swedish_without_accent_characters_and_without_period_and_comma
             !getIsAccentCharacterDisabled(applicationContext, language) &&
-                getEnablePeriodAndCommaABC(applicationContext, language) ->
+                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
                 R.xml.keys_letters_swedish
             getIsAccentCharacterDisabled(applicationContext, language) &&
-                getEnablePeriodAndCommaABC(applicationContext, language) ->
+                (getEnablePeriodAndCommaABC(applicationContext, language) || isSearchBar()) ->
                 R.xml.keys_letter_swedish_without_accent_characters
             else ->
                 R.xml.keys_letter_swedish_without_period_and_comma

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -844,6 +844,12 @@ class KeyboardView
                 val keyCount = keys.size
                 for (i in 0 until keyCount) {
                     val key = keys[i]
+
+                    // If a key has no width, it's effectively invisible. Don't draw it or its shadow.
+                    if (key.width == 0) {
+                        continue
+                    }
+
                     val code = key.code
 
                     val padding = KEY_PADDING


### PR DESCRIPTION

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
When using a browser's search or URL bar, a period is a frequently used character. This change ensures the period key is always available on the alphabetical layout in this context, regardless of the user's "period and comma" setting.

The implementation works as follows:

- `GeneralKeyboardIME` now detects `IME_ACTION_SEARCH` to force the selection of a keyboard layout that includes the period key.
- `KeyboardBase.loadKeyboard` contains new logic that only triggers when on the main alphabetical keyboard.
- If the user has disabled the comma key, its width and gap are captured, and the key is hidden.
- The captured width is added exclusively to the spacebar in the same row.
- Keys following the spacebar in that specific row are then realigned to prevent any visual gaps or layout distortion in other rows.

Closes #431

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->


