### PR TITLE
feat(settings): add toggle for word-by-word deletion (enabled by defa…

### DIFF
--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -242,7 +242,10 @@ object PreferencesHelper {
     ) {
         val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
         sharedPref.edit {
-            putBoolean(getLanguageSpecificPreferenceKey(WORD_BY_WORD_DELETION, language), shouldEnableWordByWordDeletion)
+            putBoolean(
+                getLanguageSpecificPreferenceKey(WORD_BY_WORD_DELETION, language),
+                shouldEnableWordByWordDeletion,
+            )
         }
         Toast
             .makeText(

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -24,6 +24,7 @@ object PreferencesHelper {
     private const val TRANSLATION_SOURCE = "translation_source"
     private const val EMOJI_SUGGESTIONS = "emoji_suggestions"
     private const val DISABLE_ACCENT_CHARACTER = "disable_accent_character"
+    private const val WORD_BY_WORD_DELETION = "word_by_word_deletion"
 
     /**
      * Sets the translation source language for a given language.
@@ -228,6 +229,31 @@ object PreferencesHelper {
     }
 
     /**
+     * Sets the preference for enabling or disabling word-by-word deletion for a language.
+     *
+     * @param context The application context.
+     * @param language The language for which to set the preference.
+     * @param shouldEnableWordByWordDeletion Whether to enable or disable word-by-word deletion.
+     */
+    fun setWordByWordDeletionPreference(
+        context: Context,
+        language: String,
+        shouldEnableWordByWordDeletion: Boolean,
+    ) {
+        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
+        sharedPref.edit {
+            putBoolean(getLanguageSpecificPreferenceKey(WORD_BY_WORD_DELETION, language), shouldEnableWordByWordDeletion)
+        }
+        Toast
+            .makeText(
+                context,
+                "$language Word by Word Deletion " +
+                    if (shouldEnableWordByWordDeletion) "enabled" else "disabled",
+                Toast.LENGTH_SHORT,
+            ).show()
+    }
+
+    /**
      * Sets the preference for enabling or disabling light/dark mode.
      *
      * @param context The application context.
@@ -244,7 +270,7 @@ object PreferencesHelper {
     }
 
     /**
-     * Retrieves the user’s dark mode preference.
+     * Retrieves the user's dark mode preference.
      *
      * @param context The application context.
      * @return The dark mode setting as an integer value (AppCompatDelegate.MODE_NIGHT_YES or MODE_NIGHT_NO).
@@ -374,6 +400,22 @@ object PreferencesHelper {
     ): Boolean {
         val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, MODE_PRIVATE)
         val isEnabled = sharedPref.getBoolean(getLanguageSpecificPreferenceKey(EMOJI_SUGGESTIONS, language), true)
+        return isEnabled
+    }
+
+    /**
+     * Retrieves whether word-by-word deletion is enabled for a given language.
+     *
+     * @param context The application context.
+     * @param language The language for which to check the preference.
+     * @return True if word-by-word deletion is enabled, false otherwise.
+     */
+    fun getIsWordByWordDeletionEnabled(
+        context: Context,
+        language: String,
+    ): Boolean {
+        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, MODE_PRIVATE)
+        val isEnabled = sharedPref.getBoolean(getLanguageSpecificPreferenceKey(WORD_BY_WORD_DELETION, language), true)
         return isEnabled
     }
 

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -25,6 +25,22 @@ import be.scri.ui.models.ScribeItem
 import be.scri.ui.models.ScribeItemList
 
 /**
+ * Data class to hold functionality settings state and callbacks
+ */
+private data class FunctionalitySettings(
+    val periodOnDoubleTapState: Boolean,
+    val onTogglePeriodOnDoubleTap: (Boolean) -> Unit,
+    val emojiSuggestionsState: Boolean,
+    val onToggleEmojiSuggestions: (Boolean) -> Unit,
+    val togglePopUpOnKeyPress: Boolean,
+    val onTogglePopUpOnKeyPress: (Boolean) -> Unit,
+    val toggleVibrateOnKeyPress: Boolean,
+    val onToggleVibrateOnKeyPress: (Boolean) -> Unit,
+    val wordByWordDeletionState: Boolean,
+    val onToggleWordByWordDeletion: (Boolean) -> Unit,
+)
+
+/**
  * The settings sub menu page for languages that allows for customization of language keyboard interfaces.
  */
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -121,56 +137,60 @@ fun LanguageSettingsScreen(
                     },
                 ),
         )
+
+    // Create functionality settings object
+    val functionalitySettings =
+        FunctionalitySettings(
+            periodOnDoubleTapState = periodOnDoubleTapState.value,
+            onTogglePeriodOnDoubleTap = { isEnabled ->
+                periodOnDoubleTapState.value = isEnabled
+                PreferencesHelper.setPeriodOnSpaceBarDoubleTapPreference(
+                    context,
+                    language,
+                    isEnabled,
+                )
+            },
+            emojiSuggestionsState = emojiSuggestionsState.value,
+            onToggleEmojiSuggestions = { isEnabled ->
+                emojiSuggestionsState.value = isEnabled
+                PreferencesHelper.setEmojiAutoSuggestionsPreference(
+                    context,
+                    language,
+                    isEnabled,
+                )
+            },
+            togglePopUpOnKeyPress = popupOnKeyPressState.value,
+            onTogglePopUpOnKeyPress = { isEnabled ->
+                popupOnKeyPressState.value = isEnabled
+                PreferencesHelper.setShowPopupOnKeypress(
+                    context,
+                    language,
+                    isEnabled,
+                )
+            },
+            toggleVibrateOnKeyPress = vibrateOnKeyPressState.value,
+            onToggleVibrateOnKeyPress = { shouldVibrateOnKeyPress ->
+                vibrateOnKeyPressState.value = shouldVibrateOnKeyPress
+                PreferencesHelper.setVibrateOnKeypress(
+                    context,
+                    language,
+                    shouldVibrateOnKeyPress,
+                )
+            },
+            wordByWordDeletionState = wordByWordDeletionState.value,
+            onToggleWordByWordDeletion = { isEnabled ->
+                wordByWordDeletionState.value = isEnabled
+                PreferencesHelper.setWordByWordDeletionPreference(
+                    context,
+                    language,
+                    isEnabled,
+                )
+            },
+        )
+
     val functionalityList =
         ScribeItemList(
-            items =
-                getFunctionalityListData(
-                    periodOnDoubleTapState = periodOnDoubleTapState.value,
-                    onTogglePeriodOnDoubleTap = { isEnabled ->
-                        periodOnDoubleTapState.value = isEnabled
-                        PreferencesHelper.setPeriodOnSpaceBarDoubleTapPreference(
-                            context,
-                            language,
-                            isEnabled,
-                        )
-                    },
-                    emojiSuggestionsState = emojiSuggestionsState.value,
-                    onToggleEmojiSuggestions = { isEnabled ->
-                        emojiSuggestionsState.value = isEnabled
-                        PreferencesHelper.setEmojiAutoSuggestionsPreference(
-                            context,
-                            language,
-                            isEnabled,
-                        )
-                    },
-                    togglePopUpOnKeyPress = popupOnKeyPressState.value,
-                    onTogglePopUpOnKeyPress = { isEnabled ->
-                        popupOnKeyPressState.value = isEnabled
-                        PreferencesHelper.setShowPopupOnKeypress(
-                            context,
-                            language,
-                            isEnabled,
-                        )
-                    },
-                    toggleVibrateOnKeyPress = vibrateOnKeyPressState.value,
-                    onToggleVibrateOnKeyPress = { shouldVibrateOnKeyPress ->
-                        vibrateOnKeyPressState.value = shouldVibrateOnKeyPress
-                        PreferencesHelper.setVibrateOnKeypress(
-                            context,
-                            language,
-                            shouldVibrateOnKeyPress,
-                        )
-                    },
-                    wordByWordDeletionState = wordByWordDeletionState.value,
-                    onToggleWordByWordDeletion = { isEnabled ->
-                        wordByWordDeletionState.value = isEnabled
-                        PreferencesHelper.setWordByWordDeletionPreference(
-                            context,
-                            language,
-                            isEnabled,
-                        )
-                    },
-                ),
+            items = getFunctionalityListData(functionalitySettings),
         )
 
     ScribeBaseScreen(
@@ -216,63 +236,43 @@ fun LanguageSettingsScreen(
  * - Popup on keypress
  * - Word by word deletion
  *
- * @param periodOnDoubleTapState Current state of the double-space period setting.
- * @param onTogglePeriodOnDoubleTap Callback invoked when the double-space period is toggled.
- * @param emojiSuggestionsState Current state of the emoji suggestions setting.
- * @param onToggleEmojiSuggestions Callback invoked when emoji suggestions is toggled.
- * @param togglePopUpOnKeyPress Current state of popup on keypress setting.
- * @param onTogglePopUpOnKeyPress Callback invoked when popup on keypress is toggled.
- * @param toggleVibrateOnKeyPress Current state of keypress vibration setting.
- * @param onToggleVibrateOnKeyPress Callback invoked when keypress vibration is toggled.
- * @param wordByWordDeletionState Current state of word-by-word deletion setting.
- * @param onToggleWordByWordDeletion Callback invoked when word-by-word deletion is toggled.
+ * @param settings The functionality settings containing state and callbacks.
  *
  * @return A list of [ScribeItem]s to be shown in the UI.
  */
 @Composable
-private fun getFunctionalityListData(
-    periodOnDoubleTapState: Boolean,
-    onTogglePeriodOnDoubleTap: (Boolean) -> Unit,
-    emojiSuggestionsState: Boolean,
-    onToggleEmojiSuggestions: (Boolean) -> Unit,
-    togglePopUpOnKeyPress: Boolean,
-    onTogglePopUpOnKeyPress: (Boolean) -> Unit,
-    toggleVibrateOnKeyPress: Boolean,
-    onToggleVibrateOnKeyPress: (Boolean) -> Unit,
-    wordByWordDeletionState: Boolean,
-    onToggleWordByWordDeletion: (Boolean) -> Unit,
-): List<ScribeItem> {
+private fun getFunctionalityListData(settings: FunctionalitySettings): List<ScribeItem> {
     val list =
         listOf(
             ScribeItem.SwitchItem(
                 title = R.string.app_settings_keyboard_functionality_double_space_period,
                 desc = R.string.app_settings_keyboard_functionality_double_space_period_description,
-                state = periodOnDoubleTapState,
-                onToggle = onTogglePeriodOnDoubleTap,
+                state = settings.periodOnDoubleTapState,
+                onToggle = settings.onTogglePeriodOnDoubleTap,
             ),
             ScribeItem.SwitchItem(
                 title = R.string.app_settings_keyboard_functionality_auto_suggest_emoji,
                 desc = R.string.app_settings_keyboard_functionality_auto_suggest_emoji_description,
-                state = emojiSuggestionsState,
-                onToggle = onToggleEmojiSuggestions,
+                state = settings.emojiSuggestionsState,
+                onToggle = settings.onToggleEmojiSuggestions,
             ),
             ScribeItem.SwitchItem(
                 title = R.string.app_settings_keyboard_keypress_vibration,
                 desc = R.string.app_settings_keyboard_keypress_vibration_description,
-                state = toggleVibrateOnKeyPress,
-                onToggle = onToggleVibrateOnKeyPress,
+                state = settings.toggleVibrateOnKeyPress,
+                onToggle = settings.onToggleVibrateOnKeyPress,
             ),
             ScribeItem.SwitchItem(
                 title = R.string.app_settings_keyboard_functionality_popup_on_keypress,
                 desc = R.string.app_settings_keyboard_functionality_popup_on_keypress_description,
-                state = togglePopUpOnKeyPress,
-                onToggle = onTogglePopUpOnKeyPress,
+                state = settings.togglePopUpOnKeyPress,
+                onToggle = settings.onTogglePopUpOnKeyPress,
             ),
             ScribeItem.SwitchItem(
                 title = R.string.app_settings_keyboard_functionality_delete_word_by_word,
                 desc = R.string.app_settings_keyboard_functionality_delete_word_by_word_description,
-                state = wordByWordDeletionState,
-                onToggle = onToggleWordByWordDeletion,
+                state = settings.wordByWordDeletionState,
+                onToggle = settings.onToggleWordByWordDeletion,
             ),
         )
     return list

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -81,6 +81,13 @@ fun LanguageSettingsScreen(
             )
         }
 
+    val wordByWordDeletionState =
+        remember {
+            mutableStateOf(
+                PreferencesHelper.getIsWordByWordDeletionEnabled(context, language),
+            )
+        }
+
     val translationSourceLanguageList =
         ScribeItemList(
             items =
@@ -154,6 +161,15 @@ fun LanguageSettingsScreen(
                             shouldVibrateOnKeyPress,
                         )
                     },
+                    wordByWordDeletionState = wordByWordDeletionState.value,
+                    onToggleWordByWordDeletion = { isEnabled ->
+                        wordByWordDeletionState.value = isEnabled
+                        PreferencesHelper.setWordByWordDeletionPreference(
+                            context,
+                            language,
+                            isEnabled,
+                        )
+                    },
                 ),
         )
 
@@ -198,6 +214,7 @@ fun LanguageSettingsScreen(
  * - Emoji suggestions
  * - Keypress vibration
  * - Popup on keypress
+ * - Word by word deletion
  *
  * @param periodOnDoubleTapState Current state of the double-space period setting.
  * @param onTogglePeriodOnDoubleTap Callback invoked when the double-space period is toggled.
@@ -207,6 +224,8 @@ fun LanguageSettingsScreen(
  * @param onTogglePopUpOnKeyPress Callback invoked when popup on keypress is toggled.
  * @param toggleVibrateOnKeyPress Current state of keypress vibration setting.
  * @param onToggleVibrateOnKeyPress Callback invoked when keypress vibration is toggled.
+ * @param wordByWordDeletionState Current state of word-by-word deletion setting.
+ * @param onToggleWordByWordDeletion Callback invoked when word-by-word deletion is toggled.
  *
  * @return A list of [ScribeItem]s to be shown in the UI.
  */
@@ -220,6 +239,8 @@ private fun getFunctionalityListData(
     onTogglePopUpOnKeyPress: (Boolean) -> Unit,
     toggleVibrateOnKeyPress: Boolean,
     onToggleVibrateOnKeyPress: (Boolean) -> Unit,
+    wordByWordDeletionState: Boolean,
+    onToggleWordByWordDeletion: (Boolean) -> Unit,
 ): List<ScribeItem> {
     val list =
         listOf(
@@ -246,6 +267,12 @@ private fun getFunctionalityListData(
                 desc = R.string.app_settings_keyboard_functionality_popup_on_keypress_description,
                 state = togglePopUpOnKeyPress,
                 onToggle = onTogglePopUpOnKeyPress,
+            ),
+            ScribeItem.SwitchItem(
+                title = R.string.app_settings_keyboard_functionality_delete_word_by_word,
+                desc = R.string.app_settings_keyboard_functionality_delete_word_by_word_description,
+                state = wordByWordDeletionState,
+                onToggle = onToggleWordByWordDeletion,
             ),
         )
     return list


### PR DESCRIPTION

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch  
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request introduces a new feature that allows users to enable or disable **word-by-word deletion** via the keyboard settings. By default, the toggle is enabled.

- A new settings option is added to control deletion behavior.
- The keyboard now supports two delete modes:
  - **Word-by-word** (default)
  - **Speed-up continuous delete** (previous behavior)
- When the toggle is on, long-pressing the delete key deletes one word at a time.

### Related issue

-   #416
