### PR TITLE
Added default currency symbol option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 ######################
 .idea
 *.iml
-
+.venv
 # Gradle and build files
 ########################
 .gradle

--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -203,7 +203,7 @@ fun ScribeApp(
                                 navController.navigate("translation_language_detail/$language")
                             },
                             onCurrencySelect = {
-                                navController.navigate("currency_symbol_detail/$symbol")
+                                navController.navigate("currency_symbol_detail/$symbol/$language")
                             },
                         )
                     }
@@ -220,14 +220,16 @@ fun ScribeApp(
                     )
                 }
 
-                composable("currency_symbol_detail/{symbolName}") { backStackEntry ->
+                composable("currency_symbol_detail/{symbolName}/{languageName}") { backStackEntry ->
                     val symbol = backStackEntry.arguments?.getString("symbolName") ?: ""
+                    val language = backStackEntry.arguments?.getString("languageName") ?: ""
                     DefaultCurrencySymbolScreen(
+                        currentSymbol = symbol,
+                        currentLanguage = language,
                         onBackNavigation = {
                             navController.popBackStack()
                         },
                         modifier = Modifier.padding(innerPadding),
-                        currentSymbol = symbol,
                     )
                 }
 

--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import be.scri.navigation.Screen
 import be.scri.ui.common.appcomponents.HintDialog
 import be.scri.ui.common.bottombar.ScribeBottomBar
+import be.scri.ui.screens.DefaultCurrencySymbolScreen
 import be.scri.ui.screens.InstallationScreen
 import be.scri.ui.screens.LanguageSettingsScreen
 import be.scri.ui.screens.PrivacyPolicyScreen
@@ -190,6 +191,7 @@ fun ScribeApp(
 
                 composable("${Screen.LanguageSettings.route}/{languageName}") {
                     val language = it.arguments?.getString("languageName")
+                    val symbol = it.arguments?.getString("symbolName")
                     if (language != null) {
                         LanguageSettingsScreen(
                             language = language,
@@ -199,6 +201,9 @@ fun ScribeApp(
                             modifier = Modifier.padding(innerPadding),
                             onTranslationLanguageSelect = {
                                 navController.navigate("translation_language_detail/$language")
+                            },
+                            onCurrencySelect = {
+                                navController.navigate("currency_symbol_detail/$symbol")
                             },
                         )
                     }
@@ -212,6 +217,17 @@ fun ScribeApp(
                         },
                         modifier = Modifier.padding(innerPadding),
                         currentLanguage = language,
+                    )
+                }
+
+                composable("currency_symbol_detail/{symbolName}") { backStackEntry ->
+                    val symbol = backStackEntry.arguments?.getString("symbolName") ?: ""
+                    DefaultCurrencySymbolScreen(
+                        onBackNavigation = {
+                            navController.popBackStack()
+                        },
+                        modifier = Modifier.padding(innerPadding),
+                        currentSymbol = symbol,
                     )
                 }
 

--- a/app/src/main/java/be/scri/ui/screens/DefaultCurrencySymbolScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/DefaultCurrencySymbolScreen.kt
@@ -36,23 +36,34 @@ import be.scri.ui.common.ScribeBaseScreen
  */
 @Composable
 fun DefaultCurrencySymbolScreen(
+    currentLanguage: String,
     currentSymbol: String,
     onBackNavigation: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-    var selectedSymbol =
+    val selectedSymbol =
         remember {
-            mutableStateOf(sharedPref.getString("translation_source_$currentSymbol", "$") ?: "$")
+            mutableStateOf(sharedPref.getString("default_currency", "Dollar") ?: "Dollar")
         }
     val scrollState = rememberScrollState()
-    val options =
-        listOf("Dollar", "Euro", "Pound", "Rouble", "Rupee", "Won", "Yen")
-            .filterNot { it == currentSymbol }
+    val symbolMap =
+        mapOf(
+            "Dollar" to "$",
+            "Euro" to "€",
+            "Pound" to "£",
+            "Rouble" to "₽",
+            "Rupee" to "₹",
+            "Won" to "₩",
+            "Yen" to "¥",
+        )
+
+    val currentSymbolName = symbolMap.entries.find { it.value == currentSymbol }?.key ?: "Dollar"
+    val options = symbolMap.keys.filterNot { it == currentSymbolName }
     ScribeBaseScreen(
         pageTitle = stringResource(R.string.app_settings_keyboard_layout_default_currency),
-        lastPage = currentSymbol,
+        lastPage = stringResource(id = getLanguageStringFromi18n(currentLanguage)),
         onBackNavigation = onBackNavigation,
         modifier = modifier,
     ) {
@@ -84,7 +95,7 @@ fun DefaultCurrencySymbolScreen(
                                     .fillMaxWidth()
                                     .clickable {
                                         selectedSymbol.value = option
-                                        sharedPref.edit { putString("translation_source_$currentSymbol", option) }
+                                        sharedPref.edit { putString("default_currency", option) }
                                     }.padding(vertical = 5.dp, horizontal = 8.dp),
                         ) {
                             Text(
@@ -92,11 +103,15 @@ fun DefaultCurrencySymbolScreen(
                                 style = MaterialTheme.typography.bodyLarge,
                             )
                             Spacer(modifier = Modifier.weight(1f))
+                            Text(
+                                text = symbolMap[option] ?: "",
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
                             RadioButton(
                                 selected = (option == selectedSymbol.value),
                                 onClick = {
                                     selectedSymbol.value = option
-                                    sharedPref.edit { putString("translation_source_$currentSymbol", option) }
+                                    sharedPref.edit { putString("default_currency", option) }
                                 },
                             )
                         }

--- a/app/src/main/java/be/scri/ui/screens/DefaultCurrencySymbolScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/DefaultCurrencySymbolScreen.kt
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package be.scri.ui.screens
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.edit
+import be.scri.R
+import be.scri.ui.common.ScribeBaseScreen
+
+/**
+ * The Select Languages subpage is for selecting the translation source language.
+ */
+@Composable
+fun DefaultCurrencySymbolScreen(
+    currentSymbol: String,
+    onBackNavigation: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+    var selectedSymbol =
+        remember {
+            mutableStateOf(sharedPref.getString("translation_source_$currentSymbol", "$") ?: "$")
+        }
+    val scrollState = rememberScrollState()
+    val options =
+        listOf("Dollar", "Euro", "Pound", "Rouble", "Rupee", "Won", "Yen")
+            .filterNot { it == currentSymbol }
+    ScribeBaseScreen(
+        pageTitle = stringResource(R.string.app_settings_keyboard_layout_default_currency),
+        lastPage = currentSymbol,
+        onBackNavigation = onBackNavigation,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .padding(16.dp)
+                    .verticalScroll(scrollState)
+                    .background(MaterialTheme.colorScheme.background),
+        ) {
+            Text(
+                text = stringResource(R.string.app_settings_keyboard_layout_default_currency_caption),
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(10.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+            ) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    options.forEachIndexed { index, option ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        selectedSymbol.value = option
+                                        sharedPref.edit { putString("translation_source_$currentSymbol", option) }
+                                    }.padding(vertical = 5.dp, horizontal = 8.dp),
+                        ) {
+                            Text(
+                                text = option,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            RadioButton(
+                                selected = (option == selectedSymbol.value),
+                                onClick = {
+                                    selectedSymbol.value = option
+                                    sharedPref.edit { putString("translation_source_$currentSymbol", option) }
+                                },
+                            )
+                        }
+
+                        if (index < options.lastIndex) {
+                            Divider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -33,6 +33,7 @@ fun LanguageSettingsScreen(
     language: String,
     onBackNavigation: () -> Unit,
     onTranslationLanguageSelect: () -> Unit,
+    onCurrencySelect: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -112,6 +113,7 @@ fun LanguageSettingsScreen(
                             shouldDisableAccentCharacter,
                         )
                     },
+                    onCurrencySelect = onCurrencySelect,
                 ),
         )
     val functionalityList =
@@ -273,6 +275,7 @@ private fun getLayoutListData(
     onTogglePeriodAndComma: (Boolean) -> Unit,
     toggleDisableAccentCharacter: Boolean,
     onToggleDisableAccentCharacter: (Boolean) -> Unit,
+    onCurrencySelect: () -> Unit,
 ): List<ScribeItem> {
     val list: MutableList<ScribeItem> = mutableListOf()
 
@@ -295,6 +298,16 @@ private fun getLayoutListData(
             desc = R.string.app_settings_keyboard_layout_period_and_comma_description,
             state = togglePeriodAndCommaState,
             onToggle = onTogglePeriodAndComma,
+        ),
+    )
+    list.add(
+        ScribeItem.ClickableItem(
+            title = R.string.app_settings_keyboard_layout_default_currency,
+            desc = R.string.app_settings_keyboard_layout_default_currency_description,
+            action = {
+                Log.d("Navigation", "onCurrencySelect clicked")
+                onCurrencySelect()
+            },
         ),
     )
 


### PR DESCRIPTION
### Contributor checklist

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pr adds the frontend implimentation for a menu option to change the currency symbol of the keyboard form the given [reference](https://www.figma.com/design/c8945w2iyoPYVhsqW7vRn6/scribe_public_designs?node-id=1328-3971&t=8HKzSkldIZfz8Qkw-0)

### Related issue

-   #417 
