### PR TITLE
feat: add word-by-word deletion support with long-press behavior

### DIFF
--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -160,7 +160,9 @@ class KeyHandler(
             ime.currentState == ScribeState.TRANSLATE ||
                 ime.currentState == ScribeState.CONJUGATE ||
                 ime.currentState == ScribeState.PLURAL
-        ime.handleDelete(isCommandBarActive)
+
+        // Pass the repeat state to the delete handler
+        ime.handleDelete(isCommandBarActive, ime.isDeleteRepeating())
 
         // Only process suggestions if the state is exactly IDLE.
         if (ime.currentState == ScribeState.IDLE) {

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -418,7 +418,7 @@ object PreferencesHelper {
         language: String,
     ): Boolean {
         val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, MODE_PRIVATE)
-        val isEnabled = sharedPref.getBoolean(getLanguageSpecificPreferenceKey(WORD_BY_WORD_DELETION, language), true)
+        val isEnabled = sharedPref.getBoolean(getLanguageSpecificPreferenceKey(WORD_BY_WORD_DELETION, language), false)
         return isEnabled
     }
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -37,7 +37,6 @@ import be.scri.helpers.AnnotationTextUtils.handleColorAndTextForNounType
 import be.scri.helpers.AnnotationTextUtils.handleTextForCaseAnnotation
 import be.scri.helpers.DatabaseManagers
 import be.scri.helpers.EmojiUtils.insertEmoji
-import be.scri.helpers.EmojiUtils.isEmoji
 import be.scri.helpers.KeyboardBase
 import be.scri.helpers.LanguageMappingConstants.conjugatePlaceholder
 import be.scri.helpers.LanguageMappingConstants.getLanguageAlias
@@ -78,6 +77,9 @@ abstract class GeneralKeyboardIME(
     abstract var enterKeyType: Int
     abstract var switchToLetters: Boolean
     abstract var hasTextBeforeCursor: Boolean
+
+    // Track if the delete key is currently being repeated (long press)
+    private var isDeleteRepeating: Boolean = false
 
     internal lateinit var binding: InputMethodViewBinding
 
@@ -320,6 +322,18 @@ abstract class GeneralKeyboardIME(
             switchToLetters = false
         }
     }
+
+    /**
+     * Sets the flag to indicate that the delete key is currently repeating (long press).
+     */
+    fun setDeleteRepeating(isRepeating: Boolean) {
+        isDeleteRepeating = isRepeating
+    }
+
+    /**
+     * Returns whether the delete key is currently repeating (long press).
+     */
+    fun isDeleteRepeating(): Boolean = isDeleteRepeating
 
     override fun moveCursorLeft() {
         moveCursor(false)
@@ -1801,18 +1815,24 @@ abstract class GeneralKeyboardIME(
      * Handles the logic for the Delete/Backspace key. It deletes characters from either
      * the main input field or the command bar, depending on the context.
      * @param isCommandBar `true` if the deletion should happen in the command bar.
+     * @param isLongPress `true` if this is a long press/repeat action, `false` for single tap.
      */
-    fun handleDelete(isCommandBar: Boolean = false) {
+    fun handleDelete(
+        isCommandBar: Boolean = false,
+        isLongPress: Boolean = false,
+    ) {
         if (keyboard!!.mShiftState == SHIFT_ON_ONE_CHAR) keyboard!!.mShiftState = SHIFT_OFF
         if (isCommandBar) {
             handleCommandBarDelete()
         } else {
             val inputConnection = currentInputConnection ?: return
             if (TextUtils.isEmpty(inputConnection.getSelectedText(0))) {
-                if (isEmoji(getText())) {
-                    inputConnection.deleteSurroundingText(DATA_SIZE_2, 0)
+                val isWordByWordEnabled = PreferencesHelper.getIsWordByWordDeletionEnabled(applicationContext, language)
+                // Only use word-by-word deletion on long press when the feature is enabled
+                if (isWordByWordEnabled && isLongPress) {
+                    deleteWordByWord(inputConnection)
                 } else {
-                    inputConnection.deleteSurroundingText(1, 0)
+                    deleteSingleCharacter(inputConnection)
                 }
             } else {
                 inputConnection.commitText("", 1)
@@ -1821,6 +1841,84 @@ abstract class GeneralKeyboardIME(
                 keyboard!!.mShiftState = SHIFT_ON_ONE_CHAR
                 keyboardView!!.invalidateAllKeys()
             }
+        }
+    }
+
+    /**
+     * Deletes a single character.
+     */
+    private fun deleteSingleCharacter(inputConnection: InputConnection) {
+        inputConnection.deleteSurroundingText(1, 0)
+    }
+
+    /**
+     * Deletes an entire word, including any trailing whitespace.
+     * @param inputConnection The current input connection.
+     */
+    private fun deleteWordByWord(inputConnection: InputConnection) {
+        val textBeforeCursor = inputConnection.getTextBeforeCursor(MAX_TEXT_LENGTH, 0)?.toString() ?: ""
+
+        if (textBeforeCursor.isEmpty()) {
+            return
+        }
+
+        var deletionLength = 0
+        var index = textBeforeCursor.length - 1
+
+        // Skip any  whitespace
+        while (index >= 0 && textBeforeCursor[index].isWhitespace()) {
+            deletionLength++
+            index--
+        }
+
+        // If we only had whitespace, delete it
+        if (index < 0) {
+            if (deletionLength > 0) {
+                inputConnection.deleteSurroundingText(deletionLength, 0)
+            }
+            return
+        }
+
+        // Now delete the word characters
+        if (isWordCharacter(textBeforeCursor[index])) {
+            // Delete regular word characters (letters, numbers, some punctuation)
+            while (index >= 0 && isWordCharacter(textBeforeCursor[index])) {
+                deletionLength++
+                index--
+            }
+        } else {
+            // If the character at cursor is not a word character (e.g., special punctuation),
+            // delete just that single character instead of trying to delete a whole word
+            deletionLength++
+        }
+
+        if (deletionLength > 0) {
+            inputConnection.deleteSurroundingText(deletionLength, 0)
+        }
+    }
+
+    /**
+     * Determines if a character is considered part of a word for deletion purposes.
+     */
+    private fun isWordCharacter(char: Char): Boolean {
+        // Letters and digits are always word characters
+        if (char.isLetterOrDigit()) {
+            return true
+        }
+
+        // check if special characters are considered word
+        return when (Character.getType(char).toByte()) {
+            // Connector punctuation
+            Character.CONNECTOR_PUNCTUATION -> true
+            Character.DASH_PUNCTUATION -> true
+            // for other characters
+            Character.OTHER_PUNCTUATION -> {
+                char in "'\".,@#$%&*+=~`|\\/:;?!^"
+            }
+            Character.CURRENCY_SYMBOL -> true
+            Character.MATH_SYMBOL -> char in "+=<>~^"
+            Character.OTHER_SYMBOL -> char in "@#$%&*+=~`|\\/:;?!^"
+            else -> false
         }
     }
 

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -66,6 +66,7 @@ import be.scri.helpers.MAX_KEYS_PER_MINI_ROW
 import be.scri.helpers.SHIFT_OFF
 import be.scri.helpers.SHIFT_ON_ONE_CHAR
 import be.scri.helpers.SHIFT_ON_PERMANENT
+import be.scri.services.GeneralKeyboardIME
 import be.scri.services.GeneralKeyboardIME.ScribeState
 import java.util.Arrays
 import java.util.Locale
@@ -1478,6 +1479,7 @@ class KeyboardView
                         val key = mKeys[mRepeatKeyIndex]
                         if (key.code == KEYCODE_DELETE) {
                             mHandler?.removeMessages(MSG_REPEAT)
+                            (mOnKeyboardActionListener as? GeneralKeyboardIME)?.setDeleteRepeating(false)
                             mRepeatKeyIndex = NOT_A_KEY
                         }
                     }
@@ -1613,11 +1615,17 @@ class KeyboardView
                             if (mKeys[mCurrentKey].code == KEYCODE_SPACE) {
                                 mLastSpaceMoveX = -1
                             } else {
-                                repeatKey(true)
+                                // For delete key, send the initial key press but don't set repeating flag yet
+                                // The repeating flag will be set when the actual repeat starts
+                                detectAndSendKey(mCurrentKey, mKeys[mCurrentKey].x, mKeys[mCurrentKey].y, eventTime)
                             }
 
                             // Delivering the key could have caused an abort.
                             if (mAbortKey) {
+                                // Reset delete repeating flag when key is aborted
+                                if (mRepeatKeyIndex != NOT_A_KEY && mKeys[mRepeatKeyIndex].code == KEYCODE_DELETE) {
+                                    (mOnKeyboardActionListener as? GeneralKeyboardIME)?.setDeleteRepeating(false)
+                                }
                                 mRepeatKeyIndex = NOT_A_KEY
                                 handled = true
                             }
@@ -1727,6 +1735,10 @@ class KeyboardView
                         }
 
                         invalidateKey(keyIndex)
+                        // Reset delete repeating flag when any key is released
+                        if (mRepeatKeyIndex != NOT_A_KEY && mKeys[mRepeatKeyIndex].code == KEYCODE_DELETE) {
+                            (mOnKeyboardActionListener as? GeneralKeyboardIME)?.setDeleteRepeating(false)
+                        }
                         mRepeatKeyIndex = NOT_A_KEY
                         mOnKeyboardActionListener!!.onActionUp()
                         mIsLongPressingSpace = false
@@ -1734,6 +1746,10 @@ class KeyboardView
                     MotionEvent.ACTION_CANCEL -> {
                         mIsLongPressingSpace = false
                         mLastSpaceMoveX = 0
+                        // Reset delete repeating flag when action is cancelled
+                        if (mRepeatKeyIndex != NOT_A_KEY && mKeys[mRepeatKeyIndex].code == KEYCODE_DELETE) {
+                            (mOnKeyboardActionListener as? GeneralKeyboardIME)?.setDeleteRepeating(false)
+                        }
                         removeMessages()
                         dismissPopupKeyboard()
                         mAbortKey = true
@@ -1758,6 +1774,10 @@ class KeyboardView
 
                 mIsLongPressingSpace = true
             } else {
+                // Set delete repeating flag when repeat actually starts (not on initial press)
+                if (!initialCall && key.code == KEYCODE_DELETE) {
+                    (mOnKeyboardActionListener as? GeneralKeyboardIME)?.setDeleteRepeating(true)
+                }
                 detectAndSendKey(mCurrentKey, key.x, key.y, mLastTapTime)
             }
             return true


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist


-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
- Implemented functions deleteSingleCharacter and deleteWordByWord and integrated with delete function.
- Also added delete key repeat state tracking to distinguish between single taps and long press/repeat actions for word-by-word deletion behavior.
- Changed default word-by-word deletion preference from true to false.


-   #416 
