### PR TITLE
WIP : Change the currency symbol of the keyboard

### DIFF
--- a/app/src/main/java/be/scri/App.kt
+++ b/app/src/main/java/be/scri/App.kt
@@ -38,6 +38,7 @@ import be.scri.ui.screens.WikimediaScreen
 import be.scri.ui.screens.about.AboutScreen
 import be.scri.ui.screens.settings.SettingsScreen
 import be.scri.ui.theme.ScribeTheme
+import be.scri.helpers.PreferencesHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -191,7 +192,6 @@ fun ScribeApp(
 
                 composable("${Screen.LanguageSettings.route}/{languageName}") {
                     val language = it.arguments?.getString("languageName")
-                    val symbol = it.arguments?.getString("symbolName")
                     if (language != null) {
                         LanguageSettingsScreen(
                             language = language,
@@ -203,7 +203,8 @@ fun ScribeApp(
                                 navController.navigate("translation_language_detail/$language")
                             },
                             onCurrencySelect = {
-                                navController.navigate("currency_symbol_detail/$symbol/$language")
+                                val currentSymbol = PreferencesHelper.getDefaultCurrencySymbol(context, language)
+                                navController.navigate("currency_symbol_detail/$currentSymbol/$language")
                             },
                         )
                     }

--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -5,6 +5,7 @@ package be.scri.helpers
 import android.content.Context
 import android.util.Log
 import android.view.inputmethod.InputConnection
+import be.scri.helpers.PreferencesHelper
 import be.scri.services.GeneralKeyboardIME
 import be.scri.services.GeneralKeyboardIME.ScribeState
 
@@ -73,6 +74,7 @@ class KeyHandler(
             }
             in KeyboardBase.NAVIGATION_KEYS -> handleNavigationKey(code)
             in KeyboardBase.SCRIBE_VIEW_KEYS -> handleScribeViewKey(code, language)
+            KeyboardBase.CODE_CURRENCY -> handleCurrencyKey(language)
             else -> handleDefaultKey(code)
         }
 
@@ -163,6 +165,19 @@ class KeyHandler(
         ime.handleDelete(isCommandBarActive)
 
         // Only process suggestions if the state is exactly IDLE.
+        if (ime.currentState == ScribeState.IDLE) {
+            suggestionHandler.processEmojiSuggestions(ime.getLastWordBeforeCursor())
+        }
+    }
+
+    /**
+     * Handles the currency symbol key press. It outputs the user's selected currency symbol for the current language.
+     */
+    private fun handleCurrencyKey(language: String) {
+        val currencySymbol = PreferencesHelper.getDefaultCurrencySymbol(ime.applicationContext, language)
+        ime.currentInputConnection?.commitText(currencySymbol, 1)
+        
+        // Process emoji suggestions if in idle state
         if (ime.currentState == ScribeState.IDLE) {
             suggestionHandler.processEmojiSuggestions(ime.getLastWordBeforeCursor())
         }

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -99,6 +99,7 @@ class KeyboardBase {
         const val CODE_1X3_RIGHT = 1023
         const val CODE_2X1_TOP = 1031
         const val CODE_2X1_BOTTOM = 1032
+        const val CODE_CURRENCY = 1050
         private const val MAX_KEYS_PER_MINI_ROW = 10
 
         // Sets for grouping key codes to reduce complexity in KeyHandler.

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -25,6 +25,7 @@ object PreferencesHelper {
     private const val EMOJI_SUGGESTIONS = "emoji_suggestions"
     private const val DISABLE_ACCENT_CHARACTER = "disable_accent_character"
     private const val WORD_BY_WORD_DELETION = "word_by_word_deletion"
+    private const val DEFAULT_CURRENCY = "default_currency"
 
     /**
      * Sets the translation source language for a given language.
@@ -439,5 +440,59 @@ object PreferencesHelper {
             getLanguageSpecificPreferenceKey(TRANSLATION_SOURCE, language),
             "English",
         )
+    }
+
+    /**
+     * Sets the default currency symbol preference for a specific language.
+     *
+     * @param context The application context.
+     * @param language The language for which to set the currency preference.
+     * @param currencyName The name of the currency (e.g., "Dollar", "Euro").
+     */
+    fun setDefaultCurrencySymbol(
+        context: Context,
+        language: String,
+        currencyName: String,
+    ) {
+        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
+        sharedPref.edit {
+            putString(getLanguageSpecificPreferenceKey(DEFAULT_CURRENCY, language), currencyName)
+        }
+    }
+
+    /**
+     * Retrieves the default currency symbol preference for a specific language.
+     *
+     * @param context The application context.
+     * @param language The language for which to get the currency preference.
+     * @return The currency symbol (e.g., "$", "€").
+     */
+    fun getDefaultCurrencySymbol(context: Context, language: String): String {
+        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
+        val currencyName = sharedPref.getString(getLanguageSpecificPreferenceKey(DEFAULT_CURRENCY, language), "Dollar") ?: "Dollar"
+        
+        // Map currency names to symbols
+        return when (currencyName) {
+            "Dollar" -> "$"
+            "Euro" -> "€"
+            "Pound" -> "£"
+            "Rouble" -> "₽"
+            "Rupee" -> "₹"
+            "Won" -> "₩"
+            "Yen" -> "¥"
+            else -> "$"
+        }
+    }
+
+    /**
+     * Retrieves the default currency name preference for a specific language.
+     *
+     * @param context The application context.
+     * @param language The language for which to get the currency preference.
+     * @return The currency name (e.g., "Dollar", "Euro").
+     */
+    fun getDefaultCurrencyName(context: Context, language: String): String {
+        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
+        return sharedPref.getString(getLanguageSpecificPreferenceKey(DEFAULT_CURRENCY, language), "Dollar") ?: "Dollar"
     }
 }

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -370,6 +370,11 @@ abstract class GeneralKeyboardIME(
         conjugateLabels = dbManagers.conjugateDataManager.extractConjugateHeadings(dataContract, "describe")
         keyboard = KeyboardBase(this, keyboardXml, enterKeyType)
         keyboardView?.setKeyboard(keyboard!!)
+        
+        // Set up the currency symbol if we're using the symbols keyboard layout
+        if (keyboardXml == R.xml.keys_symbols) {
+            setupCurrencySymbol()
+        }
     }
 
     /**
@@ -732,6 +737,19 @@ abstract class GeneralKeyboardIME(
         keyboard = KeyboardBase(this, xmlId, enterKeyType)
         keyboardView?.setKeyboard(keyboard!!)
         keyboardView?.requestLayout()
+        
+        // Set up the currency symbol if we're on the symbols keyboard
+        if (keyboardMode == keyboardSymbols) {
+            setupCurrencySymbol()
+        }
+    }
+
+    /**
+     * Sets up the currency symbol on the keyboard based on user preferences.
+     */
+    private fun setupCurrencySymbol() {
+        val currencySymbol = PreferencesHelper.getDefaultCurrencySymbol(this, language)
+        keyboardView?.setKeyLabel(currencySymbol, "", KeyboardBase.CODE_CURRENCY)
     }
 
     /**
@@ -1706,6 +1724,11 @@ abstract class GeneralKeyboardIME(
         keyboard = KeyboardBase(context, keyboardXml, enterKeyType)
         keyboardView?.setKeyboard(keyboard!!)
         keyboardView?.requestLayout()
+        
+        // Set up the currency symbol if we're using the symbols keyboard layout
+        if (keyboardXml == R.xml.keys_symbols) {
+            setupCurrencySymbol()
+        }
     }
 
     /**
@@ -1748,6 +1771,11 @@ abstract class GeneralKeyboardIME(
                 }
             keyboard = KeyboardBase(this, keyboardXml, enterKeyType)
             keyboardView!!.setKeyboard(keyboard!!)
+            
+            // Set up the currency symbol if we're using the symbols keyboard layout
+            if (keyboardXml == R.xml.keys_symbols) {
+                setupCurrencySymbol()
+            }
         }
     }
 

--- a/app/src/main/java/be/scri/ui/screens/DefaultCurrencySymbolScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/DefaultCurrencySymbolScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.edit
 import be.scri.R
+import be.scri.helpers.PreferencesHelper
 import be.scri.ui.common.ScribeBaseScreen
 
 /**
@@ -42,10 +43,9 @@ fun DefaultCurrencySymbolScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
     val selectedSymbol =
         remember {
-            mutableStateOf(sharedPref.getString("default_currency", "Dollar") ?: "Dollar")
+            mutableStateOf(PreferencesHelper.getDefaultCurrencyName(context, currentLanguage))
         }
     val scrollState = rememberScrollState()
     val symbolMap =
@@ -59,8 +59,9 @@ fun DefaultCurrencySymbolScreen(
             "Yen" to "¥",
         )
 
-    val currentSymbolName = symbolMap.entries.find { it.value == currentSymbol }?.key ?: "Dollar"
-    val options = symbolMap.keys.filterNot { it == currentSymbolName }
+    // Show ALL currencies, don't filter any out
+    val options = symbolMap.keys.toList()
+    
     ScribeBaseScreen(
         pageTitle = stringResource(R.string.app_settings_keyboard_layout_default_currency),
         lastPage = stringResource(id = getLanguageStringFromi18n(currentLanguage)),
@@ -95,7 +96,7 @@ fun DefaultCurrencySymbolScreen(
                                     .fillMaxWidth()
                                     .clickable {
                                         selectedSymbol.value = option
-                                        sharedPref.edit { putString("default_currency", option) }
+                                        PreferencesHelper.setDefaultCurrencySymbol(context, currentLanguage, option)
                                     }.padding(vertical = 5.dp, horizontal = 8.dp),
                         ) {
                             Text(
@@ -111,7 +112,7 @@ fun DefaultCurrencySymbolScreen(
                                 selected = (option == selectedSymbol.value),
                                 onClick = {
                                     selectedSymbol.value = option
-                                    sharedPref.edit { putString("default_currency", option) }
+                                    PreferencesHelper.setDefaultCurrencySymbol(context, currentLanguage, option)
                                 },
                             )
                         }

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -225,6 +225,8 @@ class KeyboardView
         var mKeyLabel2X1TOP: String = "LEFT"
         var mKeyLabel2X1BOTTOM: String = "RIGHT"
 
+        var mCurrencySymbol: String = "$"
+
         private var mEnterKeyColor: Int = 0
 
         private var mSpecialKeyColor: Int? = null
@@ -440,6 +442,9 @@ class KeyboardView
                 KeyboardBase.CODE_2X1_TOP -> {
                     mKeyLabel2X1TOP = label
                 }
+                KeyboardBase.CODE_CURRENCY -> {
+                    mCurrencySymbol = label
+                }
             }
         }
 
@@ -466,6 +471,7 @@ class KeyboardView
                 KeyboardBase.CODE_1X3_CENTER -> mKeyLabel1X3TOP
                 KeyboardBase.CODE_1X3_LEFT -> mKeyLabel1X3LEFT
                 KeyboardBase.CODE_1X3_RIGHT -> mKeyLabel1X3BOTTOM
+                KeyboardBase.CODE_CURRENCY -> mCurrencySymbol
                 else -> null
             }
 
@@ -978,6 +984,9 @@ class KeyboardView
                         }
                         KeyboardBase.CODE_1X3_RIGHT -> {
                             label = mKeyLabel1X3BOTTOM
+                        }
+                        KeyboardBase.CODE_CURRENCY -> {
+                            label = mCurrencySymbol
                         }
                     }
 

--- a/app/src/main/res/xml/keys_symbols_dynamic.xml
+++ b/app/src/main/res/xml/keys_symbols_dynamic.xml
@@ -38,7 +38,7 @@
             app:keyLabel="\@" />
         <Key app:keyLabel="\#" />
         <Key
-            app:code="1050"
+            app:code="1007"
             app:keyLabel="$"
             app:popupCharacters="₽€¢£¥"
             app:popupKeyboard="@xml/keyboard_popup_template" />


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
1. All languages should have dollar as default.
2. Changing a currency in one language should not change the currency of another language.
3. While selecting a language , it disappears from the menu , so changed that as to show the selected language in menu as well.
-->

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #ISSUE_NUMBER
