### PR TITLE
test: add unit test for PluralFormsManager.getPluralRepresentation

### DIFF
--- a/app/src/androidTest/kotlin/be/scri/helpers/DatabaseTest.kt
+++ b/app/src/androidTest/kotlin/be/scri/helpers/DatabaseTest.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package be.scri.helpers
+
+import DataContract
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.view.inputmethod.InputConnection
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import be.scri.helpers.data.PluralFormsManager
+import be.scri.services.GeneralKeyboardIME
+import be.scri.services.GeneralKeyboardIME.ScribeState
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DatabaseTest {
+    private lateinit var mockIME: GeneralKeyboardIME
+    private lateinit var mockInputConnection: InputConnection
+    private lateinit var keyHandler: KeyHandler
+
+    @Before
+    fun setUp() {
+        mockIME = mockk(relaxed = true)
+        mockInputConnection = mockk(relaxed = true)
+
+        every { mockIME.currentInputConnection } returns mockInputConnection
+        every { mockIME.keyboard } returns mockk(relaxed = true)
+        every { mockIME.currentState } returns ScribeState.IDLE
+
+        keyHandler = KeyHandler(mockIME)
+    }
+
+    @Test
+    fun testPluralCommandGeneratesCorrectOutput() {
+        // Arrange
+        val testWord = "cat"
+        val expectedResult = mapOf("cat" to "cats")
+
+        val mockDatabaseFileManager = mockk<DatabaseFileManager>()
+        val mockDatabase = mockk<SQLiteDatabase>()
+        val mockDataContract = mockk<DataContract>()
+        val mockCursor = mockk<Cursor>(relaxed = true)
+
+        every { mockDatabaseFileManager.getLanguageDatabase("EN") } returns mockDatabase
+        every { mockDataContract.numbers } returns mapOf("singular" to "plural")
+        every {
+            mockDatabase.rawQuery(
+                "SELECT `singular`, `plural` FROM nouns WHERE `singular` = ? COLLATE NOCASE",
+                arrayOf(testWord),
+            )
+        } returns mockCursor
+
+        // Mock: cursor behavior
+        every { mockDatabase.close() } returns Unit
+        every { mockCursor.moveToFirst() } returns true
+        every { mockCursor.getColumnIndex("singular") } returns 0
+        every { mockCursor.getString(0) } returns "cat"
+        every { mockCursor.getColumnIndex("plural") } returns 1
+        every { mockCursor.getString(1) } returns "cats"
+
+        // Act
+        val pluralManager = PluralFormsManager(mockDatabaseFileManager)
+        val result = pluralManager.getPluralRepresentation("EN", mockDataContract, testWord)
+
+        // Assert
+        assertEquals(expectedResult, result)
+    }
+}

--- a/app/src/androidTest/kotlin/be/scri/helpers/KeyboardTest.kt
+++ b/app/src/androidTest/kotlin/be/scri/helpers/KeyboardTest.kt
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package be.scri.ui
 
+import DataContract
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
 import android.view.inputmethod.InputConnection
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import be.scri.helpers.DatabaseFileManager
 import be.scri.helpers.KeyHandler
 import be.scri.helpers.KeyboardBase
+import be.scri.helpers.data.PluralFormsManager
 import be.scri.services.GeneralKeyboardIME
 import be.scri.services.GeneralKeyboardIME.ScribeState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,6 +36,42 @@ class KeyboardTest {
         every { mockIME.currentState } returns ScribeState.IDLE
 
         keyHandler = KeyHandler(mockIME)
+    }
+
+    @Test
+    fun testPluralCommandGeneratesCorrectOutput() {
+        // Arrange
+        val testWord = "cat"
+        val expectedResult = mapOf("cat" to "cats")
+
+        val mockDatabaseFileManager = mockk<DatabaseFileManager>()
+        val mockDatabase = mockk<SQLiteDatabase>()
+        val mockDataContract = mockk<DataContract>()
+        val mockCursor = mockk<Cursor>(relaxed = true)
+
+        every { mockDatabaseFileManager.getLanguageDatabase("EN") } returns mockDatabase
+        every { mockDataContract.numbers } returns mapOf("singular" to "plural")
+        every {
+            mockDatabase.rawQuery(
+                "SELECT `singular`, `plural` FROM nouns WHERE `singular` = ? COLLATE NOCASE",
+                arrayOf(testWord),
+            )
+        } returns mockCursor
+
+        // Mock: cursor behavior
+        every { mockDatabase.close() } returns Unit
+        every { mockCursor.moveToFirst() } returns true
+        every { mockCursor.getColumnIndex("singular") } returns 0
+        every { mockCursor.getString(0) } returns "cat"
+        every { mockCursor.getColumnIndex("plural") } returns 1
+        every { mockCursor.getString(1) } returns "cats"
+
+        // Act
+        val pluralManager = PluralFormsManager(mockDatabaseFileManager)
+        val result = pluralManager.getPluralRepresentation("EN", mockDataContract, testWord)
+
+        // Assert
+        assertEquals(expectedResult, result)
     }
 
     @Test

--- a/app/src/androidTest/kotlin/be/scri/helpers/KeyboardTest.kt
+++ b/app/src/androidTest/kotlin/be/scri/helpers/KeyboardTest.kt
@@ -1,21 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package be.scri.ui
 
-import DataContract
-import android.database.Cursor
-import android.database.sqlite.SQLiteDatabase
 import android.view.inputmethod.InputConnection
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import be.scri.helpers.DatabaseFileManager
 import be.scri.helpers.KeyHandler
 import be.scri.helpers.KeyboardBase
-import be.scri.helpers.data.PluralFormsManager
 import be.scri.services.GeneralKeyboardIME
 import be.scri.services.GeneralKeyboardIME.ScribeState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,42 +30,6 @@ class KeyboardTest {
         every { mockIME.currentState } returns ScribeState.IDLE
 
         keyHandler = KeyHandler(mockIME)
-    }
-
-    @Test
-    fun testPluralCommandGeneratesCorrectOutput() {
-        // Arrange
-        val testWord = "cat"
-        val expectedResult = mapOf("cat" to "cats")
-
-        val mockDatabaseFileManager = mockk<DatabaseFileManager>()
-        val mockDatabase = mockk<SQLiteDatabase>()
-        val mockDataContract = mockk<DataContract>()
-        val mockCursor = mockk<Cursor>(relaxed = true)
-
-        every { mockDatabaseFileManager.getLanguageDatabase("EN") } returns mockDatabase
-        every { mockDataContract.numbers } returns mapOf("singular" to "plural")
-        every {
-            mockDatabase.rawQuery(
-                "SELECT `singular`, `plural` FROM nouns WHERE `singular` = ? COLLATE NOCASE",
-                arrayOf(testWord),
-            )
-        } returns mockCursor
-
-        // Mock: cursor behavior
-        every { mockDatabase.close() } returns Unit
-        every { mockCursor.moveToFirst() } returns true
-        every { mockCursor.getColumnIndex("singular") } returns 0
-        every { mockCursor.getString(0) } returns "cat"
-        every { mockCursor.getColumnIndex("plural") } returns 1
-        every { mockCursor.getString(1) } returns "cats"
-
-        // Act
-        val pluralManager = PluralFormsManager(mockDatabaseFileManager)
-        val result = pluralManager.getPluralRepresentation("EN", mockDataContract, testWord)
-
-        // Assert
-        assertEquals(expectedResult, result)
     }
 
     @Test


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request adds a unit test for the PluralFormsManager.getPluralRepresentation method. It verifies the input "cat" for the output "cats".



### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #446 
