### PR TITLE
Add Visual Indicator for Selected Popup Characters

### DIFF
--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -819,6 +819,13 @@ class KeyboardView
                     }
                 val pressedColor = resources.getColor(pressedColorResId, context.theme)
                 val specialKeyColorValue = resources.getColor(mSpecialKeyColor!!, context.theme)
+                val focusedColorResId =
+                    if (isUserDarkMode) {
+                        R.color.theme_scribe_blue
+                    } else {
+                        R.color.light_scribe_color
+                    }
+                val focusedColor = resources.getColor(focusedColorResId, context.theme)
 
                 paint.color = mTextColor
                 val keyBackgroundPaint =
@@ -909,6 +916,7 @@ class KeyboardView
 
                     val backgroundColor =
                         when {
+                            key.focused -> focusedColor
                             key.pressed -> pressedColor
                             code == KEYCODE_SHIFT && mKeyboard!!.mShiftState == SHIFT_LOCKED -> pressedColor
                             code in listOf(KEYCODE_DELETE, KEYCODE_SHIFT, KEYCODE_MODE_CHANGE) -> specialKeyColorValue
@@ -1004,6 +1012,8 @@ class KeyboardView
 
                         paint.color =
                             if (key.focused) {
+                                Color.WHITE
+                            } else if (key.focused) {
                                 mPrimaryColor.getContrastColor()
                             } else {
                                 mTextColor


### PR DESCRIPTION

### Contributor checklist
-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
- Added a focused state visual indicator (using `focusedColor`) to highlight the currently hovered/selected popup character while the user is sliding.
- Added a conditional color section `theme_scribe_blue` for dark mode, `light_scribe_color` otherwise
-   #455 
