### PR TITLE
Fix/plural word not recognised

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1130,7 +1130,7 @@ abstract class GeneralKeyboardIME(
     fun findWhetherWordIsPlural(
         pluralWords: Set<String>?,
         lastWord: String?,
-    ): Boolean = pluralWords?.contains(lastWord) == true
+    ): Boolean = pluralWords?.contains(lastWord?.lowercase()) == true
 
     /**
      * Finds the required grammatical case(s) for a preposition.


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
This PR addresses two issues:

[#421](https://github.com/scribe-org/Scribe-Android/issues/421):
When a user tries to pluralise a word that is already plural, the keyboard now detects this and shows the "Already plural" message. The UI updates accordingly, and the keyboard returns to the idle state after the message is displayed.

[#467](https://github.com/scribe-org/Scribe-Android/issues/467):
Plural word detection has been improved to be case-insensitive. Previously, capitalised plural words like "Hellos" were not recognised, causing the PL suggestion keyword to not appear. This fix ensures consistent behaviour for plural recognition regardless of casing.

---
### Testing
Screenshot of text
<img width="400" height="400" alt="Screenshot_2025-07-31-17-37-58-149_com google android apps messaging" src="https://github.com/user-attachments/assets/c905e8ea-0951-4aaf-b30f-57deaf3ea382" />

---
Videos

https://github.com/user-attachments/assets/8e1ad8cd-74e6-4fbf-9fd6-fc3d2e13c38c



https://github.com/user-attachments/assets/c3d8bb8d-0a2a-4f7b-b71a-af93843bfee9



### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-  closes #421 and;
-  closes #467
