### PR TITLE
chore: update language names to native alphabets (#472)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,19 +69,7 @@
                 android:name="android.view.im"
                 android:resource="@xml/method_german" />
         </service>
-        <service
-            android:name=".services.ItalianKeyboardIME"
-            android:exported="true"
-            android:label="Scribe"
-            android:permission="android.permission.BIND_INPUT_METHOD" >
-            <intent-filter>
-                <action android:name="android.view.InputMethod" />
-            </intent-filter>
 
-            <meta-data
-                android:name="android.view.im"
-                android:resource="@xml/method_italian" />
-        </service>
         <service
             android:name=".services.PortugueseKeyboardIME"
             android:exported="true"
@@ -133,6 +121,19 @@
             <meta-data
                 android:name="android.view.im"
                 android:resource="@xml/method_swedish" />
+        </service>
+        <service
+            android:name=".services.ItalianKeyboardIME"
+            android:exported="true"
+            android:label="Scribe"
+            android:permission="android.permission.BIND_INPUT_METHOD" >
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method_italian" />
         </service>
     </application>
 

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:icon="@mipmap/ic_launcher"
-    android:settingsActivity="be.scri.activities.SettingsActivity">
-
-    <subtype android:imeSubtypeMode="Keyboard" />
-
+<input-method xmlns:android="http://schemas.android.com/apk/res/android">
+    <subtype android:label="Italiano" android:imeSubtypeLocale="it" android:imeSubtypeMode="keyboard"/>
+    <subtype android:label="Русский" android:imeSubtypeLocale="ru" android:imeSubtypeMode="keyboard"/>
+    <subtype android:label="Deutsch" android:imeSubtypeLocale="de" android:imeSubtypeMode="keyboard"/>
+    <subtype android:label="Español" android:imeSubtypeLocale="es" android:imeSubtypeMode="keyboard"/>
+    <subtype android:label="Français" android:imeSubtypeLocale="fr" android:imeSubtypeMode="keyboard"/>
+    <subtype android:label="English" android:imeSubtypeLocale="en" android:imeSubtypeMode="keyboard"/>
+    <subtype android:label="Svenska" android:imeSubtypeLocale="sv" android:imeSubtypeMode="keyboard"/>
+    <subtype android:label="Português" android:imeSubtypeLocale="pt" android:imeSubtypeMode="keyboard"/>
 </input-method>

--- a/app/src/main/res/xml/method_english.xml
+++ b/app/src/main/res/xml/method_english.xml
@@ -3,7 +3,6 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app._global.english"
-        android:imeSubtypeLocale="en_US"
+        android:imeSubtypeLocale="en"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_french.xml
+++ b/app/src/main/res/xml/method_french.xml
@@ -2,8 +2,7 @@
     android:settingsActivity="be.scri.activities.SettingsActivity"
     android:icon="@mipmap/ic_launcher" >
     <subtype
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app._global.french"
-        android:imeSubtypeLocale="fr"
-        android:imeSubtypeMode="keyboard" />
+        android:label="1. Français"
+        android:imeSubtypeLocale="Français"
+        android:imeSubtypeMode="keyboard"/>
 </input-method>

--- a/app/src/main/res/xml/method_german.xml
+++ b/app/src/main/res/xml/method_german.xml
@@ -1,6 +1,6 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android">
     <subtype
-        android:label="@string/app._global.german"
-        android:imeSubtypeLocale="ge"
+        android:label="2. Deutsch"
+        android:imeSubtypeLocale="Deutsch"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_italian.xml
+++ b/app/src/main/res/xml/method_italian.xml
@@ -1,9 +1,8 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:settingsActivity="be.scri.activities.SettingsActivity"
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app._global.italian"
-        android:imeSubtypeLocale="it"
+        android:label="Italiano"
+        android:imeSubtypeLocale="Italiano"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_portuguese.xml
+++ b/app/src/main/res/xml/method_portuguese.xml
@@ -1,9 +1,8 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:settingsActivity="be.scri.activities.SettingsActivity"
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app._global.portuguese"
-        android:imeSubtypeLocale="po"
+        android:label="Português"
+        android:imeSubtypeLocale="Português"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_russian.xml
+++ b/app/src/main/res/xml/method_russian.xml
@@ -1,9 +1,8 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:settingsActivity="be.scri.activities.SettingsActivity"
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app._global.russian"
-        android:imeSubtypeLocale="ru"
+        android:label="Русский"
+        android:imeSubtypeLocale="Русский"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_spanish.xml
+++ b/app/src/main/res/xml/method_spanish.xml
@@ -1,9 +1,8 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:settingsActivity="be.scri.activities.SettingsActivity"
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app._global.spanish"
-        android:imeSubtypeLocale="sp"
+        android:label="Español"
+        android:imeSubtypeLocale="Español"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_swedish.xml
+++ b/app/src/main/res/xml/method_swedish.xml
@@ -1,9 +1,8 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:settingsActivity="be.scri.activities.SettingsActivity"
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app._global.swedish"
-        android:imeSubtypeLocale="sw"
+        android:label="Svenska"
+        android:imeSubtypeLocale="Svenska"
         android:imeSubtypeMode="keyboard" />
 </input-method>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

The PR changes the language names of the Scribe keyboard in the input method manager screen of android. 

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #472 
