### PR TITLE
fix command bar to have colon in conjugate mode

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -525,20 +525,20 @@ abstract class GeneralKeyboardIME(
         val commandBarEditText = binding.commandBar
         val promptTextView = binding.promptText
 
-        // Set up colors and background
+        // Set up colors and background.
         commandBarHintColor = if (resolvedIsDarkMode) getColor(R.color.hint_white) else getColor(R.color.hint_black)
         commandBarTextColor = if (resolvedIsDarkMode) getColor(white) else Color.BLACK
         val backgroundColor = if (resolvedIsDarkMode) R.color.command_bar_color_dark else white
         binding.commandBarLayout.backgroundTintList = ContextCompat.getColorStateList(this, backgroundColor)
 
-        // Set prompt text
+        // Set prompt text.
         val promptText = HintUtils.getPromptText(currentState, language, context = this, text)
         promptTextView.text = promptText
         promptTextView.setTextColor(commandBarTextColor)
         promptTextView.setBackgroundColor(getColor(backgroundColor))
 
         if (currentState == ScribeState.SELECT_VERB_CONJUNCTION) {
-            // SPECIAL CASE for conjugation view
+            // Set to the verb that the user can select options for.
             val verbInfinitive = currentVerbForConjugation ?: ""
 
             commandBarEditText.setText(": $verbInfinitive")
@@ -547,14 +547,14 @@ abstract class GeneralKeyboardIME(
             commandBarEditText.isFocusable = false
             commandBarEditText.isFocusableInTouchMode = false
         } else {
-            // DEFAULT CASE for Plural, Translate, etc. where user needs to type
+            // Default for Plural, Translate, etc. where user needs to type.
             currentCommandBarHint = HintUtils.getCommandBarHint(currentState, language, word)
 
-            // Make sure the command bar is editable again
+            // Make sure the command bar is editable again.
             commandBarEditText.isFocusable = true
             commandBarEditText.isFocusableInTouchMode = true
 
-            // Set the fake hint with the custom cursor
+            // Set the fake hint with the custom cursor.
             commandBarEditText.setTextColor(commandBarHintColor)
             setCommandBarTextWithCursor(currentCommandBarHint, cursorAtStart = true)
             commandBarEditText.requestFocus()

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -137,6 +137,8 @@ abstract class GeneralKeyboardIME(
     private var commandBarHintColor: Int = Color.GRAY
     private var commandBarTextColor: Int = Color.BLACK
 
+    private var currentVerbForConjugation: String? = null
+
     /**
      * This function is updated to reliably detect search bars in various apps,
      * including browsers like Chrome and Firefox, not just fields with IME_ACTION_SEARCH.
@@ -513,6 +515,7 @@ abstract class GeneralKeyboardIME(
      * @param text A specific text to be displayed in the prompt, often used for conjugation titles.
      * @param word A word to be included in the hint text.
      */
+    @SuppressLint("SetTextI18n")
     private fun updateCommandBarHintAndPrompt(
         isUserDarkMode: Boolean? = null,
         text: String? = null,
@@ -522,24 +525,40 @@ abstract class GeneralKeyboardIME(
         val commandBarEditText = binding.commandBar
         val promptTextView = binding.promptText
 
-        // 1. Get the hint message and prompt text.
-        currentCommandBarHint = HintUtils.getCommandBarHint(currentState, language, word)
-        val promptText = HintUtils.getPromptText(currentState, language, context = this, text)
-        promptTextView.text = promptText
-
-        // 2. Set the appropriate colors based on the theme.
+        // Set up colors and background
         commandBarHintColor = if (resolvedIsDarkMode) getColor(R.color.hint_white) else getColor(R.color.hint_black)
         commandBarTextColor = if (resolvedIsDarkMode) getColor(white) else Color.BLACK
-
         val backgroundColor = if (resolvedIsDarkMode) R.color.command_bar_color_dark else white
         binding.commandBarLayout.backgroundTintList = ContextCompat.getColorStateList(this, backgroundColor)
-        promptTextView.setTextColor(if (resolvedIsDarkMode) getColor(white) else Color.BLACK)
+
+        // Set prompt text
+        val promptText = HintUtils.getPromptText(currentState, language, context = this, text)
+        promptTextView.text = promptText
+        promptTextView.setTextColor(commandBarTextColor)
         promptTextView.setBackgroundColor(getColor(backgroundColor))
 
-        // 3. Set the initial state of the command bar to show the hint.
-        commandBarEditText.setTextColor(commandBarHintColor)
-        setCommandBarTextWithCursor(currentCommandBarHint, cursorAtStart = true)
-        commandBarEditText.requestFocus()
+        if (currentState == ScribeState.SELECT_VERB_CONJUNCTION) {
+            // SPECIAL CASE for conjugation view
+            val verbInfinitive = currentVerbForConjugation ?: ""
+
+            commandBarEditText.setText(": $verbInfinitive")
+            commandBarEditText.setTextColor(commandBarTextColor)
+
+            commandBarEditText.isFocusable = false
+            commandBarEditText.isFocusableInTouchMode = false
+        } else {
+            // DEFAULT CASE for Plural, Translate, etc. where user needs to type
+            currentCommandBarHint = HintUtils.getCommandBarHint(currentState, language, word)
+
+            // Make sure the command bar is editable again
+            commandBarEditText.isFocusable = true
+            commandBarEditText.isFocusableInTouchMode = true
+
+            // Set the fake hint with the custom cursor
+            commandBarEditText.setTextColor(commandBarHintColor)
+            setCommandBarTextWithCursor(currentCommandBarHint, cursorAtStart = true)
+            commandBarEditText.requestFocus()
+        }
     }
 
     /**
@@ -783,6 +802,7 @@ abstract class GeneralKeyboardIME(
         clearSuggestionData()
         currentState = ScribeState.SELECT_COMMAND
         saveConjugateModeType("none")
+        currentVerbForConjugation = null
         updateUI()
     }
 
@@ -793,6 +813,7 @@ abstract class GeneralKeyboardIME(
         clearSuggestionData()
         currentState = ScribeState.IDLE
         saveConjugateModeType("none")
+        currentVerbForConjugation = null
         if (this::binding.isInitialized) updateUI()
     }
 
@@ -1917,6 +1938,7 @@ abstract class GeneralKeyboardIME(
      * @param rawInput The verb entered in the command bar.
      */
     private fun handleConjugateState(rawInput: String) {
+        currentVerbForConjugation = rawInput
         val languageAlias = getLanguageAlias(language)
 
         conjugateOutput =


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

- We remove the cursor in conjugate mode.
- We also make sure the entered verb is the same colour as the command bar text colour
- We also ensure that we clean up the states of variables properly. 

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   closes #496 
