### PR TITLE
Fix: replace custom language strings with locale codes (#493)

### DIFF
--- a/app/src/main/res/xml/method_french.xml
+++ b/app/src/main/res/xml/method_french.xml
@@ -3,6 +3,6 @@
     android:icon="@mipmap/ic_launcher" >
     <subtype
         android:label="1. Français"
-        android:imeSubtypeLocale="Français"
+        android:imeSubtypeLocale="fr"
         android:imeSubtypeMode="keyboard"/>
 </input-method>

--- a/app/src/main/res/xml/method_german.xml
+++ b/app/src/main/res/xml/method_german.xml
@@ -1,6 +1,6 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android">
     <subtype
         android:label="2. Deutsch"
-        android:imeSubtypeLocale="Deutsch"
+        android:imeSubtypeLocale="de"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_italian.xml
+++ b/app/src/main/res/xml/method_italian.xml
@@ -3,6 +3,6 @@
     <subtype
         android:icon="@mipmap/ic_launcher"
         android:label="Italiano"
-        android:imeSubtypeLocale="Italiano"
+        android:imeSubtypeLocale="it"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_portuguese.xml
+++ b/app/src/main/res/xml/method_portuguese.xml
@@ -3,6 +3,6 @@
     <subtype
         android:icon="@mipmap/ic_launcher"
         android:label="Português"
-        android:imeSubtypeLocale="Português"
+        android:imeSubtypeLocale="pt"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_russian.xml
+++ b/app/src/main/res/xml/method_russian.xml
@@ -3,6 +3,6 @@
     <subtype
         android:icon="@mipmap/ic_launcher"
         android:label="Русский"
-        android:imeSubtypeLocale="Русский"
+        android:imeSubtypeLocale="ru"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_spanish.xml
+++ b/app/src/main/res/xml/method_spanish.xml
@@ -3,6 +3,6 @@
     <subtype
         android:icon="@mipmap/ic_launcher"
         android:label="Español"
-        android:imeSubtypeLocale="Español"
+        android:imeSubtypeLocale="es"
         android:imeSubtypeMode="keyboard" />
 </input-method>

--- a/app/src/main/res/xml/method_swedish.xml
+++ b/app/src/main/res/xml/method_swedish.xml
@@ -3,6 +3,6 @@
     <subtype
         android:icon="@mipmap/ic_launcher"
         android:label="Svenska"
-        android:imeSubtypeLocale="Svenska"
+        android:imeSubtypeLocale="sv"
         android:imeSubtypeMode="keyboard" />
 </input-method>


### PR DESCRIPTION
> **Fix:replace custom language strings with locale codes (#493)**

- Use standard locale codes (de, sv, it, fr) instead of custom language strings to fix lowercase display issue in Android keyboard selection.

> **Below are the screen shots for the ref:**

![WhatsApp Image 2025-10-02 at 12 10 59 AM](https://github.com/user-attachments/assets/27f5c8d5-a1d0-4d35-a3b4-6147349aa52d)
