### PR TITLE
Update background colors for keyboard popup (day/night themes)

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="you_keyboard_background_color">#191C1E</color>
+    <color name="you_keyboard_background_color">#3F3F46</color>
     <color name="you_keyboard_toolbar_color">@color/you_background_color</color>
     <color name="app_text_color">@color/dark_text_color</color>
     <color name="nav_bar_color">#000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -501,7 +501,7 @@
     <color name="md_yellow_900_dark">#DA6B09</color>
 
 
-    <color name="you_keyboard_background_color">#99FFFFFF</color>
+    <color name="you_keyboard_background_color">#3F3F46</color>
     <color name="you_keyboard_toolbar_color">@color/you_background_color</color>
     <color name="app_text_color">@color/light_text_color</color>
     <color name="nav_bar_color">#FFFFFFFF</color>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request updates the background colors for the mini keyboard popup to match the app’s day and night themes.
Previously, the popup background color only adapted correctly in dark mode, but not in light mode.
This fix ensures consistent theming across both modes by updating the corresponding color values in colors.xml and colors-night.xml.


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

-   #491
