### PR TITLE
add Update state to Download language button #513

### DIFF
--- a/app/src/main/java/be/scri/ui/common/components/DownloadDataOptionComp.kt
+++ b/app/src/main/java/be/scri/ui/common/components/DownloadDataOptionComp.kt
@@ -193,7 +193,6 @@ private fun DownloadStateIcon(
 }
 
 /**
- *
  * @return true if server data is newer than local data
  */
 private const val PLACEBO_SERVER_UPDATED_AT = "2025-01-10"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
This adds an Update state to the Download Language button in `DownloadDataOptionComp`.
The Update state is shown when the server language data differs from the local language data,
determined by comparing their respective last-updated dates.

This change currently uses placeholder dates to validate the state logic and UI behavior.


### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

-   Closes #513 
