### PR TITLE
Increase height of annotation buttons to match Scribe key (#535)

### DIFF
--- a/app/src/main/res/layout/input_method_view.xml
+++ b/app/src/main/res/layout/input_method_view.xml
@@ -143,7 +143,7 @@
         <Button
             android:id="@+id/scribe_key_options"
             android:layout_width="@dimen/select_command_scribe_key_width"
-            android:layout_height="37dp"
+            android:layout_height="@dimen/command_button_height"
             android:layout_marginStart="@dimen/small_margin"
             android:background="@drawable/cmd_key_background_rounded"
             android:backgroundTint="@color/theme_scribe_blue"
@@ -174,7 +174,7 @@
         <Button
             android:id="@+id/translate_btn"
             android:layout_width="0dp"
-            android:layout_height="@dimen/toolbar_icon_height"
+            android:layout_height="@dimen/command_button_height"
             android:layout_marginStart="4dp"
             android:background="@drawable/cmd_key_background_rounded"
             android:contentDescription="@string/command_bar"
@@ -201,7 +201,7 @@
         <Button
             android:id="@+id/conjugate_btn"
             android:layout_width="0dp"
-            android:layout_height="@dimen/toolbar_icon_height"
+            android:layout_height="@dimen/command_button_height"
             android:background="@drawable/cmd_key_background_rounded"
             android:contentDescription="@string/command_bar"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -226,7 +226,7 @@
         <Button
             android:id="@+id/plural_btn"
             android:layout_width="0dp"
-            android:layout_height="@dimen/toolbar_icon_height"
+            android:layout_height="@dimen/command_button_height"
             android:layout_marginEnd="@dimen/tiny_margin"
             android:background="@drawable/cmd_key_background_rounded"
             android:contentDescription="@string/command_bar"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -80,4 +80,5 @@
     <dimen name="select_command_scribe_key_width">65dp</dimen>
     <dimen name="command_state_scribe_key_width">75dp</dimen>
     <dimen name="emoji_palette_btn_size">42dp</dimen>
+    <dimen name="command_button_height">37dp</dimen>
 </resources>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

This pull request addresses a UI inconsistency where the keyboard annotation buttons were not the same height as the Scribe key.

-     Added a new dimension resource command_button_height (37dp) in dimens.xml.
-     Updated input_method_view.xml to replace the hardcoded height of the Scribe key (scribe_key_options) with this new dimension.
-     Increased the height of the annotation buttons (translate_btn, conjugate_btn, and plural_btn) to @dimen/command_button_height so they perfectly match the Scribe key.

### Testing:
Verified that when using the German keyboard and typing a noun (e.g., "Buch"), the displayed annotation (e.g., the green "N") is now the same height as the Scribe key.

### Screenshots: 
<details>
<summary><strong>Screenshots</strong></summary>

**Fix the Annotation to match the Scribe Key**

<img src="https://github.com/user-attachments/assets/d374ecdd-450e-46d3-a67e-8a717757389d" width="420">

**Now the Command Buttons are also perfectly consistent with Scribe key**

<img src="https://github.com/user-attachments/assets/592408a1-24fe-42a8-86ed-0af2658d6496" width="420">

</details>
### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

-   Closes #535
