### PR TITLE
Test: Verify Enter key inserts new line (#440)

### DIFF
--- a/app/src/androidTest/kotlin/be/scri/helpers/KeyboardTest.kt
+++ b/app/src/androidTest/kotlin/be/scri/helpers/KeyboardTest.kt
@@ -74,18 +74,15 @@ class KeyboardTest {
 
     @Test
     fun testEnterKeyInsertsNewLine() {
-        // Arrange
         every { mockIME.currentState } returns ScribeState.IDLE
-        // Simulate the IME behavior for Enter key: sending ACTION_DOWN and ACTION_UP events
+        // Simulate the IME behavior for Enter key: sending ACTION_DOWN and ACTION_UP events.
         every { mockIME.handleKeycodeEnter() } answers {
             mockInputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
             mockInputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
         }
 
-        // Act
         keyHandler.handleKey(KeyboardBase.KEYCODE_ENTER, "en")
 
-        // Assert
         verify(exactly = 1) { mockIME.handleKeycodeEnter() }
         verify(exactly = 1) {
             mockInputConnection.sendKeyEvent(match { it.action == KeyEvent.ACTION_DOWN && it.keyCode == KeyEvent.KEYCODE_ENTER })


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-   [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-   [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

This PR adds a unit test to `KeyboardTest.kt` to verify the behavior of the Enter key. It simulates pressing the Enter key via the `KeyHandler` and asserts that the corresponding `KeyEvent`s (ACTION_DOWN and ACTION_UP) are sent to the `InputConnection`.

### Changes
- Modified `app/src/androidTest/kotlin/be/scri/helpers/KeyboardTest.kt`: Added `testEnterKeyInsertsNewLine`.

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #440
