### PR TITLE
Feature: Colon to Emoji Functionality

### DIFF
--- a/app/src/main/java/be/scri/helpers/EmojiUtils.kt
+++ b/app/src/main/java/be/scri/helpers/EmojiUtils.kt
@@ -50,7 +50,7 @@ object EmojiUtils {
         ic: InputConnection,
         emojiKeywords: HashMap<String, MutableList<String>>?,
         emojiMaxKeywordLength: Int,
-        emojiColonModeOn: Boolean
+        emojiColonModeOn: Boolean,
     ) {
         val maxLookBack = emojiMaxKeywordLength.coerceAtLeast(1)
         ic.beginBatchEdit()

--- a/app/src/main/java/be/scri/helpers/EmojiUtils.kt
+++ b/app/src/main/java/be/scri/helpers/EmojiUtils.kt
@@ -10,6 +10,8 @@ import java.util.Locale
 object EmojiUtils {
     private const val DATA_SIZE_2 = 2
 
+    val COMMON_EMOJIS = listOf("😀", "❤️", "👍", "😂", "🎉", "✨", "🔥", "👋", "😊")
+
     /**
      * Checks if the end of a string is likely an emoji.
      * This is a heuristic check based on common emoji Unicode ranges.
@@ -48,11 +50,22 @@ object EmojiUtils {
         ic: InputConnection,
         emojiKeywords: HashMap<String, MutableList<String>>?,
         emojiMaxKeywordLength: Int,
+        emojiColonModeOn: Boolean
     ) {
         val maxLookBack = emojiMaxKeywordLength.coerceAtLeast(1)
         ic.beginBatchEdit()
         try {
             val prevText = ic.getTextBeforeCursor(maxLookBack, 0)?.toString() ?: ""
+            // If emoji colon suggestion is on, look back to the : that triggered emoji suggestions
+            // Delete that text, and add the emoji
+            if (emojiColonModeOn) {
+                val colonIndex = prevText.lastIndexOf(':')
+                if (colonIndex != -1) {
+                    ic.deleteSurroundingText(prevText.length - colonIndex, 0)
+                }
+                ic.commitText(emoji, 1)
+                return
+            }
             val lastSpace = prevText.lastIndexOf(' ')
             when {
                 prevText.isEmpty() ||

--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -208,7 +208,7 @@ class KeyHandler(
      */
 
     private fun handleDeleteKey() {
-        val charToDelete = ime.currentInputConnection?.getTextBeforeCursor(1,0)
+        val charToDelete = ime.currentInputConnection?.getTextBeforeCursor(1, 0)
         ime.handleDelete(ime.isDeleteRepeating()) // pass the actual repeating status
 
         if (ime.currentState == ScribeState.IDLE) {
@@ -381,7 +381,6 @@ class KeyHandler(
         ime.handleElseCondition(code, ime.keyboardMode, isCommandBarActive)
 
         if (ime.currentState == ScribeState.IDLE) {
-
             if (code == ':'.code && ime.getLastWordBeforeCursor() == ":") { // " :" triggers emoji colon mode
                 ime.emojiColonModeOn = true
 

--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -51,7 +51,7 @@ class KeyHandler(
         resetShiftIfNeeded(code)
 
         val previousWasLastKeySpace = wasLastKeySpace
-        if (code != KeyboardBase.KEYCODE_SPACE) {
+        if (code != KeyboardBase.KEYCODE_SPACE && !ime.emojiColonModeOn) { // None to clear in emoji colon mode, causes unnecessary flash when called
             suggestionHandler.clearLinguisticSuggestions()
         }
 
@@ -134,6 +134,7 @@ class KeyHandler(
 
     /**
      * Handles the space key press and returns whether to reset wasLastKeySpace at the end.
+     * Switches emoji colon mode off, if on.
      *
      * @param previousWasLastKeySpace The previous state of wasLastKeySpace.
      *
@@ -141,6 +142,11 @@ class KeyHandler(
      */
     private fun handleSpaceKeyPress(previousWasLastKeySpace: Boolean): Boolean {
         wasLastKeySpace = spaceKeyProcessor.processKeycodeSpace(previousWasLastKeySpace)
+        // If we're suggesting emojis in colon mode, stop. Space should break emoji suggestions, and return to normal
+        if (ime.emojiColonModeOn) {
+            ime.emojiColonModeOn = false
+            ime.clearAutocomplete()
+        }
         return false
     }
 
@@ -198,15 +204,27 @@ class KeyHandler(
     /**
      * Handles the delete/backspace key press. It delegates the deletion logic to the IME
      * and then triggers a re-evaluation of word suggestions based on the new text.
+     * Turns off emoji colon mode if colon is deleted that triggered it.
      */
 
     private fun handleDeleteKey() {
+        val charToDelete = ime.currentInputConnection?.getTextBeforeCursor(1,0)
         ime.handleDelete(ime.isDeleteRepeating()) // pass the actual repeating status
 
         if (ime.currentState == ScribeState.IDLE) {
+            val deletedChar = charToDelete?.takeIf { it.isNotEmpty() }?.last()
+            if (deletedChar == ':' && ime.emojiColonModeOn) {
+                ime.emojiColonModeOn = false
+                ime.clearAutocomplete()
+            }
+
             val currentWord = ime.getLastWordBeforeCursor()
-            autocompletionHandler.processAutocomplete(currentWord)
-            suggestionHandler.processEmojiSuggestions(currentWord)
+            if (ime.emojiColonModeOn) {
+                suggestionHandler.processEmojiSuggestions(currentWord)
+            } else {
+                autocompletionHandler.processAutocomplete(currentWord)
+                suggestionHandler.processEmojiSuggestions(currentWord)
+            }
         }
     }
 
@@ -243,10 +261,15 @@ class KeyHandler(
     /**
      * Handles the mode change key press (e.g., switching to the symbol keyboard).
      * It delegates the logic to the IME and clears any active suggestions.
+     * In emoji colon mode, restore emoji suggestions from before mode change.
      */
     private fun handleModeChangeKey() {
         ime.handleModeChange(ime.keyboardMode, ime.keyboardView, ime)
-        suggestionHandler.clearAllSuggestionsAndHideButtonUI()
+        if (ime.emojiColonModeOn) {
+            suggestionHandler.processEmojiSuggestions(ime.getLastWordBeforeCursor())
+        } else {
+            suggestionHandler.clearAllSuggestionsAndHideButtonUI()
+        }
     }
 
     /**
@@ -341,7 +364,7 @@ class KeyHandler(
     /**
      * Handles default key presses (regular characters, numbers, symbols).
      * Commits the character to the input connection and processes suggestions.
-     *
+     * Toggles colon emoji mode on if ':' typed.
      * @param code The key code representing the character to input.
      */
 
@@ -358,9 +381,32 @@ class KeyHandler(
         ime.handleElseCondition(code, ime.keyboardMode, isCommandBarActive)
 
         if (ime.currentState == ScribeState.IDLE) {
+
+            if (code == ':'.code && ime.getLastWordBeforeCursor() == ":") { // " :" triggers emoji colon mode
+                ime.emojiColonModeOn = true
+
+                val commonEmojis = EmojiUtils.COMMON_EMOJIS.toMutableList()
+                ime.autoSuggestEmojis = commonEmojis
+                ime.updateButtonVisibility(true)
+                ime.updateEmojiSuggestion(true, commonEmojis) // Show common emojis otherwise there's a small delay where words pop up
+            }
+
             val currentWord = ime.getLastWordBeforeCursor()
-            autocompletionHandler.processAutocomplete(currentWord)
-            suggestionHandler.processEmojiSuggestions(currentWord)
+            if (ime.emojiColonModeOn) {
+                currentWord?.startsWith(":")?.let {
+                    if (!it) { // Turn emoji colon mode off if there's no colon anymore (like if an emoji was just selected)
+                        ime.emojiColonModeOn = false
+                        ime.clearAutocomplete()
+                        autocompletionHandler.processAutocomplete(currentWord)
+                        suggestionHandler.processEmojiSuggestions(currentWord)
+                    } else {
+                        suggestionHandler.processEmojiSuggestions(currentWord)
+                    }
+                }
+            } else { // Normal suggestions
+                autocompletionHandler.processAutocomplete(currentWord)
+                suggestionHandler.processEmojiSuggestions(currentWord)
+            }
         } else if (isCommandBarActive) {
             suggestionHandler.clearAllSuggestionsAndHideButtonUI()
             autocompletionHandler.clearAutocomplete()

--- a/app/src/main/java/be/scri/helpers/SuggestionHandler.kt
+++ b/app/src/main/java/be/scri/helpers/SuggestionHandler.kt
@@ -4,7 +4,6 @@ package be.scri.helpers
 
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import be.scri.services.GeneralKeyboardIME
 import be.scri.services.GeneralKeyboardIME.ScribeState
 
@@ -147,7 +146,6 @@ class SuggestionHandler(
                 }
 
                 val hasEmojiSuggestion = !emojis.isNullOrEmpty()
-                Log.d("SuggestionHandler", "Has emoji suggestion: $hasEmojiSuggestion")
 
                 if (hasEmojiSuggestion) {
                     ime.autoSuggestEmojis = emojis

--- a/app/src/main/java/be/scri/helpers/SuggestionHandler.kt
+++ b/app/src/main/java/be/scri/helpers/SuggestionHandler.kt
@@ -134,16 +134,20 @@ class SuggestionHandler(
                 var emojis: MutableList<String>?
                 if (ime.emojiColonModeOn) {
                     val currentWordCleaned = currentWord.removePrefix(":") // Drop colon that triggered emojiColonMode
-                    emojis = if (currentWordCleaned.isEmpty()) { // For no word typed yet, show common emojis
-                        EmojiUtils.COMMON_EMOJIS.toMutableList()
-                    } else {
-                        ime.findEmojisForPrefix(ime.emojiKeywords, currentWordCleaned)
-                    }
+                    emojis =
+                        if (
+                            currentWordCleaned.isEmpty()
+                        ) { // For no word typed yet, show common emojis
+                            EmojiUtils.COMMON_EMOJIS.toMutableList()
+                        } else {
+                            ime.findEmojisForPrefix(ime.emojiKeywords, currentWordCleaned)
+                        }
                 } else {
                     emojis = null
                 }
 
                 val hasEmojiSuggestion = !emojis.isNullOrEmpty()
+                Log.d("SuggestionHandler", "Has emoji suggestion: $hasEmojiSuggestion")
 
                 if (hasEmojiSuggestion) {
                     ime.autoSuggestEmojis = emojis

--- a/app/src/main/java/be/scri/helpers/SuggestionHandler.kt
+++ b/app/src/main/java/be/scri/helpers/SuggestionHandler.kt
@@ -4,6 +4,7 @@ package be.scri.helpers
 
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import be.scri.services.GeneralKeyboardIME
 import be.scri.services.GeneralKeyboardIME.ScribeState
 
@@ -116,7 +117,6 @@ class SuggestionHandler(
      */
     fun processEmojiSuggestions(currentWord: String?) {
         emojiSuggestionRunnable?.let { handler.removeCallbacks(it) }
-
         emojiSuggestionRunnable =
             Runnable {
                 if (ime.currentState != ScribeState.IDLE) {
@@ -131,19 +131,27 @@ class SuggestionHandler(
                     return@Runnable
                 }
 
-                val emojis =
-                    if (ime.emojiAutoSuggestionEnabled) {
-                        ime.findEmojisForLastWord(ime.emojiKeywords, currentWord)
+                var emojis: MutableList<String>?
+                if (ime.emojiColonModeOn) {
+                    val currentWordCleaned = currentWord.removePrefix(":") // Drop colon that triggered emojiColonMode
+                    emojis = if (currentWordCleaned.isEmpty()) { // For no word typed yet, show common emojis
+                        EmojiUtils.COMMON_EMOJIS.toMutableList()
                     } else {
-                        null
+                        ime.findEmojisForPrefix(ime.emojiKeywords, currentWordCleaned)
                     }
+                } else {
+                    emojis = null
+                }
 
                 val hasEmojiSuggestion = !emojis.isNullOrEmpty()
 
                 if (hasEmojiSuggestion) {
                     ime.autoSuggestEmojis = emojis
-                    ime.updateEmojiSuggestion(true, emojis)
                     ime.updateButtonVisibility(true)
+                    ime.updateEmojiSuggestion(true, emojis)
+                } else if (ime.emojiColonModeOn) { // Show blank buttons when there are no matches
+                    ime.autoSuggestEmojis = mutableListOf()
+                    ime.updateEmojiSuggestion(true, mutableListOf())
                 } else {
                     ime.updateButtonVisibility(false)
                 }
@@ -172,6 +180,7 @@ class SuggestionHandler(
     fun clearAllSuggestionsAndHideButtonUI() {
         emojiSuggestionRunnable?.let { handler.removeCallbacks(it) }
         linguisticSuggestionRunnable?.let { handler.removeCallbacks(it) }
+        wordSuggestionRunnable?.let { handler.removeCallbacks(it) }
 
         ime.disableAutoSuggest()
 

--- a/app/src/main/java/be/scri/helpers/data/EmojiDataManager.kt
+++ b/app/src/main/java/be/scri/helpers/data/EmojiDataManager.kt
@@ -2,6 +2,7 @@
 package be.scri.helpers.data
 
 import android.database.Cursor
+import android.util.Log
 import be.scri.helpers.DatabaseFileManager
 
 /**
@@ -26,17 +27,22 @@ class EmojiDataManager(
      */
     fun getEmojiKeywords(language: String): HashMap<String, MutableList<String>> {
         val emojiMap = HashMap<String, MutableList<String>>()
+        Log.d("EmojiDataManager", "getEmojiKeywords")
         val db = fileManager.getLanguageDatabase(language) ?: return emojiMap
 
         db.use {
-            if (!it.tableExists("emoji_keywords")) return emojiMap
+            if (!it.tableExists("emojikeywords")) {
+                Log.d("EmojiDataManager", "table doesnt exist")
+                return emojiMap
+            }
+            Log.d("EmojiDataManager", "table exists")
 
-            it.rawQuery("SELECT MAX(LENGTH(word)) FROM emoji_keywords", null).use { cursor ->
+            it.rawQuery("SELECT MAX(LENGTH(word)) FROM emojikeywords", null).use { cursor ->
                 if (cursor.moveToFirst()) {
                     maxKeywordLength = cursor.getInt(0)
                 }
             }
-            it.rawQuery("SELECT * FROM emoji_keywords", null).use { cursor ->
+            it.rawQuery("SELECT * FROM emojikeywords", null).use { cursor ->
                 processEmojiCursor(cursor, emojiMap)
             }
         }

--- a/app/src/main/java/be/scri/helpers/data/EmojiDataManager.kt
+++ b/app/src/main/java/be/scri/helpers/data/EmojiDataManager.kt
@@ -2,7 +2,6 @@
 package be.scri.helpers.data
 
 import android.database.Cursor
-import android.util.Log
 import be.scri.helpers.DatabaseFileManager
 
 /**
@@ -27,22 +26,17 @@ class EmojiDataManager(
      */
     fun getEmojiKeywords(language: String): HashMap<String, MutableList<String>> {
         val emojiMap = HashMap<String, MutableList<String>>()
-        Log.d("EmojiDataManager", "getEmojiKeywords")
         val db = fileManager.getLanguageDatabase(language) ?: return emojiMap
 
         db.use {
-            if (!it.tableExists("emojikeywords")) {
-                Log.d("EmojiDataManager", "table doesnt exist")
-                return emojiMap
-            }
-            Log.d("EmojiDataManager", "table exists")
+            if (!it.tableExists("emoji_keywords")) return emojiMap
 
-            it.rawQuery("SELECT MAX(LENGTH(word)) FROM emojikeywords", null).use { cursor ->
+            it.rawQuery("SELECT MAX(LENGTH(word)) FROM emoji_keywords", null).use { cursor ->
                 if (cursor.moveToFirst()) {
                     maxKeywordLength = cursor.getInt(0)
                 }
             }
-            it.rawQuery("SELECT * FROM emojikeywords", null).use { cursor ->
+            it.rawQuery("SELECT * FROM emoji_keywords", null).use { cursor ->
                 processEmojiCursor(cursor, emojiMap)
             }
         }

--- a/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
+++ b/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
@@ -783,8 +783,11 @@ class KeyboardUIManager(
     ) {
         if (currentState != ScribeState.IDLE) return
 
-        val isTablet = (context.resources.configuration.screenLayout
-            and Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE
+        val isTablet =
+            (
+                context.resources.configuration.screenLayout
+                    and Configuration.SCREENLAYOUT_SIZE_MASK
+            ) >= Configuration.SCREENLAYOUT_SIZE_LARGE
 
         val tabletButtons = listOf(binding.emojiBtnTablet1, binding.emojiBtnTablet2, binding.emojiBtnTablet3)
         val legacyPhoneButtons = listOf(binding.emojiBtnPhone1, binding.emojiBtnPhone2)

--- a/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
+++ b/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
@@ -87,6 +87,33 @@ class KeyboardUIManager(
     var genderSuggestionLeft: Button? = binding.translateBtnLeft
     var genderSuggestionRight: Button? = binding.translateBtnRight
 
+    // 6-slot phone colon emoji row buttons
+    private val emojiColonPhoneButtons: List<Button> by lazy {
+        listOf(
+            binding.emojiColonPhone1,
+            binding.emojiColonPhone2,
+            binding.emojiColonPhone3,
+            binding.emojiColonPhone4,
+            binding.emojiColonPhone5,
+            binding.emojiColonPhone6,
+        )
+    }
+
+    // 9-slot tablet colon emoji row buttons
+    private val emojiColonTabletButtons: List<Button> by lazy {
+        listOf(
+            binding.emojiColonTablet1,
+            binding.emojiColonTablet2,
+            binding.emojiColonTablet3,
+            binding.emojiColonTablet4,
+            binding.emojiColonTablet5,
+            binding.emojiColonTablet6,
+            binding.emojiColonTablet7,
+            binding.emojiColonTablet8,
+            binding.emojiColonTablet9,
+        )
+    }
+
     // State variables specific to UI rendering.
     var currentCommandBarHint: String = ""
     var commandBarHintColor: Int = Color.GRAY
@@ -752,30 +779,70 @@ class KeyboardUIManager(
         currentState: ScribeState,
         isAutoSuggestEnabled: Boolean,
         autoSuggestEmojis: MutableList<String>?,
+        emojiColonModeOn: Boolean = false,
     ) {
         if (currentState != ScribeState.IDLE) return
 
+        val isTablet = (context.resources.configuration.screenLayout
+            and Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE
+
         val tabletButtons = listOf(binding.emojiBtnTablet1, binding.emojiBtnTablet2, binding.emojiBtnTablet3)
-        val phoneButtons = listOf(binding.emojiBtnPhone1, binding.emojiBtnPhone2)
+        val legacyPhoneButtons = listOf(binding.emojiBtnPhone1, binding.emojiBtnPhone2)
 
         if (isAutoSuggestEnabled && autoSuggestEmojis != null) {
-            val emojiListener = { emoji: String ->
-                View.OnClickListener { listener.onEmojiSelected(emoji) }
-            }
+            val emojiListener = { emoji: String -> View.OnClickListener { listener.onEmojiSelected(emoji) } }
 
-            tabletButtons.forEachIndexed { index, button ->
-                val emoji = autoSuggestEmojis.getOrNull(index) ?: ""
-                button.text = emoji
-                button.setOnClickListener(if (emoji.isNotEmpty()) emojiListener(emoji) else null)
-            }
+            if (emojiColonModeOn && !isTablet) {
+                // Phone colon mode: show the dedicated 6-slot row, hide word buttons and separators.
+                binding.translateBtn.visibility = View.GONE
+                binding.conjugateBtn.visibility = View.GONE
+                binding.pluralBtn.visibility = View.GONE
+                binding.separator2.visibility = View.GONE
+                binding.separator3.visibility = View.GONE
+                legacyPhoneButtons.forEach { it.visibility = View.GONE }
+                binding.emojiColonRowPhone.visibility = View.VISIBLE
 
-            phoneButtons.forEachIndexed { index, button ->
-                val emoji = autoSuggestEmojis.getOrNull(index) ?: ""
-                button.text = emoji
-                button.setOnClickListener(if (emoji.isNotEmpty()) emojiListener(emoji) else null)
+                emojiColonPhoneButtons.forEachIndexed { index, button ->
+                    val emoji = autoSuggestEmojis.getOrNull(index) ?: ""
+                    button.text = emoji
+                    button.setOnClickListener(if (emoji.isNotEmpty()) emojiListener(emoji) else null)
+                }
+            } else if (emojiColonModeOn && isTablet) {
+                // Tablet colon mode: show the dedicated 9-slot row, hide word buttons and separators.
+                binding.translateBtn.visibility = View.GONE
+                binding.conjugateBtn.visibility = View.GONE
+                binding.pluralBtn.visibility = View.GONE
+                binding.separator2.visibility = View.GONE
+                binding.separator3.visibility = View.GONE
+                legacyPhoneButtons.forEach { it.visibility = View.GONE }
+                tabletButtons.forEach { it.visibility = View.GONE }
+                binding.emojiColonRowPhone.visibility = View.GONE
+                binding.emojiColonRowTablet.visibility = View.VISIBLE
+
+                emojiColonTabletButtons.forEachIndexed { index, button ->
+                    val emoji = autoSuggestEmojis.getOrNull(index) ?: ""
+                    button.text = emoji
+                    button.setOnClickListener(if (emoji.isNotEmpty()) emojiListener(emoji) else null)
+                }
+            } else {
+                // Non-colon mode: ensure both colon rows are hidden, use existing emoji buttons.
+                binding.emojiColonRowPhone.visibility = View.GONE
+                binding.emojiColonRowTablet.visibility = View.GONE
+                tabletButtons.forEachIndexed { index, button ->
+                    val emoji = autoSuggestEmojis.getOrNull(index) ?: ""
+                    button.text = emoji
+                    button.setOnClickListener(if (emoji.isNotEmpty()) emojiListener(emoji) else null)
+                }
+                legacyPhoneButtons.forEachIndexed { index, button ->
+                    val emoji = autoSuggestEmojis.getOrNull(index) ?: ""
+                    button.text = emoji
+                    button.setOnClickListener(if (emoji.isNotEmpty()) emojiListener(emoji) else null)
+                }
             }
         } else {
-            (tabletButtons + phoneButtons).forEach { button ->
+            binding.emojiColonRowPhone.visibility = View.GONE
+            binding.emojiColonRowTablet.visibility = View.GONE
+            (tabletButtons + legacyPhoneButtons).forEach { button ->
                 button.text = ""
                 button.setOnClickListener(null)
             }
@@ -786,6 +853,14 @@ class KeyboardUIManager(
      * Disables all auto-suggestions and resets the suggestion buttons to their default, inactive state.
      */
     fun disableAutoSuggest(language: String) {
+        // Ensure both colon emoji rows are hidden and word buttons are fully restored.
+        binding.emojiColonRowPhone.visibility = View.GONE
+        binding.emojiColonRowTablet.visibility = View.GONE
+        binding.separator2.visibility = View.VISIBLE
+        binding.separator3.visibility = View.VISIBLE
+        binding.conjugateBtn.visibility = View.VISIBLE
+        binding.pluralBtn.visibility = View.VISIBLE
+
         binding.translateBtnRight.visibility = View.INVISIBLE
         binding.translateBtnLeft.visibility = View.INVISIBLE
         binding.translateBtn.visibility = View.VISIBLE

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1202,16 +1202,14 @@ abstract class GeneralKeyboardIME(
     fun findEmojisForPrefix(
         emojiKeywords: HashMap<String, MutableList<String>>?,
         prefix: String,
-    ): MutableList<String>? {
-        Log.d("GeneralKeyboardIME", "Prefix: $prefix")
-        return emojiKeywords
+    ): MutableList<String>? =
+        emojiKeywords
             ?.filterKeys { it.startsWith(prefix.lowercase(Locale.ROOT)) }
             ?.values
             ?.flatten()
             ?.distinct()
             ?.toMutableList()
             ?.takeIf { it.isNotEmpty() }
-    }
 
     /**
      * Finds the grammatical gender(s) for the last typed word.

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1202,14 +1202,16 @@ abstract class GeneralKeyboardIME(
     fun findEmojisForPrefix(
         emojiKeywords: HashMap<String, MutableList<String>>?,
         prefix: String,
-    ): MutableList<String>? =
-        emojiKeywords
+    ): MutableList<String>? {
+        Log.d("GeneralKeyboardIME", "Prefix: $prefix")
+        return emojiKeywords
             ?.filterKeys { it.startsWith(prefix.lowercase(Locale.ROOT)) }
             ?.values
             ?.flatten()
             ?.distinct()
             ?.toMutableList()
             ?.takeIf { it.isNotEmpty() }
+    }
 
     /**
      * Finds the grammatical gender(s) for the last typed word.

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -141,6 +141,7 @@ abstract class GeneralKeyboardIME(
     var wordSuggestions: List<String>? = null
     var checkIfPluralWord: Boolean = false
     private var currentEnterKeyType: Int? = null
+    var emojiColonModeOn: Boolean = false
 
     internal var currentState: ScribeState = ScribeState.IDLE
     internal var invalidCommandSource: ScribeState = ScribeState.IDLE
@@ -320,6 +321,7 @@ abstract class GeneralKeyboardIME(
         emojiAutoSuggestionEnabled = getIsEmojiSuggestionsEnabled(applicationContext, language)
         autoSuggestEmojis = null
         suggestionHandler.clearAllSuggestionsAndHideButtonUI()
+        emojiColonModeOn = false
 
         moveToIdleState()
 
@@ -626,6 +628,11 @@ abstract class GeneralKeyboardIME(
             currentVerbForConjugation = null
         } else {
             moveToIdleState()
+            // If the user just closed the command menu without selecting anything,
+            // and emoji colon mode was active, restore emoji suggestions.
+            if (emojiColonModeOn) {
+                suggestionHandler.processEmojiSuggestions(getLastWordBeforeCursor())
+            }
         }
         refreshUI()
     }
@@ -654,11 +661,16 @@ abstract class GeneralKeyboardIME(
 
     override fun onCloseClicked() {
         moveToIdleState()
+        // If the user just closed the command view without doing anything,
+        // and emoji colon mode was active, restore emoji suggestions.
+        if (emojiColonModeOn) {
+            suggestionHandler.processEmojiSuggestions(getLastWordBeforeCursor())
+        }
     }
 
     override fun onEmojiSelected(emoji: String) {
         if (emoji.isNotEmpty()) {
-            insertEmoji(emoji, currentInputConnection, emojiKeywords, emojiMaxKeywordLength)
+            insertEmoji(emoji, currentInputConnection, emojiKeywords, emojiMaxKeywordLength, emojiColonModeOn)
         }
     }
 
@@ -1177,6 +1189,27 @@ abstract class GeneralKeyboardIME(
         emojiKeywords: HashMap<String, MutableList<String>>?,
         lastWord: String?,
     ) = lastWord?.let { emojiKeywords?.get(it.lowercase()) }
+
+    /**
+     * Finds associated emojis for the last typed word by matching prefixes of keywords.
+     * i.e. 'cheer' should match 'cheerful'
+     *
+     * @param emojiKeywords The map of keywords to emojis.
+     * @param prefix The word to look up.
+     *
+     * @return A mutable list of emoji suggestions, or null if none are found.
+     */
+    fun findEmojisForPrefix(
+        emojiKeywords: HashMap<String, MutableList<String>>?,
+        prefix: String,
+    ): MutableList<String>? =
+        emojiKeywords
+            ?.filterKeys { it.startsWith(prefix.lowercase(Locale.ROOT)) }
+            ?.values
+            ?.flatten()
+            ?.distinct()
+            ?.toMutableList()
+            ?.takeIf { it.isNotEmpty() }
 
     /**
      * Finds the grammatical gender(s) for the last typed word.
@@ -1808,7 +1841,7 @@ abstract class GeneralKeyboardIME(
     fun updateEmojiSuggestion(
         enabled: Boolean,
         emojis: MutableList<String>?,
-    ) = uiManager.updateEmojiSuggestion(currentState, enabled, emojis)
+    ) = uiManager.updateEmojiSuggestion(currentState, enabled, emojis, emojiColonModeOn)
 
     /**
      * Disables all auto-suggestions and resets the suggestion buttons to their default, inactive state.

--- a/app/src/main/res/layout/input_method_view.xml
+++ b/app/src/main/res/layout/input_method_view.xml
@@ -154,6 +154,7 @@
             android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/separator_1"
+            app:layout_constraintHorizontal_bias="0"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -405,6 +406,219 @@
             app:layout_constraintHorizontal_weight="1"
             app:layout_constraintStart_toEndOf="@+id/emoji_space_tablet_2"
             app:layout_constraintTop_toTopOf="@+id/plural_btn" />
+
+        <!-- 6-slot emoji row for phone colon mode. Spans full width after the Scribe key. -->
+        <LinearLayout
+            android:id="@+id/emoji_colon_row_phone"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/scribe_key_options"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <Button
+                android:id="@+id/emoji_colon_phone_1"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_phone_2"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_phone_3"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_phone_4"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_phone_5"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_phone_6"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+        </LinearLayout>
+
+        <!-- 9-slot emoji row for tablet colon mode. Spans full width after the Scribe key. -->
+        <LinearLayout
+            android:id="@+id/emoji_colon_row_tablet"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/scribe_key_options"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_1"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_2"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_3"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_4"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_5"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_6"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_7"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_8"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+            <View
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="@color/special_key_light" />
+
+            <Button
+                android:id="@+id/emoji_colon_tablet_9"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@null"
+                android:textSize="20sp" />
+
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
<!---Thank you for your pull request! 🚀-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the ./gradlew lintKotlin detekt test command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

Implements emoji colon mode: an emoji suggestion mode triggered by typing ` :` (space + colon) in the keyboard. This allows users to search for emojis by keyword prefix directly from the suggestion bar without interrupting their typing flow.

Typing a space followed by `:` activates emoji colon mode (`emojiColonModeOn` flag in `GeneralKeyboardIME`). While active:

- The word suggestion bar is replaced by a dedicated emoji row — 6 slots on phones, 9 on tablets — defined in `input_method_view.xml`.
- A set of common emojis (`😀 ❤️ 👍 😂 🎉 ✨ 🔥 👋 😊`) is shown immediately on the bare `:` before any letters are typed.
- As the user types, the prefix is matched against the `emoji_keywords` table using the new `findEmojisForPrefix()` function, which finds all keywords starting with the typed prefix and collects their associated emojis.
- If no keywords match, empty slots are displayed rather than falling back to word buttons.
- Tapping an emoji deletes back to the `:` that triggered the mode and commits the emoji.
- Typing a space or deleting the `:` exits emoji colon mode and restores normal suggestions.
- Mid-word colons (e.g. in URLs or times) do not trigger the mode — only a colon immediately following a space does.

### Files changed

| File | Change |
|---|---|
| `GeneralKeyboardIME.kt` | Added `emojiColonModeOn` state, `findEmojisForPrefix()`, and colon mode restoration after closing command menus. |
| `KeyHandler.kt` | Detects the ` :` trigger, toggles colon mode on/off on space or colon deletion, suppresses word suggestion flicker during colon mode, and restores emoji suggestions after mode changes. |
| `SuggestionHandler.kt` | Strips the leading colon before prefix lookup, shows common emojis on bare `:`, and shows blank slots on no match. |
| `KeyboardUIManager.kt` | Renders the 6-slot phone row and 9-slot tablet row during colon mode, hides word buttons and separators, and restores them on exit. |
| `EmojiUtils.kt` | Added `COMMON_EMOJIS` constant and colon-mode branch in `insertEmoji` that deletes back to the triggering `:` before committing the selected emoji. |
| `input_method_view.xml` | Added the dedicated phone and tablet colon emoji button rows. |

### Backend dependencies

Emoji colon mode requires `emoji_keywords` data to be available in the language pack. Getting this working locally required some work in the `Scribe-Data` and `Scribe-Server` repos.

| Repo | Fix |
|---|---|
| **Scribe-Data** | PR #684 — fixes the `data_to_sqlite.py` insertion loop that overflows the `emoji_keywords` table columns, so the data actually reaches the SQLite output. |
| **Scribe-Server** | `emoji_keywords` must be added to `DATA_TYPES` in `update_data.sh`, and the underscore must be preserved through `generateMariaTableName` (currently strips it to `emojikeywords`). Dependencies for PyICU must also be added. |

Emoji colon mode on tablet:
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/f86064a5-7f66-4f24-82c5-7e2ac0324909" />

Emoji colon mode on phone:
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/3033dad1-c8db-4cc1-a9bf-a98b83201cc4" />

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #590