### PR TITLE
fix-navegation

### DIFF
--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -697,7 +697,9 @@ abstract class GeneralKeyboardIME(
     }
 
     override fun onConjugateClicked() {
-        currentState = ScribeState.CONJUGATE
+        if (currentState != ScribeState.SELECT_VERB_CONJUNCTION) {
+            currentState = ScribeState.CONJUGATE
+        }
         refreshUI()
     }
 


### PR DESCRIPTION
Fix: Left/right navigation in conjugation view resets keyboard to alphabetical view

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Cause:
The buttons calls `onConjugateClicked()`  that reopen conjugation grid.

Changes:
The pull request changes the function `onConjugateClicked()` on file `GeneralKeyboardIME.kt` . Now it changes the conjugation state only when you are not in the conjugation grid.

<img width="240" height="520" alt="Screen_recording_20260430_001746" src="https://github.com/user-attachments/assets/a2dbab19-edce-4383-a7a6-8f04343c1313" />

### Related issue

- Closes #549 

