### PR TITLE
feat: switch numeric inputs to symbols keyboard

### DIFF
--- a/app/src/main/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/main/java/be/scri/helpers/KeyHandler.kt
@@ -20,9 +20,9 @@ import be.scri.services.GeneralKeyboardIME.ScribeState
 class KeyHandler(
     private val ime: GeneralKeyboardIME,
 ) {
-    private val suggestionHandler = SuggestionHandler(ime)
+    private val suggestionHandler = ime.suggestionHandler
     private val spaceKeyProcessor = SpaceKeyProcessor(ime, suggestionHandler)
-    private val autocompletionHandler = AutocompletionHandler(ime)
+    private val autocompletionHandler = ime.autocompletionHandler
 
     /** Tracks if the last key pressed was a space, used for "period on double space" logic. */
     private var wasLastKeySpace: Boolean = false

--- a/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
+++ b/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
@@ -62,6 +62,8 @@ class KeyboardUIManager(
 
         fun getKeyboardLayoutXML(): Int
 
+        fun getCurrentKeyboardLayoutXML(): Int
+
         fun getCurrentEnterKeyType(): Int
 
         fun commitText(text: String)
@@ -226,7 +228,11 @@ class KeyboardUIManager(
 
         binding.scribeKeyOptions.foreground = AppCompatResources.getDrawable(context, R.drawable.ic_scribe_icon_vector)
 
-        initializeKeyboard(listener.getKeyboardLayoutXML())
+        val keyboardXml = listener.getCurrentKeyboardLayoutXML()
+        initializeKeyboard(keyboardXml)
+        if (keyboardXml == R.xml.keys_symbols) {
+            setupCurrencySymbol(language)
+        }
 
         updateButtonVisibility(ScribeState.IDLE, emojiAutoSuggestionEnabled, autoSuggestEmojis)
         updateEmojiSuggestion(ScribeState.IDLE, emojiAutoSuggestionEnabled, autoSuggestEmojis)

--- a/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
+++ b/app/src/main/java/be/scri/helpers/ui/KeyboardUIManager.kt
@@ -71,6 +71,8 @@ class KeyboardUIManager(
         fun onKeyboardActionListener(): KeyboardView.OnKeyboardActionListener
 
         fun processLinguisticSuggestions(word: String)
+
+        fun isNumericKeyboardActive(): Boolean
     }
 
     var keyboardView: KeyboardView = binding.keyboardView
@@ -161,7 +163,12 @@ class KeyboardUIManager(
         val isUserDarkMode = getIsDarkModeOrNot(context)
 
         when (currentState) {
-            ScribeState.IDLE -> setupIdleView(language, emojiAutoSuggestionEnabled, autoSuggestEmojis)
+            ScribeState.IDLE ->
+                setupIdleView(
+                    language,
+                    emojiAutoSuggestionEnabled,
+                    autoSuggestEmojis,
+                )
             ScribeState.SELECT_COMMAND -> setupSelectCommandView(language)
             ScribeState.INVALID -> setupInvalidView(language, invalidCommandSource)
             ScribeState.TRANSLATE -> {
@@ -186,7 +193,7 @@ class KeyboardUIManager(
         emojiAutoSuggestionEnabled: Boolean,
         autoSuggestEmojis: MutableList<String>?,
     ) {
-        binding.commandOptionsBar.visibility = View.VISIBLE
+        binding.commandOptionsBar.visibility = if (listener.isNumericKeyboardActive()) View.GONE else View.VISIBLE
         binding.toolbarBar.visibility = View.GONE
 
         val isUserDarkMode = getIsDarkModeOrNot(context)
@@ -245,7 +252,7 @@ class KeyboardUIManager(
      * (Translate, Conjugate, Plural).
      */
     private fun setupSelectCommandView(language: String) {
-        binding.commandOptionsBar.visibility = View.VISIBLE
+        binding.commandOptionsBar.visibility = if (listener.isNumericKeyboardActive()) View.GONE else View.VISIBLE
         binding.toolbarBar.visibility = View.GONE
 
         val isUserDarkMode = getIsDarkModeOrNot(context)
@@ -792,6 +799,8 @@ class KeyboardUIManager(
      * Disables all auto-suggestions and resets the suggestion buttons to their default, inactive state.
      */
     fun disableAutoSuggest(language: String) {
+        val isNumericKeyboard = listener.getCurrentKeyboardLayoutXML() == R.xml.keys_numeric
+
         binding.translateBtnRight.visibility = View.INVISIBLE
         binding.translateBtnLeft.visibility = View.INVISIBLE
         binding.translateBtn.visibility = View.VISIBLE
@@ -807,9 +816,20 @@ class KeyboardUIManager(
         binding.translateBtn.background = null
         binding.translateBtn.setOnClickListener(createSuggestionClickListener(suggestion1))
 
-        val suggestion2 = suggestions.getOrNull(1) ?: ""
-        binding.conjugateBtn.text = suggestion2
-        binding.conjugateBtn.setOnClickListener(createSuggestionClickListener(suggestion2))
+        if (isNumericKeyboard) {
+            binding.conjugateBtn.text = ""
+            binding.conjugateBtn.setOnClickListener(null)
+            binding.conjugateBtn.visibility = View.GONE
+            binding.separator2.visibility = View.GONE
+            binding.separator3.visibility = View.GONE
+        } else {
+            val suggestion2 = suggestions.getOrNull(1) ?: ""
+            binding.conjugateBtn.visibility = View.VISIBLE
+            binding.conjugateBtn.text = suggestion2
+            binding.conjugateBtn.setOnClickListener(createSuggestionClickListener(suggestion2))
+            binding.separator2.visibility = View.VISIBLE
+            binding.separator3.visibility = View.VISIBLE
+        }
 
         val suggestion3 = suggestions.getOrNull(2) ?: ""
         binding.pluralBtn.text = suggestion3

--- a/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/EnglishKeyboardIME.kt
@@ -32,7 +32,6 @@ class EnglishKeyboardIME : GeneralKeyboardIME("English") {
     override var inputTypeClass: Int = InputType.TYPE_CLASS_TEXT
     override var enterKeyType: Int = IME_ACTION_NONE
     override var switchToLetters: Boolean = false
-    override var hasTextBeforeCursor: Boolean = false
 
     private val keyHandler by lazy { KeyHandler(this) }
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -121,8 +121,8 @@ abstract class GeneralKeyboardIME(
     private val shiftPermToggleSpeed: Int = DEFAULT_SHIFT_PERM_TOGGLE_SPEED
 
     private lateinit var dbManagers: DatabaseManagers
-    private lateinit var suggestionHandler: SuggestionHandler
-    private lateinit var autocompletionHandler: AutocompletionHandler
+    internal lateinit var suggestionHandler: SuggestionHandler
+    internal lateinit var autocompletionHandler: AutocompletionHandler
     private lateinit var autocompletionManager: AutocompletionDataManager
     private var dataContract: DataContract? = null
 
@@ -176,6 +176,12 @@ abstract class GeneralKeyboardIME(
         internal const val MAX_TEXT_LENGTH = 1000
         const val COMMIT_TEXT_CURSOR_POSITION = 1
         internal const val CUSTOM_CURSOR = "│" // special tall cursor character
+
+        internal fun shouldUseNumericKeyboard(inputType: Int): Boolean =
+            when (inputType and TYPE_MASK_CLASS) {
+                TYPE_CLASS_NUMBER, TYPE_CLASS_DATETIME, TYPE_CLASS_PHONE -> true
+                else -> false
+            }
     }
 
     enum class ScribeState { IDLE, SELECT_COMMAND, TRANSLATE, CONJUGATE, PLURAL, SELECT_VERB_CONJUNCTION, INVALID, ALREADY_PLURAL }
@@ -287,16 +293,12 @@ abstract class GeneralKeyboardIME(
         hasTextBeforeCursor = currentInputConnection?.getTextBeforeCursor(1, 0)?.isNotEmpty() == true
 
         val keyboardXml =
-            when (inputTypeClass) {
-                TYPE_CLASS_NUMBER, TYPE_CLASS_DATETIME, TYPE_CLASS_PHONE -> {
-                    keyboardMode = keyboardSymbols
-                    R.xml.keys_symbols
-                }
-
-                else -> {
-                    keyboardMode = keyboardLetters
-                    getKeyboardLayoutXML()
-                }
+            if (shouldUseNumericKeyboard(attribute.inputType)) {
+                keyboardMode = keyboardSymbols
+                R.xml.keys_symbols
+            } else {
+                keyboardMode = keyboardLetters
+                getKeyboardLayoutXML()
             }
 
         loadLanguageData()
@@ -304,7 +306,7 @@ abstract class GeneralKeyboardIME(
         keyboard = KeyboardBase(this, keyboardXml, enterKeyType)
         keyboardView?.setKeyboard(keyboard!!)
 
-        if (keyboardXml == R.xml.keys_symbols) {
+        if (this::uiManager.isInitialized && keyboardXml == R.xml.keys_symbols) {
             uiManager.setupCurrencySymbol(language)
         }
     }
@@ -726,6 +728,13 @@ abstract class GeneralKeyboardIME(
     }
 
     override fun getCurrentEnterKeyType(): Int = enterKeyType
+
+    override fun getCurrentKeyboardLayoutXML(): Int =
+        when (keyboardMode) {
+            keyboardSymbols -> R.xml.keys_symbols
+            keyboardSymbolShift -> R.xml.keys_symbols_shift
+            else -> getKeyboardLayoutXML()
+        }
 
     override fun onKeyboardActionListener(): KeyboardView.OnKeyboardActionListener = this
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -342,7 +342,7 @@ abstract class GeneralKeyboardIME(
         banner.visibility =
             if (hasData) View.GONE else View.VISIBLE
         binding.commandOptionsBar.visibility =
-            if (hasData) View.VISIBLE else View.GONE
+            if (hasData && !isNumericKeyboardActive) View.VISIBLE else View.GONE
         val isDarkMode = getIsDarkModeOrNot(applicationContext)
         val bannerColor = if (isDarkMode) R.color.dark_tutorial_button_color else R.color.light_tutorial_button_color
         val bannerTextColor = if (isDarkMode) R.color.dark_button_outline_color else R.color.light_text_color
@@ -735,6 +735,8 @@ abstract class GeneralKeyboardIME(
 
     override fun getCurrentEnterKeyType(): Int = enterKeyType
 
+    override fun isNumericKeyboardActive(): Boolean = isNumericKeyboardActive
+
     override fun getCurrentKeyboardLayoutXML(): Int =
         when (keyboardMode) {
             keyboardSymbols -> getPrimarySymbolKeyboardLayoutXML()
@@ -742,8 +744,11 @@ abstract class GeneralKeyboardIME(
             else -> getKeyboardLayoutXML()
         }
 
-    private fun getPrimarySymbolKeyboardLayoutXML(): Int =
-        if (isNumericKeyboardActive) R.xml.keys_numeric else R.xml.keys_symbols
+    private fun getPrimarySymbolKeyboardLayoutXML(): Int = if (isNumericKeyboardActive) {
+        R.xml.keys_numeric
+    } else {
+        R.xml.keys_symbols
+    }
 
     override fun onKeyboardActionListener(): KeyboardView.OnKeyboardActionListener = this
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -744,11 +744,12 @@ abstract class GeneralKeyboardIME(
             else -> getKeyboardLayoutXML()
         }
 
-    private fun getPrimarySymbolKeyboardLayoutXML(): Int = if (isNumericKeyboardActive) {
-        R.xml.keys_numeric
-    } else {
-        R.xml.keys_symbols
-    }
+    private fun getPrimarySymbolKeyboardLayoutXML(): Int =
+        if (isNumericKeyboardActive) {
+            R.xml.keys_numeric
+        } else {
+            R.xml.keys_symbols
+        }
 
     override fun onKeyboardActionListener(): KeyboardView.OnKeyboardActionListener = this
 

--- a/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/GeneralKeyboardIME.kt
@@ -144,6 +144,7 @@ abstract class GeneralKeyboardIME(
     var wordSuggestions: List<String>? = null
     var checkIfPluralWord: Boolean = false
     private var currentEnterKeyType: Int? = null
+    private var isNumericKeyboardActive: Boolean = false
 
     internal var currentState: ScribeState = ScribeState.IDLE
     internal var invalidCommandSource: ScribeState = ScribeState.IDLE
@@ -181,6 +182,16 @@ abstract class GeneralKeyboardIME(
             when (inputType and TYPE_MASK_CLASS) {
                 TYPE_CLASS_NUMBER, TYPE_CLASS_DATETIME, TYPE_CLASS_PHONE -> true
                 else -> false
+            }
+
+        internal fun getKeyboardLayoutXMLForInputType(
+            inputType: Int,
+            letterKeyboardLayoutXML: Int,
+        ): Int =
+            if (shouldUseNumericKeyboard(inputType)) {
+                R.xml.keys_numeric
+            } else {
+                letterKeyboardLayoutXML
             }
     }
 
@@ -292,14 +303,9 @@ abstract class GeneralKeyboardIME(
         // This setter triggers the logic in the property override if not shadowed.
         hasTextBeforeCursor = currentInputConnection?.getTextBeforeCursor(1, 0)?.isNotEmpty() == true
 
-        val keyboardXml =
-            if (shouldUseNumericKeyboard(attribute.inputType)) {
-                keyboardMode = keyboardSymbols
-                R.xml.keys_symbols
-            } else {
-                keyboardMode = keyboardLetters
-                getKeyboardLayoutXML()
-            }
+        isNumericKeyboardActive = shouldUseNumericKeyboard(attribute.inputType)
+        keyboardMode = if (isNumericKeyboardActive) keyboardSymbols else keyboardLetters
+        val keyboardXml = getKeyboardLayoutXMLForInputType(attribute.inputType, getKeyboardLayoutXML())
 
         loadLanguageData()
 
@@ -731,10 +737,13 @@ abstract class GeneralKeyboardIME(
 
     override fun getCurrentKeyboardLayoutXML(): Int =
         when (keyboardMode) {
-            keyboardSymbols -> R.xml.keys_symbols
+            keyboardSymbols -> getPrimarySymbolKeyboardLayoutXML()
             keyboardSymbolShift -> R.xml.keys_symbols_shift
             else -> getKeyboardLayoutXML()
         }
+
+    private fun getPrimarySymbolKeyboardLayoutXML(): Int =
+        if (isNumericKeyboardActive) R.xml.keys_numeric else R.xml.keys_symbols
 
     override fun onKeyboardActionListener(): KeyboardView.OnKeyboardActionListener = this
 
@@ -1180,7 +1189,7 @@ abstract class GeneralKeyboardIME(
                     R.xml.keys_symbols_shift
                 } else {
                     this.keyboardMode = keyboardSymbols
-                    R.xml.keys_symbols
+                    getPrimarySymbolKeyboardLayoutXML()
                 }
             keyboard = KeyboardBase(this, keyboardXml, enterKeyType)
             keyboardView!!.setKeyboard(keyboard!!)
@@ -1205,7 +1214,7 @@ abstract class GeneralKeyboardIME(
         val keyboardXml =
             if (keyboardMode == keyboardLetters) {
                 this.keyboardMode = keyboardSymbols
-                R.xml.keys_symbols
+                getPrimarySymbolKeyboardLayoutXML()
             } else {
                 this.keyboardMode = keyboardLetters
                 getKeyboardLayoutXML()

--- a/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/ItalianKeyboardIME.kt
@@ -32,7 +32,6 @@ class ItalianKeyboardIME : GeneralKeyboardIME("Italian") {
     override var inputTypeClass: Int = InputType.TYPE_CLASS_TEXT
     override var enterKeyType: Int = IME_ACTION_NONE
     override var switchToLetters: Boolean = false
-    override var hasTextBeforeCursor: Boolean = false
 
     private val keyHandler by lazy { KeyHandler(this) }
 

--- a/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/RussianKeyboardIME.kt
@@ -32,7 +32,6 @@ class RussianKeyboardIME : GeneralKeyboardIME("Russian") {
     override var inputTypeClass: Int = InputType.TYPE_CLASS_TEXT
     override var enterKeyType: Int = IME_ACTION_NONE
     override var switchToLetters: Boolean = false
-    override var hasTextBeforeCursor: Boolean = false
 
     private val keyHandler by lazy { KeyHandler(this) }
 

--- a/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
+++ b/app/src/main/java/be/scri/services/SwedishKeyboardIME.kt
@@ -42,7 +42,6 @@ class SwedishKeyboardIME : GeneralKeyboardIME("Swedish") {
     override var inputTypeClass: Int = InputType.TYPE_CLASS_TEXT
     override var enterKeyType: Int = IME_ACTION_NONE
     override var switchToLetters: Boolean = false
-    override var hasTextBeforeCursor: Boolean = false
 
     private val keyHandler by lazy { KeyHandler(this) }
 

--- a/app/src/main/res/xml/keys_numeric.xml
+++ b/app/src/main/res/xml/keys_numeric.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Row app:keyWidth="25%p">
+        <Key
+            app:keyEdgeFlags="left"
+            app:keyLabel="1" />
+        <Key app:keyLabel="2" />
+        <Key app:keyLabel="3" />
+        <Key
+            app:code="-5"
+            app:isRepeatable="true"
+            app:keyEdgeFlags="right"
+            app:keyIcon="@drawable/ic_clear_outline_vector" />
+    </Row>
+    <Row app:keyWidth="25%p">
+        <Key
+            app:keyEdgeFlags="left"
+            app:keyLabel="4" />
+        <Key app:keyLabel="5" />
+        <Key app:keyLabel="6" />
+        <Key app:keyLabel="-" />
+    </Row>
+    <Row app:keyWidth="25%p">
+        <Key
+            app:keyEdgeFlags="left"
+            app:keyLabel="7" />
+        <Key app:keyLabel="8" />
+        <Key app:keyLabel="9" />
+        <Key app:keyLabel="+" />
+    </Row>
+    <Row app:keyWidth="25%p">
+        <Key
+            app:code="-2"
+            app:keyEdgeFlags="left"
+            app:keyLabel="ABC" />
+        <Key app:keyLabel="0" />
+        <Key
+            app:keyLabel="."
+            app:popupCharacters=",/:"
+            app:popupKeyboard="@xml/keyboard_popup_template" />
+        <Key
+            app:code="-4"
+            app:keyEdgeFlags="right"
+            app:keyIcon="@drawable/ic_enter_vector" />
+    </Row>
+</Keyboard>

--- a/app/src/test/kotlin/be/scri/helpers/ui/KeyboardUIManagerTest.kt
+++ b/app/src/test/kotlin/be/scri/helpers/ui/KeyboardUIManagerTest.kt
@@ -57,6 +57,7 @@ class KeyboardUIManagerTest {
         // Mock Listener
         listener = mockk(relaxed = true)
         every { listener.getKeyboardLayoutXML() } returns be.scri.R.xml.keys_letters_english
+        every { listener.getCurrentKeyboardLayoutXML() } returns be.scri.R.xml.keys_letters_english
         every { listener.onKeyboardActionListener() } returns mockk()
 
         // Init Manager

--- a/app/src/test/kotlin/be/scri/services/GeneralKeyboardIMEInputTypeTest.kt
+++ b/app/src/test/kotlin/be/scri/services/GeneralKeyboardIMEInputTypeTest.kt
@@ -4,8 +4,8 @@ package be.scri.services
 
 import android.text.InputType
 import be.scri.R
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 

--- a/app/src/test/kotlin/be/scri/services/GeneralKeyboardIMEInputTypeTest.kt
+++ b/app/src/test/kotlin/be/scri/services/GeneralKeyboardIMEInputTypeTest.kt
@@ -3,7 +3,9 @@
 package be.scri.services
 
 import android.text.InputType
+import be.scri.R
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -32,5 +34,25 @@ class GeneralKeyboardIMEInputTypeTest {
         val inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
 
         assertFalse(GeneralKeyboardIME.shouldUseNumericKeyboard(inputType))
+    }
+
+    @Test
+    fun getKeyboardLayoutXMLForInputType_returnsNumericLayoutForNumberInputs() {
+        val inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+
+        assertEquals(
+            R.xml.keys_numeric,
+            GeneralKeyboardIME.getKeyboardLayoutXMLForInputType(inputType, R.xml.keys_letters_english),
+        )
+    }
+
+    @Test
+    fun getKeyboardLayoutXMLForInputType_returnsLetterLayoutForTextInputs() {
+        val inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+
+        assertEquals(
+            R.xml.keys_letters_english,
+            GeneralKeyboardIME.getKeyboardLayoutXMLForInputType(inputType, R.xml.keys_letters_english),
+        )
     }
 }

--- a/app/src/test/kotlin/be/scri/services/GeneralKeyboardIMEInputTypeTest.kt
+++ b/app/src/test/kotlin/be/scri/services/GeneralKeyboardIMEInputTypeTest.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package be.scri.services
+
+import android.text.InputType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneralKeyboardIMEInputTypeTest {
+    @Test
+    fun shouldUseNumericKeyboard_returnsTrueForNumberInputs() {
+        val inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+
+        assertTrue(GeneralKeyboardIME.shouldUseNumericKeyboard(inputType))
+    }
+
+    @Test
+    fun shouldUseNumericKeyboard_returnsTrueForDateTimeInputs() {
+        val inputType = InputType.TYPE_CLASS_DATETIME or InputType.TYPE_DATETIME_VARIATION_DATE
+
+        assertTrue(GeneralKeyboardIME.shouldUseNumericKeyboard(inputType))
+    }
+
+    @Test
+    fun shouldUseNumericKeyboard_returnsTrueForPhoneInputs() {
+        assertTrue(GeneralKeyboardIME.shouldUseNumericKeyboard(InputType.TYPE_CLASS_PHONE))
+    }
+
+    @Test
+    fun shouldUseNumericKeyboard_returnsFalseForTextInputs() {
+        val inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+
+        assertFalse(GeneralKeyboardIME.shouldUseNumericKeyboard(inputType))
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Tue Jan 04 09:48:27 CET 2022
+#Sat May 09 08:20:13 PST 2026
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=20f1b1176237254a6fc204d8434196fa11a4cfb387567519c61556e8710aed78
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Adds automatic switching to the numeric/symbol keyboard for input fields that request numeric-style input.

This PR:
- Detects number, datetime, and phone input types in `GeneralKeyboardIME`.
- Preserves the selected keyboard layout when the idle UI is refreshed, so numeric input fields are not reset back to the ABC layout.
- Updates keyboard UI tests for the new current-layout lookup.
- Adds unit tests for numeric input type detection.

Tested with:

```bash
./gradlew lintKotlin detekt test
```

### Related issue

- Closes #607 