### PR TITLE
Add swipe to delete, swipe to restore, and interactive onboarding tutorial 

### DIFF
--- a/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
@@ -25,6 +25,91 @@ class BackspaceHandler(
     var isDeleteRepeating: Boolean = false
 
     /**
+     * Stack to store deleted text blocks for undo restoration.
+     */
+    private val deletedChunksStack = java.util.Stack<String>()
+
+    /**
+     * Timestamp of the last programmatic swipe operation (delete or restore).
+     */
+    var lastSwipeOperationTime: Long = 0
+
+    /**
+     * Clear all elements in the undo stack.
+     */
+    fun clearUndoStack() {
+        deletedChunksStack.clear()
+    }
+
+    /**
+     * Deletes the character or word before the cursor and pushes it onto the stack.
+     */
+    fun performSwipeDelete() {
+        lastSwipeOperationTime = System.currentTimeMillis()
+        val inputConnection = ime.currentInputConnection ?: return
+        val textBeforeCursor = inputConnection.getTextBeforeCursor(MAX_TEXT_LENGTH, 0)?.toString() ?: ""
+        if (textBeforeCursor.isEmpty()) {
+            return
+        }
+
+        val isWordByWordEnabled = getIsWordByWordDeletionEnabled(ime.applicationContext, ime.language)
+        val deletionLength = if (isWordByWordEnabled) {
+            getWordDeletionLength(textBeforeCursor)
+        } else {
+            1
+        }
+
+        if (deletionLength > 0) {
+            val chunkToDelete = textBeforeCursor.takeLast(deletionLength)
+            deletedChunksStack.push(chunkToDelete)
+
+            inputConnection.deleteSurroundingText(deletionLength, 0)
+        }
+    }
+
+    /**
+     * Pops the last deleted chunk from the stack and restores it.
+     */
+    fun performSwipeRestore() {
+        lastSwipeOperationTime = System.currentTimeMillis()
+        val inputConnection = ime.currentInputConnection ?: return
+        if (!deletedChunksStack.isEmpty()) {
+            val chunkToRestore = deletedChunksStack.pop()
+
+            inputConnection.commitText(chunkToRestore, 1)
+        }
+    }
+
+    /**
+     * Helper to compute deletion length for the word before the cursor.
+     */
+    private fun getWordDeletionLength(text: String): Int {
+        var deletionLength = 0
+        var index = text.length - 1
+
+        // Skip any whitespace.
+        while (index >= 0 && text[index].isWhitespace()) {
+            deletionLength++
+            index--
+        }
+
+        if (index < 0) {
+            return deletionLength
+        }
+
+        // Delete word characters or a single special character
+        if (isWordCharacter(text[index])) {
+            while (index >= 0 && isWordCharacter(text[index])) {
+                deletionLength++
+                index--
+            }
+        } else {
+            deletionLength++
+        }
+        return deletionLength
+    }
+
+    /**
      * Handles the logic for the Delete/Backspace key. It deletes characters from either
      * the main input field or the command bar, depending on the context.
      *

--- a/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
@@ -53,11 +53,12 @@ class BackspaceHandler(
         }
 
         val isWordByWordEnabled = getIsWordByWordDeletionEnabled(ime.applicationContext, ime.language)
-        val deletionLength = if (isWordByWordEnabled) {
-            getWordDeletionLength(textBeforeCursor)
-        } else {
-            1
-        }
+        val deletionLength =
+            if (isWordByWordEnabled) {
+                getWordDeletionLength(textBeforeCursor)
+            } else {
+                1
+            }
 
         if (deletionLength > 0) {
             val chunkToDelete = textBeforeCursor.takeLast(deletionLength)

--- a/app/src/keyboards/java/be/scri/helpers/ui/HintUtils.kt
+++ b/app/src/keyboards/java/be/scri/helpers/ui/HintUtils.kt
@@ -34,6 +34,7 @@ object HintUtils {
             putBoolean("hint_shown_main", false)
             putBoolean("hint_shown_settings", false)
             putBoolean("hint_shown_about", false)
+            putBoolean("swipe_tutorial_shown", false)
             apply()
         }
     }

--- a/app/src/keyboards/java/be/scri/helpers/ui/HintUtils.kt
+++ b/app/src/keyboards/java/be/scri/helpers/ui/HintUtils.kt
@@ -35,6 +35,7 @@ object HintUtils {
             putBoolean("hint_shown_settings", false)
             putBoolean("hint_shown_about", false)
             putBoolean("swipe_tutorial_shown", false)
+            putBoolean("swipe_tutorial_interactive_shown", false)
             apply()
         }
     }

--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -119,8 +119,9 @@ abstract class GeneralKeyboardIME(
         NOT_ACTIVE,
         SWIPE_LEFT_STEP,
         SWIPE_RIGHT_STEP,
-        COMPLETED
+        COMPLETED,
     }
+
     private var swipeTutorialState = SwipeTutorialState.NOT_ACTIVE
 
     // MARK: State Variables
@@ -502,7 +503,7 @@ abstract class GeneralKeyboardIME(
         newSelStart: Int,
         newSelEnd: Int,
         candidatesStart: Int,
-        candidatesEnd: Int
+        candidatesEnd: Int,
     ) {
         super.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesStart, candidatesEnd)
         // If the selection/cursor changed manually (not from our programmatic swipe gestures within 500ms), clear the stack

--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -115,6 +115,14 @@ abstract class GeneralKeyboardIME(
     internal val binding: InputMethodViewBinding
         get() = uiManager.binding
 
+    private enum class SwipeTutorialState {
+        NOT_ACTIVE,
+        SWIPE_LEFT_STEP,
+        SWIPE_RIGHT_STEP,
+        COMPLETED
+    }
+    private var swipeTutorialState = SwipeTutorialState.NOT_ACTIVE
+
     // MARK: State Variables
 
     internal var isSingularAndPlural: Boolean = false
@@ -306,6 +314,7 @@ abstract class GeneralKeyboardIME(
         restarting: Boolean,
     ) {
         super.onStartInput(attribute, restarting)
+        backspaceHandler.clearUndoStack()
         inputTypeClass = attribute!!.inputType and TYPE_MASK_CLASS
         enterKeyType = attribute.imeOptions and (IME_MASK_ACTION or IME_FLAG_NO_ENTER_ACTION)
         currentEnterKeyType = enterKeyType
@@ -406,6 +415,73 @@ abstract class GeneralKeyboardIME(
             }
             keyboardView?.invalidateAllKeys()
         }
+
+        // Show swipe delete & undo gesture tutorial overlay if not already shown
+        initSwipeTutorial()
+    }
+
+    private fun initSwipeTutorial() {
+        val sharedPref = applicationContext.getSharedPreferences("app_preferences", MODE_PRIVATE)
+        val tutorialShown = sharedPref.getBoolean("swipe_tutorial_shown", false)
+        if (!tutorialShown) {
+            val ic = currentInputConnection
+            if (ic != null) {
+                ic.commitText("Scribe ", 1)
+            }
+            binding.swipeTutorialOverlay.visibility = View.VISIBLE
+            binding.swipeTutorialClose.setOnClickListener {
+                dismissSwipeTutorial()
+            }
+            setSwipeTutorialState(SwipeTutorialState.SWIPE_LEFT_STEP)
+        } else {
+            binding.swipeTutorialOverlay.visibility = View.GONE
+            swipeTutorialState = SwipeTutorialState.NOT_ACTIVE
+        }
+    }
+
+    private fun setSwipeTutorialState(state: SwipeTutorialState) {
+        swipeTutorialState = state
+        when (state) {
+            SwipeTutorialState.SWIPE_LEFT_STEP -> {
+                binding.swipeTutorialOverlay.visibility = View.VISIBLE
+                binding.swipeTutorialProgress.text = "Step 1 of 2"
+                binding.swipeTutorialIcon.setImageResource(R.drawable.ic_swipe_left)
+                binding.swipeTutorialTitle.text = "Swipe Left to Delete"
+                binding.swipeTutorialDesc.text = "Swipe left anywhere on the keyboard to delete the last word."
+                binding.swipeTutorialStatus.text = "Practice: Swipe left on the keyboard below to delete 'Scribe'!"
+                binding.swipeTutorialStatus.setTextColor(ContextCompat.getColor(applicationContext, R.color.theme_scribe_blue))
+                binding.swipeTutorialClose.text = "Skip"
+            }
+            SwipeTutorialState.SWIPE_RIGHT_STEP -> {
+                binding.swipeTutorialOverlay.visibility = View.VISIBLE
+                binding.swipeTutorialProgress.text = "Step 2 of 2"
+                binding.swipeTutorialIcon.setImageResource(R.drawable.ic_swipe_right)
+                binding.swipeTutorialTitle.text = "Swipe Right to Restore"
+                binding.swipeTutorialDesc.text = "Swipe right anywhere on the keyboard to restore/undo deletion."
+                binding.swipeTutorialStatus.text = "Practice: Swipe right now to restore the word!"
+                binding.swipeTutorialStatus.setTextColor(ContextCompat.getColor(applicationContext, R.color.theme_scribe_blue))
+                binding.swipeTutorialClose.text = "Skip"
+            }
+            SwipeTutorialState.COMPLETED -> {
+                binding.swipeTutorialOverlay.visibility = View.VISIBLE
+                binding.swipeTutorialProgress.text = "Tutorial Completed!"
+                binding.swipeTutorialIcon.setImageResource(R.drawable.ic_swipe_success)
+                binding.swipeTutorialTitle.text = "You're All Set!"
+                binding.swipeTutorialDesc.text = "You can swipe left to delete and swipe right to restore at any time."
+                binding.swipeTutorialStatus.text = "Success! Tap 'Got it!' to start typing."
+                binding.swipeTutorialStatus.setTextColor(android.graphics.Color.parseColor("#10B981"))
+                binding.swipeTutorialClose.text = "Got it!"
+            }
+            SwipeTutorialState.NOT_ACTIVE -> {
+                binding.swipeTutorialOverlay.visibility = View.GONE
+            }
+        }
+    }
+
+    private fun dismissSwipeTutorial() {
+        val sharedPref = applicationContext.getSharedPreferences("app_preferences", MODE_PRIVATE)
+        sharedPref.edit().putBoolean("swipe_tutorial_shown", true).apply()
+        setSwipeTutorialState(SwipeTutorialState.NOT_ACTIVE)
     }
 
     /**
@@ -416,7 +492,24 @@ abstract class GeneralKeyboardIME(
      */
     override fun onFinishInputView(finishingInput: Boolean) {
         super.onFinishInputView(finishingInput)
+        backspaceHandler.clearUndoStack()
         moveToIdleState()
+    }
+
+    override fun onUpdateSelection(
+        oldSelStart: Int,
+        oldSelEnd: Int,
+        newSelStart: Int,
+        newSelEnd: Int,
+        candidatesStart: Int,
+        candidatesEnd: Int
+    ) {
+        super.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesStart, candidatesEnd)
+        // If the selection/cursor changed manually (not from our programmatic swipe gestures within 500ms), clear the stack
+        val timeSinceLastSwipe = System.currentTimeMillis() - backspaceHandler.lastSwipeOperationTime
+        if (timeSinceLastSwipe > 500) {
+            backspaceHandler.clearUndoStack()
+        }
     }
 
     // MARK: OnKeyboardActionListener
@@ -482,13 +575,35 @@ abstract class GeneralKeyboardIME(
     override fun moveCursorRight() = moveCursor(true)
 
     override fun onText(text: String) {
+        backspaceHandler.clearUndoStack()
         currentInputConnection?.commitText(text, 0)
+    }
+
+    override fun onSwipeLeft() {
+        if (swipeTutorialState == SwipeTutorialState.SWIPE_LEFT_STEP) {
+            backspaceHandler.performSwipeDelete()
+            setSwipeTutorialState(SwipeTutorialState.SWIPE_RIGHT_STEP)
+        } else if (swipeTutorialState == SwipeTutorialState.NOT_ACTIVE) {
+            backspaceHandler.performSwipeDelete()
+        }
+    }
+
+    override fun onSwipeRight() {
+        if (swipeTutorialState == SwipeTutorialState.SWIPE_RIGHT_STEP) {
+            backspaceHandler.performSwipeRestore()
+            setSwipeTutorialState(SwipeTutorialState.COMPLETED)
+        } else if (swipeTutorialState == SwipeTutorialState.NOT_ACTIVE) {
+            backspaceHandler.performSwipeRestore()
+        }
     }
 
     /**
      * Handles key input from the keyboard. Delegates to specific handlers based on the key code.
      */
     override fun onKey(code: Int) {
+        if (code != KeyboardBase.KEYCODE_DELETE) {
+            backspaceHandler.clearUndoStack()
+        }
         val inputConnection = currentInputConnection
         if (inputConnection != null) {
             when (code) {
@@ -734,11 +849,13 @@ abstract class GeneralKeyboardIME(
 
     override fun onEmojiSelected(emoji: String) {
         if (emoji.isNotEmpty()) {
+            backspaceHandler.clearUndoStack()
             insertEmoji(emoji, currentInputConnection, emojiKeywords, emojiMaxKeywordLength)
         }
     }
 
     override fun onSuggestionClicked(suggestion: String) {
+        backspaceHandler.clearUndoStack()
         currentInputConnection?.commitText("$suggestion ", 1)
         moveToIdleState()
     }
@@ -768,6 +885,7 @@ abstract class GeneralKeyboardIME(
     }
 
     override fun commitText(text: String) {
+        backspaceHandler.clearUndoStack()
         if (currentState == ScribeState.SELECT_VERB_CONJUNCTION) {
             val label = text.trim()
             val conjugateIndex = getValidatedConjugateIndex()

--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -422,7 +422,7 @@ abstract class GeneralKeyboardIME(
 
     private fun initSwipeTutorial() {
         val sharedPref = applicationContext.getSharedPreferences("app_preferences", MODE_PRIVATE)
-        val tutorialShown = sharedPref.getBoolean("swipe_tutorial_shown", false)
+        val tutorialShown = sharedPref.getBoolean("swipe_tutorial_interactive_shown", false)
         if (!tutorialShown) {
             val ic = currentInputConnection
             if (ic != null) {
@@ -480,7 +480,7 @@ abstract class GeneralKeyboardIME(
 
     private fun dismissSwipeTutorial() {
         val sharedPref = applicationContext.getSharedPreferences("app_preferences", MODE_PRIVATE)
-        sharedPref.edit().putBoolean("swipe_tutorial_shown", true).apply()
+        sharedPref.edit().putBoolean("swipe_tutorial_interactive_shown", true).apply()
         setSwipeTutorialState(SwipeTutorialState.NOT_ACTIVE)
     }
 

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -606,6 +606,7 @@ object PreferencesHelper {
             putBoolean("hint_shown_settings", false)
             putBoolean("hint_shown_about", false)
             putBoolean("swipe_tutorial_shown", false)
+            putBoolean("swipe_tutorial_interactive_shown", false)
             apply()
         }
     }

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -605,6 +605,7 @@ object PreferencesHelper {
             putBoolean("hint_shown_main", false)
             putBoolean("hint_shown_settings", false)
             putBoolean("hint_shown_about", false)
+            putBoolean("swipe_tutorial_shown", false)
             apply()
         }
     }

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -142,6 +142,16 @@ class KeyboardView
              * that don't need delete repeat tracking.
              */
             fun setDeleteRepeating(isRepeating: Boolean) {}
+
+            /**
+             * Triggered when the user swipes left across the keyboard.
+             */
+            fun onSwipeLeft() {}
+
+            /**
+             * Triggered when the user swipes right across the keyboard.
+             */
+            fun onSwipeRight() {}
         }
 
         var mKeyboard: KeyboardBase? = null
@@ -207,6 +217,12 @@ class KeyboardView
         private var mTopSmallNumberMarginHeight = 0f
         private val mSpaceMoveThreshold: Int
         private var ignoreTouches = false
+
+        private var mSwipeActive = false
+        private var mStartX = 0f
+        private var mStartY = 0f
+        private var mLastSwipeX = 0f
+        private var mSwipeAccumulatedDelta = 0f
 
         var mKeyLabel: String = "He"
 
@@ -329,6 +345,8 @@ class KeyboardView
             private const val KEY_HEIGHT = 100
             private var leftShiftForLabel = 0
             private const val LEFT_RIGHT_CONJUGATE_KEY_EXTRA_HEIGHT = 340
+            private const val SWIPE_THRESHOLD = 80f
+            private const val SWIPE_STEP_PX = 45f
         }
 
         var setPreview: Boolean = true
@@ -1458,6 +1476,14 @@ class KeyboardView
                             override fun commitPeriodAfterSpace() {
                                 mOnKeyboardActionListener!!.commitPeriodAfterSpace()
                             }
+
+                            override fun onSwipeLeft() {
+                                mOnKeyboardActionListener?.onSwipeLeft()
+                            }
+
+                            override fun onSwipeRight() {
+                                mOnKeyboardActionListener?.onSwipeRight()
+                            }
                         }
 
                     val keyboard =
@@ -1667,8 +1693,8 @@ class KeyboardView
             val eventTime = me.eventTime
             val keyIndex = getPressedKeyIndex(touchX, touchY)
 
-            // Ignore all motion events until a DOWN.
-            if (mAbortKey && action != MotionEvent.ACTION_DOWN && action != MotionEvent.ACTION_CANCEL) {
+            // Ignore all motion events until a DOWN, unless a swipe gesture is active.
+            if (mAbortKey && action != MotionEvent.ACTION_DOWN && action != MotionEvent.ACTION_CANCEL && !mSwipeActive) {
                 handled = true
             }
 
@@ -1702,6 +1728,11 @@ class KeyboardView
                         handled = true
                     }
                     MotionEvent.ACTION_DOWN -> {
+                        mStartX = me.x
+                        mStartY = me.y
+                        mLastSwipeX = me.x
+                        mSwipeAccumulatedDelta = 0f
+                        mSwipeActive = false
                         mAbortKey = false
                         mLastCodeX = touchX
                         mLastCodeY = touchY
@@ -1749,6 +1780,46 @@ class KeyboardView
                         }
                     }
                     MotionEvent.ACTION_MOVE -> {
+                        val dx = me.x - mStartX
+                        val dy = me.y - mStartY
+                        if (!mSwipeActive) {
+                            if (Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy) * 2) {
+                                mSwipeActive = true
+                                mHandler?.removeMessages(MSG_LONGPRESS)
+                                mAbortKey = true
+                                showPreview(NOT_A_KEY)
+                                if (mRepeatKeyIndex != NOT_A_KEY) {
+                                    mHandler?.removeMessages(MSG_REPEAT)
+                                    if (mKeys.getOrNull(mRepeatKeyIndex)?.code == KEYCODE_DELETE) {
+                                        mOnKeyboardActionListener?.setDeleteRepeating(false)
+                                    }
+                                    mRepeatKeyIndex = NOT_A_KEY
+                                }
+                                mLastSwipeX = me.x
+                            }
+                        }
+
+                        if (mSwipeActive) {
+                            val deltaX = me.x - mLastSwipeX
+                            mSwipeAccumulatedDelta += deltaX
+                            mLastSwipeX = me.x
+
+                            while (mSwipeAccumulatedDelta <= -SWIPE_STEP_PX) {
+                                mOnKeyboardActionListener?.onSwipeLeft()
+                                vibrateIfNeeded()
+                                mSwipeAccumulatedDelta += SWIPE_STEP_PX
+                            }
+
+                            while (mSwipeAccumulatedDelta >= SWIPE_STEP_PX) {
+                                mOnKeyboardActionListener?.onSwipeRight()
+                                vibrateIfNeeded()
+                                mSwipeAccumulatedDelta -= SWIPE_STEP_PX
+                            }
+
+                            mLastMoveTime = eventTime
+                            return true
+                        }
+
                         var continueLongPress = false
                         if (keyIndex != NOT_A_KEY) {
                             if (mCurrentKey == NOT_A_KEY) {
@@ -1802,6 +1873,20 @@ class KeyboardView
                         }
                     }
                     MotionEvent.ACTION_UP -> {
+                        if (mSwipeActive) {
+                            mSwipeActive = false
+                            mLastSpaceMoveX = 0
+                            removeMessages()
+                            showPreview(NOT_A_KEY)
+                            if (mRepeatKeyIndex != NOT_A_KEY && mKeys.getOrNull(mRepeatKeyIndex)?.code == KEYCODE_DELETE) {
+                                mOnKeyboardActionListener?.setDeleteRepeating(false)
+                            }
+                            mRepeatKeyIndex = NOT_A_KEY
+                            mOnKeyboardActionListener!!.onActionUp()
+                            mIsLongPressingSpace = false
+                            return true
+                        }
+
                         mLastSpaceMoveX = 0
                         removeMessages()
                         if (keyIndex == mCurrentKey) {
@@ -1852,6 +1937,21 @@ class KeyboardView
                         mIsLongPressingSpace = false
                     }
                     MotionEvent.ACTION_CANCEL -> {
+                        if (mSwipeActive) {
+                            mSwipeActive = false
+                            mIsLongPressingSpace = false
+                            mLastSpaceMoveX = 0
+                            if (mRepeatKeyIndex != NOT_A_KEY && mKeys.getOrNull(mRepeatKeyIndex)?.code == KEYCODE_DELETE) {
+                                mOnKeyboardActionListener?.setDeleteRepeating(false)
+                            }
+                            removeMessages()
+                            dismissPopupKeyboard()
+                            mAbortKey = true
+                            showPreview(NOT_A_KEY)
+                            mRepeatKeyIndex = NOT_A_KEY
+                            return true
+                        }
+
                         mIsLongPressingSpace = false
                         mLastSpaceMoveX = 0
                         // Reset delete repeating flag when action is cancelled.

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1694,7 +1694,8 @@ class KeyboardView
             val keyIndex = getPressedKeyIndex(touchX, touchY)
 
             // Ignore all motion events until a DOWN, unless a swipe gesture is active.
-            if (mAbortKey && action != MotionEvent.ACTION_DOWN && action != MotionEvent.ACTION_CANCEL && !mSwipeActive) {
+            val isIgnoredAction = action != MotionEvent.ACTION_DOWN && action != MotionEvent.ACTION_CANCEL
+            if (mAbortKey && !mSwipeActive && isIgnoredAction) {
                 handled = true
             }
 

--- a/app/src/main/res/drawable/ic_swipe_left.xml
+++ b/app/src/main/res/drawable/ic_swipe_left.xml
@@ -1,0 +1,35 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="96dp"
+    android:height="96dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Semi-transparent key outlines representing keyboard keys -->
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1"
+        android:strokeAlpha="0.35"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 3.5,9 H 5.5 C 6.3,9 7,9.7 7,10.5 V 13.5 C 7,14.3 6.3,15 5.5,15 H 3.5 C 2.7,15 2,14.3 2,13.5 V 10.5 C 2,9.7 2.7,9 3.5,9 Z M 11,9 H 13 C 13.8,9 14.5,9.7 14.5,10.5 V 13.5 C 14.5,14.3 13.8,15 13,15 H 11 C 10.2,15 9.5,14.3 9.5,13.5 V 10.5 C 9.5,9.7 10.2,9 11,9 Z M 18.5,9 H 20.5 C 21.3,9 22,9.7 22,10.5 V 13.5 C 22,14.3 21.3,15 20.5,15 H 18.5 C 17.7,15 17,14.3 17,13.5 V 10.5 C 17,9.7 17.7,9 18.5,9 Z" />
+    
+    <!-- Gesture trail: horizontal sweep line from right key to left key -->
+    <path
+        android:strokeColor="#3F51B5"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 19.5,12 H 4.5" />
+        
+    <!-- Left-pointing Arrowhead -->
+    <path
+        android:strokeColor="#3F51B5"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 8.5,8 L 4.5,12 L 8.5,16" />
+        
+    <!-- Starting Touch Point Dot -->
+    <path
+        android:fillColor="#3F51B5"
+        android:pathData="M 19.5,12 m -1.5,0 a 1.5,1.5 0 1,0 3,0 a 1.5,1.5 0 1,0 -3,0" />
+</vector>

--- a/app/src/main/res/drawable/ic_swipe_right.xml
+++ b/app/src/main/res/drawable/ic_swipe_right.xml
@@ -1,0 +1,35 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="96dp"
+    android:height="96dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Semi-transparent key outlines representing keyboard keys -->
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1"
+        android:strokeAlpha="0.35"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 3.5,9 H 5.5 C 6.3,9 7,9.7 7,10.5 V 13.5 C 7,14.3 6.3,15 5.5,15 H 3.5 C 2.7,15 2,14.3 2,13.5 V 10.5 C 2,9.7 2.7,9 3.5,9 Z M 11,9 H 13 C 13.8,9 14.5,9.7 14.5,10.5 V 13.5 C 14.5,14.3 13.8,15 13,15 H 11 C 10.2,15 9.5,14.3 9.5,13.5 V 10.5 C 9.5,9.7 10.2,9 11,9 Z M 18.5,9 H 20.5 C 21.3,9 22,9.7 22,10.5 V 13.5 C 22,14.3 21.3,15 20.5,15 H 18.5 C 17.7,15 17,14.3 17,13.5 V 10.5 C 17,9.7 17.7,9 18.5,9 Z" />
+    
+    <!-- Gesture trail: horizontal sweep line from left key to right key -->
+    <path
+        android:strokeColor="#4CAF50"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 4.5,12 H 19.5" />
+        
+    <!-- Right-pointing Arrowhead -->
+    <path
+        android:strokeColor="#4CAF50"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 15.5,8 L 19.5,12 L 15.5,16" />
+        
+    <!-- Starting Touch Point Dot -->
+    <path
+        android:fillColor="#4CAF50"
+        android:pathData="M 4.5,12 m -1.5,0 a 1.5,1.5 0 1,0 3,0 a 1.5,1.5 0 1,0 -3,0" />
+</vector>

--- a/app/src/main/res/drawable/ic_swipe_success.xml
+++ b/app/src/main/res/drawable/ic_swipe_success.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="96dp"
+    android:height="96dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Semi-transparent key outlines representing keyboard keys -->
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1"
+        android:strokeAlpha="0.35"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 3.5,9 H 5.5 C 6.3,9 7,9.7 7,10.5 V 13.5 C 7,14.3 6.3,15 5.5,15 H 3.5 C 2.7,15 2,14.3 2,13.5 V 10.5 C 2,9.7 2.7,9 3.5,9 Z M 11,9 H 13 C 13.8,9 14.5,9.7 14.5,10.5 V 13.5 C 14.5,14.3 13.8,15 13,15 H 11 C 10.2,15 9.5,14.3 9.5,13.5 V 10.5 C 9.5,9.7 10.2,9 11,9 Z M 18.5,9 H 20.5 C 21.3,9 22,9.7 22,10.5 V 13.5 C 22,14.3 21.3,15 20.5,15 H 18.5 C 17.7,15 17,14.3 17,13.5 V 10.5 C 17,9.7 17.7,9 18.5,9 Z" />
+    
+    <!-- Success Checkmark -->
+    <path
+        android:strokeColor="#4CAF50"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 8.5,12.5 L 11,15 L 16.5,9.5" />
+</vector>

--- a/app/src/main/res/layout/input_method_view.xml
+++ b/app/src/main/res/layout/input_method_view.xml
@@ -707,4 +707,107 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/swipe_tutorial_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#F20F172A"
+        android:clickable="false"
+        android:focusable="false"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:id="@+id/tutorial_step_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="12dp"
+            android:clickable="false"
+            android:focusable="false"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/swipe_tutorial_close"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintVertical_chainStyle="packed">
+
+            <TextView
+                android:id="@+id/swipe_tutorial_progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Step 1 of 2"
+                android:textColor="#3B82F6"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                android:textAllCaps="true"
+                android:letterSpacing="0.1" />
+
+            <ImageView
+                android:id="@+id/swipe_tutorial_icon"
+                android:layout_width="72dp"
+                android:layout_height="72dp"
+                android:layout_marginTop="8dp"
+                android:src="@drawable/ic_swipe_left"
+                android:contentDescription="Gesture animation" />
+
+            <TextView
+                android:id="@+id/swipe_tutorial_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="Swipe Left to Delete"
+                android:textColor="@color/white"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/swipe_tutorial_desc"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="Swipe left anywhere on the keyboard to delete the last word."
+                android:textColor="#94A3B8"
+                android:textSize="13sp"
+                android:gravity="center" />
+
+            <TextView
+                android:id="@+id/swipe_tutorial_status"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="Practice: Type some letters or use our test word below!"
+                android:textColor="#10B981"
+                android:textSize="13sp"
+                android:textStyle="bold"
+                android:gravity="center" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/swipe_tutorial_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
+            android:text="Skip"
+            android:background="@drawable/cmd_key_background_rounded"
+            android:backgroundTint="@color/theme_scribe_blue"
+            android:textColor="@color/white"
+            android:paddingStart="32dp"
+            android:paddingEnd="32dp"
+            android:textAllCaps="false"
+            app:layout_constraintTop_toBottomOf="@+id/tutorial_step_container"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/testKeyboards/kotlin/be/scri/helpers/BackspaceHandlerTest.kt
+++ b/app/src/testKeyboards/kotlin/be/scri/helpers/BackspaceHandlerTest.kt
@@ -12,9 +12,6 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/testKeyboards/kotlin/be/scri/helpers/BackspaceHandlerTest.kt
+++ b/app/src/testKeyboards/kotlin/be/scri/helpers/BackspaceHandlerTest.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package be.scri.helpers
+
+import android.content.Context
+import android.view.inputmethod.InputConnection
+import androidx.test.core.app.ApplicationProvider
+import be.scri.services.GeneralKeyboardIME
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BackspaceHandlerTest {
+    private lateinit var context: Context
+    private lateinit var ime: GeneralKeyboardIME
+    private lateinit var inputConnection: InputConnection
+    private lateinit var backspaceHandler: BackspaceHandler
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        inputConnection = mockk(relaxed = true)
+        ime = mockk(relaxed = true)
+
+        every { ime.currentInputConnection } returns inputConnection
+        every { ime.applicationContext } returns context
+        every { ime.language } returns "English"
+
+        backspaceHandler = BackspaceHandler(ime)
+
+        mockkObject(PreferencesHelper)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `performSwipeDelete with word deletion disabled deletes single character`() {
+        every { PreferencesHelper.getIsWordByWordDeletionEnabled(any(), any()) } returns false
+        every { inputConnection.getTextBeforeCursor(any(), any()) } returns "Hello World"
+
+        backspaceHandler.performSwipeDelete()
+
+        // Should delete 1 character ("d")
+        verify { inputConnection.deleteSurroundingText(1, 0) }
+    }
+
+    @Test
+    fun `performSwipeDelete with word deletion enabled deletes last word`() {
+        every { PreferencesHelper.getIsWordByWordDeletionEnabled(any(), any()) } returns true
+        every { inputConnection.getTextBeforeCursor(any(), any()) } returns "Hello World "
+
+        backspaceHandler.performSwipeDelete()
+
+        // For "Hello World ", the last word is "World" plus trailing space " ", length = 6
+        verify { inputConnection.deleteSurroundingText(6, 0) }
+    }
+
+    @Test
+    fun `performSwipeRestore commits previously deleted chunk`() {
+        every { PreferencesHelper.getIsWordByWordDeletionEnabled(any(), any()) } returns false
+        every { inputConnection.getTextBeforeCursor(any(), any()) } returns "Hello World"
+
+        // Perform delete of "d"
+        backspaceHandler.performSwipeDelete()
+
+        // Perform restore
+        backspaceHandler.performSwipeRestore()
+
+        // Should commit "d" back
+        verify { inputConnection.commitText("d", 1) }
+    }
+
+    @Test
+    fun `clearUndoStack prevents restoration`() {
+        every { PreferencesHelper.getIsWordByWordDeletionEnabled(any(), any()) } returns false
+        every { inputConnection.getTextBeforeCursor(any(), any()) } returns "Hello World"
+
+        // Perform delete of "d"
+        backspaceHandler.performSwipeDelete()
+
+        // Clear stack
+        backspaceHandler.clearUndoStack()
+
+        // Perform restore
+        backspaceHandler.performSwipeRestore()
+
+        // Should NOT commit anything
+        verify(exactly = 0) { inputConnection.commitText(any(), any()) }
+    }
+}


### PR DESCRIPTION
Closes #622

## Summary

Implements swipe-based text editing and a one-time interactive onboarding tutorial
for Scribe Keyboard. Users can now swipe left to delete and swipe right to restore
text, with haptic feedback on each step. First-time users are guided through both
gestures via a live practice overlay before it dismisses itself.

---

## What's changed

### Swipe left — delete
- Swipe left anywhere on the keyboard to delete the previous word or character
- Deletion mode (word vs. character) follows the user's existing backspace preference
- Haptic tick fires on each `45px` step of travel
- Gesture registers after `80px` horizontal threshold; aborts default key click

### Swipe right — restore
- Swipe right to restore the most recently deleted block from a stack, in sequence
- Stack is cleared automatically on cursor movement or normal key input to prevent
  stale restoration context

### Interactive onboarding tutorial
- Shown once on first launch, controlled by `swipe_tutorial_shown` preference
- Overlay is non-blocking — touches pass through so users practice on the real keyboard
- `"Scribe "` is auto-inserted at tutorial start for immediate hands-on practice
- **Skip** dismisses at any step; **Got it!** dismisses from the success screen
- Both actions save the preference so the tutorial never reappears

---

## Tutorial steps

| Step | Instruction | Advances when |
|------|-------------|---------------|
| 1 | Swipe left to delete `"Scribe "` | Word successfully deleted |
| 2 | Swipe right to restore `"Scribe "` | Word successfully restored |
| ✅ | Tap **Got it!** to finish | Preference saved, overlay closed |

---

## Files changed

### Logic

| File | Changes |
|------|---------|
| `KeyboardView.kt` | Added `onSwipeLeft()` and `onSwipeRight()` to the action listener interface. Tracks horizontal gesture travel in `onModifiedTouchEvent()`, aborts default click handling during swipe, fires haptic feedback. |
| `BackspaceHandler.kt` | Introduced `deletedChunksStack` (`java.util.Stack`). Added `performSwipeDelete()` (push + delete) and `performSwipeRestore()` (pop + insert). Stack clears on cursor movement or direct key input. |
| `GeneralKeyboardIME.kt` | Declares `SwipeTutorialState` enum (`NOT_ACTIVE`, `SWIPE_LEFT_STEP`, `SWIPE_RIGHT_STEP`, `COMPLETED`). Routes gesture events, drives tutorial step progression, auto-inserts `"Scribe "` at tutorial start. |

### Layout & assets

| File | Changes |
|------|---------|
| `input_method_view.xml` | Set `android:clickable="false"` and `android:focusable="false"` on the tutorial overlay for touch pass-through. Redesigned to show one instruction, one illustration, and one action button at a time. |
| `ic_swipe_left.xml` | Updated — three-key outline with indigo/blue gesture trail. |
| `ic_swipe_right.xml` | Updated — three-key outline with emerald green gesture trail. |
| `ic_swipe_success.xml` | **New** — three-key outline with emerald green checkmark. |

### Tests

| File | Changes |
|------|---------|
| `BackspaceHandlerTest.kt` | JUnit/Robolectric tests covering stack push/pop behaviour, deletion offsets, character vs. word-by-word modes, and automatic stack clearing. |

---

## Testing

### Automated

```bash
./gradlew testKeyboardsDebugUnitTest
```

### Manual checklist

> Start from a fresh install or clear the `swipe_tutorial_shown` preference.

- [ ] Tutorial overlay appears on first launch with dark-slate translucent style
- [ ] `"Scribe "` is pre-typed in the active text field
- [ ] Keyboard keys respond to touch while the overlay is visible
- [ ] Swiping left deletes `"Scribe "` word-by-word with haptic feedback, then advances to step 2
- [ ] Swiping right restores `"Scribe "` with haptic feedback, then shows the success screen
- [ ] Tapping **Got it!** dismisses the overlay; normal typing and swipes work correctly
- [ ] Tapping **Skip** at any step dismisses the overlay and saves the preference
- [ ] Tutorial does not reappear on subsequent launches
- [ ] Swipe delete and restore work correctly outside the tutorial in normal use

---

## Screenshots

| Step 1 — Swipe left to delete | Step 2 — Swipe right to restore | Completion screen |
|:---:|:---:|:---:|
| <img width="719" height="1600" alt="Tutorial step 1 – swipe left to delete" src="https://github.com/user-attachments/assets/ab733fca-30c7-4c79-bd7f-7ff0838f031c" /> | <img width="719" height="1600" alt="Tutorial step 2 – swipe right to restore" src="https://github.com/user-attachments/assets/b3d84866-077d-49d7-b71f-ec062d8705f2" /> | <img width="719" height="1600" alt="Tutorial completion screen" src="https://github.com/user-attachments/assets/f637353a-6200-421e-a2f6-af04a59ada92" /> |
