### PR TITLE
Select Command Mode text command disappear when typing 

### DIFF
--- a/app/src/keyboards/java/be/scri/helpers/SuggestionHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/SuggestionHandler.kt
@@ -159,7 +159,9 @@ class SuggestionHandler(
      */
     fun clearLinguisticSuggestions() {
         linguisticSuggestionRunnable?.let { handler.removeCallbacks(it) }
-        ime.disableAutoSuggest()
+        if (ime.currentState != ScribeState.SELECT_COMMAND) {
+            ime.disableAutoSuggest()
+        }
         ime.nounTypeSuggestion = null
         ime.checkIfPluralWord = false
         ime.caseAnnotationSuggestion = null
@@ -174,9 +176,8 @@ class SuggestionHandler(
         emojiSuggestionRunnable?.let { handler.removeCallbacks(it) }
         linguisticSuggestionRunnable?.let { handler.removeCallbacks(it) }
 
-        ime.disableAutoSuggest()
-
         if (ime.currentState != ScribeState.SELECT_COMMAND) {
+            ime.disableAutoSuggest()
             ime.updateButtonVisibility(false)
         }
 

--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -1372,7 +1372,9 @@ abstract class GeneralKeyboardIME(
         this.wordSuggestions = wordSuggestions
 
         if (currentState != ScribeState.IDLE) {
-            uiManager.disableAutoSuggest(language)
+            if (currentState != ScribeState.SELECT_COMMAND) {
+                uiManager.disableAutoSuggest(language)
+            }
             return
         }
         val hasLinguisticSuggestions = nounTypeSuggestion != null || isPlural || caseAnnotationSuggestion != null || isSingularAndPlural


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This fixes the issue where when the user starts typing without selecting the option , translate option is hidden 
Fixes: #629 
