### PR TITLE
Fix keyboard background not updating with theme changes

### DIFF
--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -598,12 +598,16 @@ class KeyboardView
                         mBackgroundColor
                     }
 
+                val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+                val currentNightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                val isSystemDarkMode = currentNightMode == Configuration.UI_MODE_NIGHT_YES
+                val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkMode)
+
                 val miniKeyboardBackgroundColor =
-                    if (context.config.isUsingSystemTheme) {
-                        resources.getColor(R.color.default_key_color, context.theme)
-                    } else {
-                        resources.getColor(R.color.default_key_color, context.theme)
-                    }
+                    resources.getColor(
+                        if (isUserDarkMode) R.color.dark_keyboard_bg_color else R.color.light_keyboard_bg_color,
+                        context.theme,
+                    )
 
                 if (changedView.id == R.id.mini_keyboard_view) {
                     val previewBackground = background as LayerDrawable
@@ -614,7 +618,7 @@ class KeyboardView
 
                     previewBackground
                         .findDrawableByLayerId(R.id.button_background_stroke)
-                        .applyColorFilter(context.getColor(R.color.default_key_color))
+                        .applyColorFilter(miniKeyboardBackgroundColor)
 
                     background = previewBackground
                 } else {
@@ -1478,6 +1482,28 @@ class KeyboardView
                     mMiniKeyboard =
                         mMiniKeyboardContainer!!
                             .findViewById<View>(R.id.mini_keyboard_view) as KeyboardView
+                }
+
+                val sharedPref = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+                val currentNightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                val isSystemDarkMode = currentNightMode == Configuration.UI_MODE_NIGHT_YES
+                val isUserDarkMode = sharedPref.getBoolean("dark_mode", isSystemDarkMode)
+
+                val miniKeyboardBackgroundColor =
+                    resources.getColor(
+                        if (isUserDarkMode) R.color.dark_keyboard_bg_color else R.color.light_keyboard_bg_color,
+                        context.theme,
+                    )
+
+                mMiniKeyboard!!.background?.let { bg ->
+                    if (bg is LayerDrawable) {
+                        bg
+                            .findDrawableByLayerId(R.id.button_background_shape)
+                            ?.applyColorFilter(miniKeyboardBackgroundColor)
+                        bg
+                            .findDrawableByLayerId(R.id.button_background_stroke)
+                            ?.applyColorFilter(miniKeyboardBackgroundColor)
+                    }
                 }
 
                 getLocationInWindow(mCoordinates)

--- a/app/src/main/res/drawable/minikeyboard_background.xml
+++ b/app/src/main/res/drawable/minikeyboard_background.xml
@@ -12,7 +12,7 @@
             <stroke
                 android:width="1dp"
                 android:color="@color/divider_grey" />
-            <solid android:color="@color/special_key_dark" />
+            <solid android:color="@color/toolbar_background_color" />
             <corners android:radius="12dp" />
         </shape>
     </item>


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
Updates the keyboard background color to match the currently selected app theme, ensuring consistent appearance across light and dark modes.
Fixes: #632 