### PR TITLE
Fix adding hook in KeyboardView to dismiss the active popup keys on hide 

### DIFF
--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -630,6 +630,8 @@ class KeyboardView
                         background = ColorDrawable(toolbarColor)
                     }
                 }
+            } else {
+                closing()
             }
         }
 


### PR DESCRIPTION

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description
Add cleanup hook in KeyboardView's onVisibilityChanged to dismiss active popup keys on hide

Fixes- #634 
