### PR TITLE
Localize clipboard accessibility labels

### DIFF
--- a/app/src/main/res/layout/input_method_view.xml
+++ b/app/src/main/res/layout/input_method_view.xml
@@ -752,7 +752,7 @@ GeneralKeyboardIME.kt
                 android:layout_centerVertical="true"
                 android:layout_marginStart="@dimen/medium_margin"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:contentDescription="Close Clipboard"
+                android:contentDescription="@string/i18n.app.clipboard.close"
                 android:padding="@dimen/small_margin"
                 android:src="@drawable/ic_arrow_left_vector"
                 android:tint="@color/icon_color" />
@@ -779,7 +779,7 @@ GeneralKeyboardIME.kt
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="@dimen/medium_margin"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:contentDescription="Clear All"
+                android:contentDescription="@string/i18n.app.clipboard.clear_all"
                 android:padding="@dimen/small_margin"
                 android:src="@drawable/ic_delete_vector"
                 android:tint="#E53935" />

--- a/app/src/main/res/layout/input_method_view.xml
+++ b/app/src/main/res/layout/input_method_view.xml
@@ -752,7 +752,7 @@ GeneralKeyboardIME.kt
                 android:layout_centerVertical="true"
                 android:layout_marginStart="@dimen/medium_margin"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/i18n.app.clipboard.close"
+                android:contentDescription="@string/i18n.app.clipboard.close_clipboard"
                 android:padding="@dimen/small_margin"
                 android:src="@drawable/ic_arrow_left_vector"
                 android:tint="@color/icon_color" />

--- a/app/src/main/res/values/string.xml
+++ b/app/src/main/res/values/string.xml
@@ -150,6 +150,8 @@
         at time of usage, and a link to the license.</string>
     <string name="i18n.app.about.title">About</string>
     <string name="i18n.app.clipboard.clipboard_is_empty">Clipboard is empty</string>
+    <string name="i18n.app.clipboard.clear_all">Clear all</string>
+    <string name="i18n.app.clipboard.close">Close clipboard</string>
     <string name="i18n.app.clipboard.copied_to_clipboard">Copied to clipboard</string>
     <string name="i18n.app.clipboard.copy_to_clipboard">Copy to clipboard</string>
     <string name="i18n.app.clipboard.title">Clipboard</string>

--- a/app/src/main/res/values/string.xml
+++ b/app/src/main/res/values/string.xml
@@ -58,9 +58,9 @@
     <string name="i18n.app.about.legal.third_party.entry_simple_keyboard">Simple Keyboard\n• Author: Simple Mobile Tools\n• License: GPL-3.0\n• Link: https://github.com/SimpleMobileTools/Simple-Keyboard/blob/main/LICENSE</string>
     <string name="i18n.app.about.legal.third_party.text">The Scribe developers (SCRIBE) built the iOS application "Scribe - Language Keyboards" (SERVICE) using third party code. All source code used in the creation of this SERVICE comes from sources that allow its full use in the manner done so by the SERVICE. This section lists the source code on which the SERVICE was based as well as the coinciding licenses of each.\n\nThe following is a list of all used source code, the main author or authors of the code, the license under which it was released at time of usage, and a link to the license.</string>
     <string name="i18n.app.about.title">About</string>
-    <string name="i18n.app.clipboard.clipboard_is_empty">Clipboard is empty</string>
     <string name="i18n.app.clipboard.clear_all">Clear all</string>
-    <string name="i18n.app.clipboard.close">Close clipboard</string>
+    <string name="i18n.app.clipboard.clipboard_is_empty">Clipboard is empty</string>
+    <string name="i18n.app.clipboard.close_clipboard">Close clipboard</string>
     <string name="i18n.app.clipboard.copied_to_clipboard">Copied to clipboard</string>
     <string name="i18n.app.clipboard.copy_to_clipboard">Copy to clipboard</string>
     <string name="i18n.app.clipboard.title">Clipboard</string>


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [ ] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

Moves the clipboard panel close and clear-all content descriptions into string resources so TalkBack labels can be localized with the rest of the clipboard text.

Checked with `./gradlew :app:processKeyboardsDebugResources`.

### Related issue

- #641