### PR TITLE
feat: finalize floating keyboard option (#663)

### DIFF
--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -651,10 +651,6 @@ abstract class GeneralKeyboardIME(
         return isActionSearch || isUriType || hasSearchHint
     }
 
-    override fun isClipboardKeyEnabled(): Boolean = PreferencesHelper.getIsClipboardKeyEnabled(this, language)
-
-    override fun isFloatingKeyEnabled(): Boolean = PreferencesHelper.getIsFloatingKeyEnabled(this, language)
-
     private fun loadLanguageData() {
         val languageAlias = getLanguageAlias(language)
         dataContract = dbManagers.getLanguageContract(languageAlias)

--- a/app/src/main/java/be/scri/helpers/KeyboardBase.kt
+++ b/app/src/main/java/be/scri/helpers/KeyboardBase.kt
@@ -39,10 +39,6 @@ class KeyboardBase {
         fun isSearchBar(): Boolean
 
         fun isFloatingModeActive(): Boolean
-
-        fun isClipboardKeyEnabled(): Boolean
-
-        fun isFloatingKeyEnabled(): Boolean
     }
 
     /** Horizontal gap default for all rows  */

--- a/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/be/scri/helpers/PreferencesHelper.kt
@@ -26,8 +26,6 @@ object PreferencesHelper {
     private const val DEFAULT_CURRENCY = "default_currency"
     private const val HOLD_FOR_ALT_KEYS = "hold_for_alt_keys"
     private const val INCREASE_TEXT_SIZE = "increase_text_size"
-    private const val CLIPBOARD_KEY_ON_KEYBOARD = "clipboard_key_on_keyboard"
-    private const val FLOATING_KEY_ON_KEYBOARD = "floating_key_on_keyboard"
 
     /**
      * Sets the translation source language for a given language.
@@ -534,56 +532,6 @@ object PreferencesHelper {
     ): Boolean {
         val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
         return sharedPref.getBoolean(getLanguageSpecificPreferenceKey(HOLD_FOR_ALT_KEYS, language), true)
-    }
-
-    /**
-     * Sets the preference for showing or hiding the clipboard key on the keyboard.
-     */
-    fun setClipboardKeyPreference(
-        context: Context,
-        language: String,
-        enabled: Boolean,
-    ) {
-        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
-        sharedPref.edit {
-            putBoolean(getLanguageSpecificPreferenceKey(CLIPBOARD_KEY_ON_KEYBOARD, language), enabled)
-        }
-    }
-
-    /**
-     * Retrieves whether the clipboard key is enabled on the keyboard for a given language.
-     */
-    fun getIsClipboardKeyEnabled(
-        context: Context,
-        language: String,
-    ): Boolean {
-        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
-        return sharedPref.getBoolean(getLanguageSpecificPreferenceKey(CLIPBOARD_KEY_ON_KEYBOARD, language), true)
-    }
-
-    /**
-     * Sets the preference for showing or hiding the floating key on the keyboard.
-     */
-    fun setFloatingKeyPreference(
-        context: Context,
-        language: String,
-        enabled: Boolean,
-    ) {
-        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
-        sharedPref.edit {
-            putBoolean(getLanguageSpecificPreferenceKey(FLOATING_KEY_ON_KEYBOARD, language), enabled)
-        }
-    }
-
-    /**
-     * Retrieves whether the floating key is enabled on the keyboard for a given language.
-     */
-    fun getIsFloatingKeyEnabled(
-        context: Context,
-        language: String,
-    ): Boolean {
-        val sharedPref = context.getSharedPreferences(SCRIBE_PREFS, Context.MODE_PRIVATE)
-        return sharedPref.getBoolean(getLanguageSpecificPreferenceKey(FLOATING_KEY_ON_KEYBOARD, language), false)
     }
 
     /**

--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -109,19 +109,6 @@ fun LanguageSettingsScreen(
             )
         }
 
-    val clipboardKeyOnKeyboardState =
-        remember {
-            mutableStateOf(
-                PreferencesHelper.getIsClipboardKeyEnabled(context, language),
-            )
-        }
-
-    val floatingKeyOnKeyboardState =
-        remember {
-            mutableStateOf(
-                PreferencesHelper.getIsFloatingKeyEnabled(context, language),
-            )
-        }
     val wordByWordDeletionState =
         remember {
             mutableStateOf(
@@ -165,24 +152,6 @@ fun LanguageSettingsScreen(
                             context,
                             language,
                             shouldDisableAccentCharacter,
-                        )
-                    },
-                    toggleClipboardKeyOnKeyboard = clipboardKeyOnKeyboardState.value,
-                    onToggleClipboardKeyOnKeyboard = { isEnabled ->
-                        clipboardKeyOnKeyboardState.value = isEnabled
-                        PreferencesHelper.setClipboardKeyPreference(
-                            context,
-                            language,
-                            isEnabled,
-                        )
-                    },
-                    toggleFloatingKeyOnKeyboard = floatingKeyOnKeyboardState.value,
-                    onToggleFloatingKeyOnKeyboard = { isEnabled ->
-                        floatingKeyOnKeyboardState.value = isEnabled
-                        PreferencesHelper.setFloatingKeyPreference(
-                            context,
-                            language,
-                            isEnabled,
                         )
                     },
                     onCurrencySelect = onCurrencySelect,
@@ -374,17 +343,12 @@ private fun getFunctionalityListData(settings: FunctionalitySettings): List<Scri
  *
  * @return A list of [ScribeItem]s to be displayed in the UI.
  */
-@Suppress("LongParameterList", "UnusedParameter")
 private fun getLayoutListData(
     language: String,
     togglePeriodAndCommaState: Boolean,
     onTogglePeriodAndComma: (Boolean) -> Unit,
     toggleDisableAccentCharacter: Boolean,
     onToggleDisableAccentCharacter: (Boolean) -> Unit,
-    toggleClipboardKeyOnKeyboard: Boolean,
-    onToggleClipboardKeyOnKeyboard: (Boolean) -> Unit,
-    toggleFloatingKeyOnKeyboard: Boolean,
-    onToggleFloatingKeyOnKeyboard: (Boolean) -> Unit,
     onCurrencySelect: () -> Unit,
 ): List<ScribeItem> {
     val list: MutableList<ScribeItem> = mutableListOf()
@@ -411,14 +375,6 @@ private fun getLayoutListData(
         ),
     )
 
-    list.add(
-        ScribeItem.SwitchItem(
-            title = R.string.i18n_app_settings_keyboard_layout_floating_on_keyboard,
-            desc = R.string.i18n_app_settings_keyboard_layout_floating_on_keyboard_description,
-            state = toggleFloatingKeyOnKeyboard,
-            onToggle = onToggleFloatingKeyOnKeyboard,
-        ),
-    )
     list.add(
         ScribeItem.ClickableItem(
             title = R.string.i18n_app_settings_keyboard_layout_default_currency,

--- a/app/src/main/java/be/scri/views/KeyboardView.kt
+++ b/app/src/main/java/be/scri/views/KeyboardView.kt
@@ -1151,6 +1151,18 @@ class KeyboardView
                             key.icon = resources.getDrawable(drawableId)
                             key.icon!!.applyColorFilter(mTextColor)
                         } else {
+                            if (code == KeyboardBase.KEYCODE_FLOAT_TOGGLE) {
+                                val isFloating =
+                                    (context as? KeyboardBase.KeyboardContextProvider)?.isFloatingModeActive() == true ||
+                                        (mPopupParent?.context as? KeyboardBase.KeyboardContextProvider)?.isFloatingModeActive() == true
+                                val floatIconRes =
+                                    if (isFloating) {
+                                        R.drawable.ic_keyboard_dismiss
+                                    } else {
+                                        R.drawable.ic_float_keyboard
+                                    }
+                                key.icon = resources.getDrawable(floatIconRes, context.theme)
+                            }
                             val isIconOnlyKey =
                                 code == KEYCODE_DELETE ||
                                     code == KEYCODE_SHIFT ||

--- a/app/src/main/res/drawable/ic_keyboard_dismiss.xml
+++ b/app/src/main/res/drawable/ic_keyboard_dismiss.xml
@@ -4,6 +4,7 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:fillColor="@color/theme_scribe_blue"
-      android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6l-6,-6L7.41,8.59z"/>
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3z M19,19H5V5h14V19z M16.59,8.59L12,13.17L7.41,8.59L6,10l6,6l6,-6L16.59,8.59z"/>
 </vector>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,9 +14,5 @@
     <string name="drag_keyboard">Drag keyboard</string>
     <string name="clipboard">Clipboard</string>
     <string name="floating_keyboard">Floating keyboard</string>
-    <string name="i18n.app.settings.keyboard.layout.clipboard_on_keyboard">Clipboard key on keyboard</string>
-    <string name="i18n.app.settings.keyboard.layout.clipboard_on_keyboard_description">Include a key to access the clipboard on the main keyboard.</string>
-    <string name="i18n.app.settings.keyboard.layout.floating_on_keyboard">Floating key on keyboard</string>
-    <string name="i18n.app.settings.keyboard.layout.floating_on_keyboard_description">Include a key to float the keyboard UI on the main keyboard.</string>
 </resources>
 


### PR DESCRIPTION
## Description
This PR finalizes the floating keyboard feature as requested in #663 by updating the float toggle key icon behavior and removing obsolete layout setting options.

### Key Changes
1. **Dynamic Floating Key Icon**:
   - Updated `ic_keyboard_dismiss.xml` vector drawable to represent a **down chevron inside a square frame**.
   - Updated `KeyboardView.kt` so that when `KeyboardBase.KEYCODE_FLOAT_TOGGLE` is drawn, it dynamically shows:
     - **Down chevron in a square (`ic_keyboard_dismiss`)** when the keyboard is currently in floating mode.
     - **Move/float icon (`ic_float_keyboard`)** when the keyboard is docked.

2. **UI & Preferences Cleanup**:
   - Removed obsolete "Floating key on keyboard" layout switch option from `LanguageSettingsScreen.kt`.
   - Removed obsolete "Clipboard key on keyboard" layout preference options from `LanguageSettingsScreen.kt`.
   - Cleaned up `PreferencesHelper.kt` by removing `FLOATING_KEY_ON_KEYBOARD` and `CLIPBOARD_KEY_ON_KEYBOARD` constants, setters, and getters.
   - Removed `isFloatingKeyEnabled()` and `isClipboardKeyEnabled()` methods from `KeyboardContextProvider` interface in `KeyboardBase.kt` and `GeneralKeyboardIME.kt`.
   - Cleaned up unused string resources in `strings.xml`.

## Related Issue
Closes #663

## Verification & Testing
- Automated Gradle build test passed cleanly via `./gradlew assembleDebug`.
- Verified string resources and UI layout settings screen compiling without lint errors.

### Screenshots
<img width="309" alt="Floating mode down chevron in square key icon" src="https://github.com/user-attachments/assets/f9484be1-6c01-4ca6-8d1d-5d87fb68e25d" />
<img width="307" alt="Docked mode float key icon" src="https://github.com/user-attachments/assets/9dec421e-fec2-4b17-ae22-464019610eef" />
