### PR TITLE
feat: align LanguageSettingsScreen header and layout order with Figma designs 

### DIFF
--- a/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt
@@ -57,6 +57,7 @@ fun LanguageSettingsScreen(
     onTranslationLanguageSelect: () -> Unit,
     onCurrencySelect: () -> Unit,
     modifier: Modifier = Modifier,
+    onDefaultLayoutSelect: () -> Unit = {},
 ) {
     val context = LocalContext.current
 
@@ -164,6 +165,7 @@ fun LanguageSettingsScreen(
                         )
                     },
                     onCurrencySelect = onCurrencySelect,
+                    onDefaultLayoutSelect = onDefaultLayoutSelect,
                 ),
         )
 
@@ -249,8 +251,10 @@ fun LanguageSettingsScreen(
             items = getFunctionalityListData(functionalitySettings),
         )
 
+    val pageTitleText = "${stringResource(getLanguageStringFromi18n(language))} ${stringResource(R.string.i18n_app_settings_title).lowercase()}"
+
     ScribeBaseScreen(
-        pageTitle = stringResource(getLanguageStringFromi18n(language)),
+        pageTitle = pageTitleText,
         lastPage = stringResource(R.string.i18n_app_settings_title),
         onBackNavigation = onBackNavigation,
         modifier = modifier,
@@ -374,28 +378,18 @@ private fun getLayoutListData(
     toggleDisableAccentCharacter: Boolean,
     onToggleDisableAccentCharacter: (Boolean) -> Unit,
     onCurrencySelect: () -> Unit,
+    onDefaultLayoutSelect: () -> Unit = {},
 ): List<ScribeItem> {
     val list: MutableList<ScribeItem> = mutableListOf()
 
-    when (language) {
-        "German", "Swedish", "Spanish" -> {
-            list.add(
-                ScribeItem.SwitchItem(
-                    title = R.string.i18n_app_settings_keyboard_layout_disable_accent_characters,
-                    desc = R.string.i18n_app_settings_keyboard_layout_disable_accent_characters_description,
-                    state = toggleDisableAccentCharacter,
-                    onToggle = onToggleDisableAccentCharacter,
-                ),
-            )
-        }
-    }
-
     list.add(
-        ScribeItem.SwitchItem(
-            title = R.string.i18n_app_settings_keyboard_layout_period_and_comma,
-            desc = R.string.i18n_app_settings_keyboard_layout_period_and_comma_description,
-            state = togglePeriodAndCommaState,
-            onToggle = onTogglePeriodAndComma,
+        ScribeItem.ClickableItem(
+            title = R.string.i18n_app_settings_keyboard_layout_default_layout,
+            desc = R.string.i18n_app_settings_keyboard_layout_default_layout_description,
+            action = {
+                Log.d("Navigation", "onDefaultLayoutSelect clicked")
+                onDefaultLayoutSelect()
+            },
         ),
     )
 
@@ -409,6 +403,28 @@ private fun getLayoutListData(
             },
         ),
     )
+
+    list.add(
+        ScribeItem.SwitchItem(
+            title = R.string.i18n_app_settings_keyboard_layout_period_and_comma,
+            desc = R.string.i18n_app_settings_keyboard_layout_period_and_comma_description,
+            state = togglePeriodAndCommaState,
+            onToggle = onTogglePeriodAndComma,
+        ),
+    )
+
+    when (language) {
+        "German", "Swedish", "Spanish" -> {
+            list.add(
+                ScribeItem.SwitchItem(
+                    title = R.string.i18n_app_settings_keyboard_layout_disable_accent_characters,
+                    desc = R.string.i18n_app_settings_keyboard_layout_disable_accent_characters_description,
+                    state = toggleDisableAccentCharacter,
+                    onToggle = onToggleDisableAccentCharacter,
+                ),
+            )
+        }
+    }
 
     return list
 }


### PR DESCRIPTION
## Description
This PR addresses issue [#674](https://github.com/scribe-org/Scribe-Android/issues/674) by aligning the `LanguageSettingsScreen` UI layout and header title with the [official Figma designs](https://www.figma.com/design/c8945w2iyoPYVhsqW7vRn6/scribe_public_designs?node-id=513-1616).

### Key Improvements:
- **Header Title Formatting**: Updated the top page header title format from `{Language}` (e.g. `English`) to `{Language} settings` (e.g., **`Deutsch settings`**, **`English settings`**) as specified in the Figma design system.
- **Layout Section Item Reordering**: Re-ordered the list items under the **Layout** section in `getLayoutListData()` to match the exact Figma visual hierarchy:
  1. **Default keyboard** (`Default layout`)
  2. **Default currency symbol**
  3. **Period and comma on ABC**
  4. **Disable accent characters** (conditionally displayed for German, Swedish, and Spanish)
- **Extensible Navigation Callback**: Introduced an optional `onDefaultLayoutSelect` callback parameter to `LanguageSettingsScreen` for seamless future navigation handling.

---

## Related Issue
Closes #674

---

## Changes Made

| File / Location | Summary of Changes |
|---|---|
| **`app/src/main/java/be/scri/ui/screens/LanguageSettingsScreen.kt`** | • Updated `pageTitle` calculation to render `"{Language} settings"`.<br>• Added `Default keyboard` (`R.string.i18n_app_settings_keyboard_layout_default_layout`) item to `getLayoutListData()`.<br>• Reordered items in the **Layout** section to match Figma specs.<br>• Added optional `onDefaultLayoutSelect: () -> Unit = {}` callback parameter. |

---

## Screenshots & Visual Comparison

| Before (Past) | After (Current Implementation) |
|:---:|:---:|
| <img width="410" alt="Past Implementation" src="https://github.com/user-attachments/assets/f423f78e-9996-4989-9c24-7dc144f20fba" /> | <img width="410" alt="Current Figma Aligned Implementation" src="https://github.com/user-attachments/assets/8a668e85-c0e0-497d-8979-5cb744b9bad1" /> |

---

## Type of Change
- [x] UI / UX Enhancement (non-breaking visual update matching Figma designs.