### PR TITLE
feat: add recently used emojis section

### DIFF
--- a/app/src/keyboards/java/be/scri/helpers/KeyboardLanguageMappingConstants.kt
+++ b/app/src/keyboards/java/be/scri/helpers/KeyboardLanguageMappingConstants.kt
@@ -84,6 +84,7 @@ object KeyboardLanguageMappingConstants {
         mapOf(
             "EN" to
                 mapOf(
+                    "recently_used" to ENInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to ENInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to ENInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to ENInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,
@@ -96,6 +97,7 @@ object KeyboardLanguageMappingConstants {
                 ),
             "ES" to
                 mapOf(
+                    "recently_used" to ESInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to ESInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to ESInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to ESInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,
@@ -108,6 +110,7 @@ object KeyboardLanguageMappingConstants {
                 ),
             "DE" to
                 mapOf(
+                    "recently_used" to DEInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to DEInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to DEInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to DEInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,
@@ -120,6 +123,7 @@ object KeyboardLanguageMappingConstants {
                 ),
             "IT" to
                 mapOf(
+                    "recently_used" to ITInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to ITInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to ITInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to ITInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,
@@ -132,6 +136,7 @@ object KeyboardLanguageMappingConstants {
                 ),
             "FR" to
                 mapOf(
+                    "recently_used" to FRInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to FRInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to FRInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to FRInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,
@@ -144,6 +149,7 @@ object KeyboardLanguageMappingConstants {
                 ),
             "PT" to
                 mapOf(
+                    "recently_used" to PTInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to PTInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to PTInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to PTInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,
@@ -156,6 +162,7 @@ object KeyboardLanguageMappingConstants {
                 ),
             "RU" to
                 mapOf(
+                    "recently_used" to RUInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to RUInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to RUInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to RUInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,
@@ -168,6 +175,7 @@ object KeyboardLanguageMappingConstants {
                 ),
             "SV" to
                 mapOf(
+                    "recently_used" to SVInterfaceVariables.RECENTLY_USED_EMOJI_HEADER,
                     "smileys_emotion" to SVInterfaceVariables.SMILEYS_EMOTIONS_EMOJI_HEADER,
                     "people_body" to SVInterfaceVariables.PEOPLE_BODY_EMOJI_HEADER,
                     "animals_nature" to SVInterfaceVariables.ANIMALS_NATURE_EMOJI_HEADER,

--- a/app/src/keyboards/java/be/scri/helpers/RecentEmojiHelper.kt
+++ b/app/src/keyboards/java/be/scri/helpers/RecentEmojiHelper.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package be.scri.helpers
+
+import android.content.Context
+
+private const val PREFS_NAME = "recent_emojis"
+private const val KEY_RECENT = "recent_emoji_list"
+private const val MAX_RECENT = 30
+
+fun recordRecentEmoji(
+    context: Context,
+    emoji: String,
+) {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val current =
+        prefs
+            .getString(KEY_RECENT, "")!!
+            .split(",")
+            .filter { it.isNotBlank() }
+            .toMutableList()
+    current.remove(emoji)
+    current.add(0, emoji)
+    while (current.size > MAX_RECENT) current.removeAt(current.lastIndex)
+    prefs.edit().putString(KEY_RECENT, current.joinToString(",")).apply()
+}
+
+fun getRecentEmojis(context: Context): List<String> {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    return prefs.getString(KEY_RECENT, "")!!.split(",").filter { it.isNotBlank() }
+}

--- a/app/src/keyboards/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -90,4 +90,6 @@ object ENInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objects"
     const val SYMBOLS_EMOJI_HEADER = "Symbols"
     const val FLAGS_EMOJI_HEADER = "Flags"
+
+    const val RECENTLY_USED_EMOJI_HEADER = "Recently Used"
 }

--- a/app/src/keyboards/java/be/scri/helpers/english/ENInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/english/ENInterfaceVariables.kt
@@ -90,6 +90,5 @@ object ENInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objects"
     const val SYMBOLS_EMOJI_HEADER = "Symbols"
     const val FLAGS_EMOJI_HEADER = "Flags"
-
     const val RECENTLY_USED_EMOJI_HEADER = "Recently Used"
 }

--- a/app/src/keyboards/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -92,5 +92,5 @@ object FRInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objets"
     const val SYMBOLS_EMOJI_HEADER = "Symboles"
     const val FLAGS_EMOJI_HEADER = "Drapeaux"
-    const val RECENTLY_USED_EMOJI_HEADER = "Récemment utilisés"
+    const val RECENTLY_USED_EMOJI_HEADER = "Récemment Utilisés"
 }

--- a/app/src/keyboards/java/be/scri/helpers/french/FRInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/french/FRInterfaceVariables.kt
@@ -92,4 +92,5 @@ object FRInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objets"
     const val SYMBOLS_EMOJI_HEADER = "Symboles"
     const val FLAGS_EMOJI_HEADER = "Drapeaux"
+    const val RECENTLY_USED_EMOJI_HEADER = "Récemment utilisés"
 }

--- a/app/src/keyboards/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -91,5 +91,5 @@ object DEInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objekte"
     const val SYMBOLS_EMOJI_HEADER = "Symbole"
     const val FLAGS_EMOJI_HEADER = "Flaggen"
-    const val RECENTLY_USED_EMOJI_HEADER = "Zuletzt verwendet"
+    const val RECENTLY_USED_EMOJI_HEADER = "Zuletzt Verwendet"
 }

--- a/app/src/keyboards/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -91,6 +91,5 @@ object DEInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objekte"
     const val SYMBOLS_EMOJI_HEADER = "Symbole"
     const val FLAGS_EMOJI_HEADER = "Flaggen"
-
     const val RECENTLY_USED_EMOJI_HEADER = "Zuletzt verwendet"
 }

--- a/app/src/keyboards/java/be/scri/helpers/german/DEInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/german/DEInterfaceVariables.kt
@@ -91,4 +91,6 @@ object DEInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objekte"
     const val SYMBOLS_EMOJI_HEADER = "Symbole"
     const val FLAGS_EMOJI_HEADER = "Flaggen"
+
+    const val RECENTLY_USED_EMOJI_HEADER = "Zuletzt verwendet"
 }

--- a/app/src/keyboards/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -73,5 +73,5 @@ object ITInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Oggetti"
     const val SYMBOLS_EMOJI_HEADER = "Simboli"
     const val FLAGS_EMOJI_HEADER = "Bandiere"
-    const val RECENTLY_USED_EMOJI_HEADER = "Usati di recente"
+    const val RECENTLY_USED_EMOJI_HEADER = "Usati di Recente"
 }

--- a/app/src/keyboards/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -73,6 +73,5 @@ object ITInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Oggetti"
     const val SYMBOLS_EMOJI_HEADER = "Simboli"
     const val FLAGS_EMOJI_HEADER = "Bandiere"
-
     const val RECENTLY_USED_EMOJI_HEADER = "Usati di recente"
 }

--- a/app/src/keyboards/java/be/scri/helpers/italian/ITInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/italian/ITInterfaceVariables.kt
@@ -73,4 +73,6 @@ object ITInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Oggetti"
     const val SYMBOLS_EMOJI_HEADER = "Simboli"
     const val FLAGS_EMOJI_HEADER = "Bandiere"
+
+    const val RECENTLY_USED_EMOJI_HEADER = "Usati di recente"
 }

--- a/app/src/keyboards/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
@@ -73,4 +73,5 @@ object PTInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objetos"
     const val SYMBOLS_EMOJI_HEADER = "Símbolos"
     const val FLAGS_EMOJI_HEADER = "Bandeiras"
+    const val RECENTLY_USED_EMOJI_HEADER = "Usados recentemente"
 }

--- a/app/src/keyboards/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/portuguese/PTInterfaceVariables.kt
@@ -73,5 +73,5 @@ object PTInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objetos"
     const val SYMBOLS_EMOJI_HEADER = "Símbolos"
     const val FLAGS_EMOJI_HEADER = "Bandeiras"
-    const val RECENTLY_USED_EMOJI_HEADER = "Usados recentemente"
+    const val RECENTLY_USED_EMOJI_HEADER = "Usados Recentemente"
 }

--- a/app/src/keyboards/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -73,4 +73,5 @@ object RUInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Предметы"
     const val SYMBOLS_EMOJI_HEADER = "Символы"
     const val FLAGS_EMOJI_HEADER = "Флаги"
+    const val RECENTLY_USED_EMOJI_HEADER = "Недавно использованные"
 }

--- a/app/src/keyboards/java/be/scri/helpers/russian/RUInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/russian/RUInterfaceVariables.kt
@@ -73,5 +73,5 @@ object RUInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Предметы"
     const val SYMBOLS_EMOJI_HEADER = "Символы"
     const val FLAGS_EMOJI_HEADER = "Флаги"
-    const val RECENTLY_USED_EMOJI_HEADER = "Недавно использованные"
+    const val RECENTLY_USED_EMOJI_HEADER = "Недавно Использованные"
 }

--- a/app/src/keyboards/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -94,4 +94,6 @@ object ESInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objetos"
     const val SYMBOLS_EMOJI_HEADER = "Símbolos"
     const val FLAGS_EMOJI_HEADER = "Banderas"
+
+    const val RECENTLY_USED_EMOJI_HEADER = "Recently Used"
 }

--- a/app/src/keyboards/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/spanish/ESInterfaceVariables.kt
@@ -94,6 +94,5 @@ object ESInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objetos"
     const val SYMBOLS_EMOJI_HEADER = "Símbolos"
     const val FLAGS_EMOJI_HEADER = "Banderas"
-
-    const val RECENTLY_USED_EMOJI_HEADER = "Recently Used"
+    const val RECENTLY_USED_EMOJI_HEADER = "Usados Recientemente"
 }

--- a/app/src/keyboards/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -73,5 +73,5 @@ object SVInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objekt"
     const val SYMBOLS_EMOJI_HEADER = "Symboler"
     const val FLAGS_EMOJI_HEADER = "Flaggor"
-    const val RECENTLY_USED_EMOJI_HEADER = "Nyligen använda"
+    const val RECENTLY_USED_EMOJI_HEADER = "Nyligen Använda"
 }

--- a/app/src/keyboards/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
+++ b/app/src/keyboards/java/be/scri/helpers/swedish/SVInterfaceVariables.kt
@@ -73,4 +73,5 @@ object SVInterfaceVariables {
     const val OBJECTS_EMOJI_HEADER = "Objekt"
     const val SYMBOLS_EMOJI_HEADER = "Symboler"
     const val FLAGS_EMOJI_HEADER = "Flaggor"
+    const val RECENTLY_USED_EMOJI_HEADER = "Nyligen använda"
 }

--- a/app/src/keyboards/java/be/scri/helpers/ui/KeyboardUIManager.kt
+++ b/app/src/keyboards/java/be/scri/helpers/ui/KeyboardUIManager.kt
@@ -38,6 +38,7 @@ import be.scri.helpers.PreferencesHelper
 import be.scri.helpers.PreferencesHelper.getIsDarkModeOrNot
 import be.scri.helpers.english.ENInterfaceVariables.ALREADY_PLURAL_MSG
 import be.scri.helpers.getCategoryIconRes
+import be.scri.helpers.getRecentEmojis
 import be.scri.helpers.parseRawEmojiSpecsFile
 import be.scri.models.ScribeState
 import be.scri.services.GeneralKeyboardIME
@@ -878,8 +879,17 @@ class KeyboardUIManager(
         emojis: List<EmojiData>,
         language: String,
     ) {
+        val recentEmojiChars = getRecentEmojis(context)
+        val recentEmojiData = recentEmojiChars.mapNotNull { char -> emojis.find { it.emoji == char } }
+
         val emojiCategories = prepareEmojiCategories(emojis)
-        val emojiItems = prepareEmojiItems(emojiCategories)
+        val categoriesWithRecents =
+            if (recentEmojiData.isNotEmpty()) {
+                linkedMapOf("recently_used" to recentEmojiData) + emojiCategories
+            } else {
+                emojiCategories
+            }
+        val emojiItems = prepareEmojiItems(categoriesWithRecents)
         val categoryHeaders =
             (emojiCategoryHeaders["EN"] ?: emptyMap()) + (emojiCategoryHeaders[getLanguageAlias(language)] ?: emptyMap())
 
@@ -902,7 +912,7 @@ class KeyboardUIManager(
                 listener.onEmojiSelected(emojiData.emoji)
             }
 
-        setupEmojiCategoryStrip(emojiCategories, emojiItems, emojiLayoutManager)
+        setupEmojiCategoryStrip(categoriesWithRecents, emojiItems, emojiLayoutManager)
     }
 
     /**

--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -68,6 +68,7 @@ import be.scri.helpers.SuggestionHandler
 import be.scri.helpers.clipboard.ClipboardHandler
 import be.scri.helpers.data.AutocompletionDataManager
 import be.scri.helpers.english.ENInterfaceVariables.ALREADY_PLURAL_MSG
+import be.scri.helpers.recordRecentEmoji
 import be.scri.helpers.ui.KeyboardUIManager
 import be.scri.models.ScribeLanguage
 import be.scri.models.ScribeState
@@ -872,6 +873,7 @@ abstract class GeneralKeyboardIME(
 
     override fun onEmojiSelected(emoji: String) {
         if (emoji.isNotEmpty()) {
+            recordRecentEmoji(this, emoji)
             insertEmoji(emoji, currentInputConnection, emojiKeywords, emojiMaxKeywordLength)
         }
     }

--- a/app/src/main/java/be/scri/helpers/EmojiHelper.kt
+++ b/app/src/main/java/be/scri/helpers/EmojiHelper.kt
@@ -94,5 +94,6 @@ fun getCategoryIconRes(category: String): Int =
         "objects" -> R.drawable.ic_emoji_objects
         "symbols" -> R.drawable.ic_emoji_symbols
         "flags" -> R.drawable.ic_emoji_flags
+        "recently_used" -> R.drawable.counter_clockwise_icon
         else -> R.drawable.ic_emoji_vector
     }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->
Added a recently used emoji keyboard functionality, along with a "Recently Used" header, for all `InterfaceVariables.kt` files for each of the languages.
Changes:
* Added `RECENTLY_USED_EMOJI_HEADER` to each `InterfaceVariables.kt` for localized headers
* Added `RecentEmojiHelper.kt` to persist recently used emojis (checking for duplicates, max emoji values at 30, most recent first)
* Updated `GeneralKeyboardIME.kt` and `KeyboardUIManager.kt` to record selections and add "Recently Used" section above existing categories
* Added category strip icon for "Recently Used" in `EmojiHelper.kt`

### Related issue

<!--- Scribe-Android prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

-Closes #654

