### PR TITLE
refactor: introduce KeyboardIMEContext interface contract (Part 16) - #426

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,3 +94,4 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 ### ♻️ Code Refactoring
 
 - Code quality improvements were continuously done to assure that the application is easy to maintain and meets Kotlin standards ([#426](https://github.com/scribe-org/Scribe-Android/issues/426)).
+- Introduced `KeyboardIMEContext` interface contract to decouple handler dependencies from the concrete `GeneralKeyboardIME` class ([#426](https://github.com/scribe-org/Scribe-Android/issues/426)).

--- a/app/src/keyboards/java/be/scri/helpers/AutocompletionHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/AutocompletionHandler.kt
@@ -5,12 +5,11 @@ package be.scri.helpers
 import android.os.Handler
 import android.os.Looper
 import be.scri.models.ScribeState
-import be.scri.services.GeneralKeyboardIME
 
 /**
  * Handles autocompletion when user is typing.
  *
- * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
+ * @property ime The [KeyboardIMEContext] instance this handler is associated with.
  */
 class AutocompletionHandler(
     private val ime: KeyboardIMEContext,

--- a/app/src/keyboards/java/be/scri/helpers/AutocompletionHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/AutocompletionHandler.kt
@@ -13,7 +13,7 @@ import be.scri.services.GeneralKeyboardIME
  * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
  */
 class AutocompletionHandler(
-    private val ime: GeneralKeyboardIME,
+    private val ime: KeyboardIMEContext,
 ) {
     private val handler = Handler(Looper.getMainLooper())
     private var autocompleteRunnable: Runnable? = null

--- a/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
@@ -17,7 +17,7 @@ import be.scri.services.GeneralKeyboardIME.Companion.MAX_TEXT_LENGTH
  * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
  */
 class BackspaceHandler(
-    private val ime: GeneralKeyboardIME,
+    private val ime: KeyboardIMEContext,
 ) {
     /**
      * Track if the delete key is currently being repeated (long press).
@@ -45,9 +45,9 @@ class BackspaceHandler(
         if (isCommandBar) {
             handleCommandBarDelete()
         } else {
-            val inputConnection = ime.currentInputConnection ?: return
+            val inputConnection = ime.getInputConnection() ?: return
             if (TextUtils.isEmpty(inputConnection.getSelectedText(0))) {
-                val isWordByWordEnabled = getIsWordByWordDeletionEnabled(ime.applicationContext, ime.language)
+                val isWordByWordEnabled = getIsWordByWordDeletionEnabled(ime.imeContext, ime.language)
                 // Only use word-by-word deletion on long press when the feature is enabled.
                 if (isWordByWordEnabled && isLongPress) {
                     deleteWordByWord(inputConnection)

--- a/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/BackspaceHandler.kt
@@ -2,19 +2,17 @@
 
 package be.scri.helpers
 
-import android.text.TextUtils
 import android.view.inputmethod.InputConnection
+import be.scri.helpers.KeyboardIMEContext.Companion.MAX_TEXT_LENGTH
 import be.scri.helpers.PreferencesHelper.getIsWordByWordDeletionEnabled
 import be.scri.models.ScribeState
-import be.scri.services.GeneralKeyboardIME
-import be.scri.services.GeneralKeyboardIME.Companion.MAX_TEXT_LENGTH
 
 /**
- * Handles backspace/delete events for the [GeneralKeyboardIME].
+ * Handles backspace/delete events for keyboard services implementing [KeyboardIMEContext].
  * Encapsulates logic for single character deletion, word-by-word deletion,
  * command bar deletion, and repeating delete state.
  *
- * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
+ * @property ime The [KeyboardIMEContext] instance this handler is associated with.
  */
 class BackspaceHandler(
     private val ime: KeyboardIMEContext,
@@ -46,7 +44,7 @@ class BackspaceHandler(
             handleCommandBarDelete()
         } else {
             val inputConnection = ime.getInputConnection() ?: return
-            if (TextUtils.isEmpty(inputConnection.getSelectedText(0))) {
+            if (inputConnection.getSelectedText(0).isNullOrEmpty()) {
                 val isWordByWordEnabled = getIsWordByWordDeletionEnabled(ime.imeContext, ime.language)
                 // Only use word-by-word deletion on long press when the feature is enabled.
                 if (isWordByWordEnabled && isLongPress) {

--- a/app/src/keyboards/java/be/scri/helpers/FloatingKeyboardHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/FloatingKeyboardHandler.kt
@@ -17,13 +17,12 @@ import android.view.WindowManager
 import androidx.core.content.ContextCompat
 import be.scri.R
 import be.scri.helpers.PreferencesHelper.getIsDarkModeOrNot
-import be.scri.services.GeneralKeyboardIME
 
 /**
  * Manages floating keyboard state, resize handles, touch listeners, and layout transitions
- * for [GeneralKeyboardIME].
+ * for keyboard services implementing [KeyboardIMEContext].
  *
- * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
+ * @property ime The [KeyboardIMEContext] instance this handler is associated with.
  */
 class FloatingKeyboardHandler(
     private val ime: KeyboardIMEContext,
@@ -173,7 +172,7 @@ class FloatingKeyboardHandler(
 
             dragBar.visibility = View.VISIBLE
 
-            if (modeChanged) ime.recreateKeyboardPublic()
+            if (modeChanged) ime.recreateKeyboard()
 
             card.post {
                 disableParentClipping(root)
@@ -232,7 +231,7 @@ class FloatingKeyboardHandler(
 
             dragBar.visibility = View.GONE
 
-            if (modeChanged) ime.recreateKeyboardPublic()
+            if (modeChanged) ime.recreateKeyboard()
 
             card.translationX = 0f
             card.translationY = 0f

--- a/app/src/keyboards/java/be/scri/helpers/FloatingKeyboardHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/FloatingKeyboardHandler.kt
@@ -26,7 +26,7 @@ import be.scri.services.GeneralKeyboardIME
  * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
  */
 class FloatingKeyboardHandler(
-    private val ime: GeneralKeyboardIME,
+    private val ime: KeyboardIMEContext,
 ) {
     var isFloatingMode: Boolean = false
         private set
@@ -57,17 +57,18 @@ class FloatingKeyboardHandler(
     private var isResizing = false
 
     fun initFloatingMode() {
-        isFloatingMode = PreferencesHelper.getIsFloatingModeEnabled(ime, ime.language)
+        isFloatingMode = PreferencesHelper.getIsFloatingModeEnabled(ime.imeContext, ime.language)
         lastAppliedFloatingMode = null
         applyFloatingModeState()
     }
 
     fun toggleFloatingMode() {
         isFloatingMode = !isFloatingMode
-        PreferencesHelper.setIsFloatingModeEnabled(ime, ime.language, isFloatingMode)
+        PreferencesHelper.setIsFloatingModeEnabled(ime.imeContext, ime.language, isFloatingMode)
         lastAppliedFloatingMode = null
         applyFloatingModeState()
-        ime.window
+        ime
+            .getImeWindow()
             ?.window
             ?.decorView
             ?.requestLayout()
@@ -76,10 +77,11 @@ class FloatingKeyboardHandler(
     fun disableFloatingMode() {
         if (isFloatingMode) {
             isFloatingMode = false
-            PreferencesHelper.setIsFloatingModeEnabled(ime, ime.language, isFloatingMode)
+            PreferencesHelper.setIsFloatingModeEnabled(ime.imeContext, ime.language, isFloatingMode)
             lastAppliedFloatingMode = null
             applyFloatingModeState()
-            ime.window
+            ime
+                .getImeWindow()
                 ?.window
                 ?.decorView
                 ?.requestLayout()
@@ -90,9 +92,9 @@ class FloatingKeyboardHandler(
         if (!ime.isUiManagerInitialized) return
         val card = ime.binding.keyboardCard
         val dragBar = ime.binding.floatingDragBar
-        val density = ime.resources.displayMetrics.density
+        val density = ime.getImeResources().displayMetrics.density
         val root = ime.binding.root
-        val win = ime.window?.window
+        val win = ime.getImeWindow()?.window
 
         val modeChanged = lastAppliedFloatingMode != isFloatingMode
         lastAppliedFloatingMode = isFloatingMode
@@ -132,8 +134,8 @@ class FloatingKeyboardHandler(
                 card.layoutParams = params
             }
 
-            val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime, ime.language)
-            val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime, ime.language)
+            val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime.imeContext, ime.language)
+            val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime.imeContext, ime.language)
             card.scaleX = scaleFactorX
             card.scaleY = scaleFactorY
             card.alpha = 1.0f
@@ -150,9 +152,9 @@ class FloatingKeyboardHandler(
                 ime.binding.resizeHandleBottomRight.visibility = View.GONE
             }
 
-            val isDarkMode = getIsDarkModeOrNot(ime)
+            val isDarkMode = getIsDarkModeOrNot(ime.imeContext)
             val kbBgColorRes = if (isDarkMode) R.color.dark_keyboard_bg_color else R.color.light_keyboard_bg_color
-            val kbBgColor = ContextCompat.getColor(ime, kbBgColorRes)
+            val kbBgColor = ContextCompat.getColor(ime.imeContext, kbBgColorRes)
 
             val floatingBg =
                 GradientDrawable().apply {
@@ -175,15 +177,15 @@ class FloatingKeyboardHandler(
 
             card.post {
                 disableParentClipping(root)
-                var storedX = PreferencesHelper.getFloatingX(ime, ime.language)
-                var storedY = PreferencesHelper.getFloatingY(ime, ime.language)
-                val currentScaleX = PreferencesHelper.getFloatingScaleX(ime, ime.language)
-                val currentScaleY = PreferencesHelper.getFloatingScaleY(ime, ime.language)
+                var storedX = PreferencesHelper.getFloatingX(ime.imeContext, ime.language)
+                var storedY = PreferencesHelper.getFloatingY(ime.imeContext, ime.language)
+                val currentScaleX = PreferencesHelper.getFloatingScaleX(ime.imeContext, ime.language)
+                val currentScaleY = PreferencesHelper.getFloatingScaleY(ime.imeContext, ime.language)
 
                 if (storedY == 0f) storedY = 100f * density
 
-                val screenWidth = ime.resources.displayMetrics.widthPixels
-                val screenHeight = ime.resources.displayMetrics.heightPixels
+                val screenWidth = ime.getImeResources().displayMetrics.widthPixels
+                val screenHeight = ime.getImeResources().displayMetrics.heightPixels
                 val cardWidth = card.width.toFloat()
                 val cardHeight = card.height.toFloat()
 
@@ -222,9 +224,9 @@ class FloatingKeyboardHandler(
             card.scaleY = 1.0f
             card.alpha = 1.0f
 
-            val isDarkMode = getIsDarkModeOrNot(ime)
+            val isDarkMode = getIsDarkModeOrNot(ime.imeContext)
             val kbBgColorRes = if (isDarkMode) R.color.dark_keyboard_bg_color else R.color.light_keyboard_bg_color
-            card.background = ColorDrawable(ContextCompat.getColor(ime, kbBgColorRes))
+            card.background = ColorDrawable(ContextCompat.getColor(ime.imeContext, kbBgColorRes))
             card.elevation = 0f
             card.clipToOutline = false
 
@@ -276,7 +278,9 @@ class FloatingKeyboardHandler(
     ) {
         val card = ime.binding.keyboardCard
         val screenHeight =
-            ime.resources.displayMetrics.heightPixels
+            ime
+                .getImeResources()
+                .displayMetrics.heightPixels
                 .toFloat()
 
         val cardWidth = card.width.toFloat()
@@ -368,7 +372,9 @@ class FloatingKeyboardHandler(
     ) {
         val card = ime.binding.keyboardCard
         val screenHeight =
-            ime.resources.displayMetrics.heightPixels
+            ime
+                .getImeResources()
+                .displayMetrics.heightPixels
                 .toFloat()
         val cardHeight = card.height.toFloat()
 
@@ -391,8 +397,8 @@ class FloatingKeyboardHandler(
 
                     initialTouchX = event.rawX
                     initialTouchY = event.rawY
-                    initialScaleX = PreferencesHelper.getFloatingScaleX(ime, ime.language)
-                    initialScaleY = PreferencesHelper.getFloatingScaleY(ime, ime.language)
+                    initialScaleX = PreferencesHelper.getFloatingScaleX(ime.imeContext, ime.language)
+                    initialScaleY = PreferencesHelper.getFloatingScaleY(ime.imeContext, ime.language)
 
                     val viewId = view.id
                     dragFactorX =
@@ -416,8 +422,8 @@ class FloatingKeyboardHandler(
                     card.animate().cancel()
                     card.alpha = 0.7f
 
-                    val density = ime.resources.displayMetrics.density
-                    val activeColor = ContextCompat.getColor(ime, R.color.theme_scribe_blue)
+                    val density = ime.getImeResources().displayMetrics.density
+                    val activeColor = ContextCompat.getColor(ime.imeContext, R.color.theme_scribe_blue)
                     (card.background as? GradientDrawable)?.setStroke((2.5f * density).toInt(), activeColor)
 
                     val location = IntArray(2)
@@ -463,16 +469,18 @@ class FloatingKeyboardHandler(
                     val card = ime.binding.keyboardCard
                     val finalScaleX = card.scaleX
                     val finalScaleY = card.scaleY
-                    PreferencesHelper.setFloatingScaleX(ime, ime.language, finalScaleX)
-                    PreferencesHelper.setFloatingScaleY(ime, ime.language, finalScaleY)
+                    PreferencesHelper.setFloatingScaleX(ime.imeContext, ime.language, finalScaleX)
+                    PreferencesHelper.setFloatingScaleY(ime.imeContext, ime.language, finalScaleY)
 
                     val screenHeight =
-                        ime.resources.displayMetrics.heightPixels
+                        ime
+                            .getImeResources()
+                            .displayMetrics.heightPixels
                             .toFloat()
                     val cardHeight = card.height.toFloat()
                     val liveY = (screenHeight - cardHeight * finalScaleY) / 2f - card.translationY
-                    PreferencesHelper.setFloatingX(ime, ime.language, card.translationX)
-                    PreferencesHelper.setFloatingY(ime, ime.language, liveY)
+                    PreferencesHelper.setFloatingX(ime.imeContext, ime.language, card.translationX)
+                    PreferencesHelper.setFloatingY(ime.imeContext, ime.language, liveY)
 
                     applyFloatingModeState()
                     card
@@ -502,17 +510,17 @@ class FloatingKeyboardHandler(
                     card.animate().cancel()
                     card.alpha = 0.7f
 
-                    val density = ime.resources.displayMetrics.density
-                    val activeColor = ContextCompat.getColor(ime, R.color.theme_scribe_blue)
+                    val density = ime.getImeResources().displayMetrics.density
+                    val activeColor = ContextCompat.getColor(ime.imeContext, R.color.theme_scribe_blue)
                     (card.background as? GradientDrawable)?.setStroke((2.5f * density).toInt(), activeColor)
 
-                    val displayMetrics = ime.resources.displayMetrics
+                    val displayMetrics = ime.getImeResources().displayMetrics
                     val screenWidth = displayMetrics.widthPixels
                     val screenHeight = displayMetrics.heightPixels
                     val cardWidth = card.width.toFloat()
                     val cardHeight = card.height.toFloat()
-                    val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime, ime.language)
-                    val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime, ime.language)
+                    val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime.imeContext, ime.language)
+                    val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime.imeContext, ime.language)
 
                     maxTranslationX = (screenWidth - cardWidth * scaleFactorX) / 2f
                     minTranslationX = -maxTranslationX
@@ -520,8 +528,8 @@ class FloatingKeyboardHandler(
                     minTranslationY = 0f
                     maxTranslationY = screenHeight.toFloat() - cardHeight * scaleFactorY
 
-                    initialTranslationX = PreferencesHelper.getFloatingX(ime, ime.language).coerceInSafe(minTranslationX, maxTranslationX)
-                    initialTranslationY = PreferencesHelper.getFloatingY(ime, ime.language).coerceInSafe(minTranslationY, maxTranslationY)
+                    initialTranslationX = PreferencesHelper.getFloatingX(ime.imeContext, ime.language).coerceInSafe(minTranslationX, maxTranslationX)
+                    initialTranslationY = PreferencesHelper.getFloatingY(ime.imeContext, ime.language).coerceInSafe(minTranslationY, maxTranslationY)
 
                     showCorners()
                     true
@@ -536,19 +544,19 @@ class FloatingKeyboardHandler(
                     targetX = targetX.coerceInSafe(minTranslationX, maxTranslationX)
                     targetY = targetY.coerceInSafe(minTranslationY, maxTranslationY)
 
-                    val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime, ime.language)
-                    val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime, ime.language)
+                    val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime.imeContext, ime.language)
+                    val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime.imeContext, ime.language)
                     updateFloatingViewsPosition(targetX, targetY, scaleFactorX, scaleFactorY)
 
                     val card = ime.binding.keyboardCard
-                    val density = ime.resources.displayMetrics.density
+                    val density = ime.getImeResources().displayMetrics.density
                     val isNearBottom = targetY < 60f * density
                     if (isNearBottom) {
-                        val dockColor = ContextCompat.getColor(ime, R.color.theme_scribe_blue)
+                        val dockColor = ContextCompat.getColor(ime.imeContext, R.color.theme_scribe_blue)
                         (card.background as? GradientDrawable)?.setStroke((4.0f * density).toInt(), dockColor)
                         card.alpha = 0.85f
                     } else {
-                        val activeColor = ContextCompat.getColor(ime, R.color.theme_scribe_blue)
+                        val activeColor = ContextCompat.getColor(ime.imeContext, R.color.theme_scribe_blue)
                         (card.background as? GradientDrawable)?.setStroke((2.5f * density).toInt(), activeColor)
                         card.alpha = 0.7f
                     }
@@ -563,9 +571,9 @@ class FloatingKeyboardHandler(
                     finalTargetX = finalTargetX.coerceInSafe(minTranslationX, maxTranslationX)
                     finalTargetY = finalTargetY.coerceInSafe(minTranslationY, maxTranslationY)
 
-                    val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime, ime.language)
-                    val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime, ime.language)
-                    val density = ime.resources.displayMetrics.density
+                    val scaleFactorX = PreferencesHelper.getFloatingScaleX(ime.imeContext, ime.language)
+                    val scaleFactorY = PreferencesHelper.getFloatingScaleY(ime.imeContext, ime.language)
+                    val density = ime.getImeResources().displayMetrics.density
                     val isNearBottom = finalTargetY < 60f * density
 
                     val card = ime.binding.keyboardCard
@@ -574,8 +582,8 @@ class FloatingKeyboardHandler(
                         disableFloatingMode()
                     } else {
                         updateFloatingViewsPosition(finalTargetX, finalTargetY, scaleFactorX, scaleFactorY)
-                        PreferencesHelper.setFloatingX(ime, ime.language, finalTargetX)
-                        PreferencesHelper.setFloatingY(ime, ime.language, finalTargetY)
+                        PreferencesHelper.setFloatingX(ime.imeContext, ime.language, finalTargetX)
+                        PreferencesHelper.setFloatingY(ime.imeContext, ime.language, finalTargetY)
                         applyFloatingModeState()
                     }
 

--- a/app/src/keyboards/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/KeyHandler.kt
@@ -5,16 +5,17 @@ package be.scri.helpers
 import android.content.Context
 import android.util.Log
 import android.view.inputmethod.InputConnection
+import be.scri.helpers.KeyboardIMEContext.Companion.COMMIT_TEXT_CURSOR_POSITION
+import be.scri.helpers.KeyboardIMEContext.Companion.MAX_TEXT_LENGTH
 import be.scri.models.ScribeState
-import be.scri.services.GeneralKeyboardIME
 
 /**
- * Handles key events for the [GeneralKeyboardIME].
+ * Handles key events for keyboard services implementing [KeyboardIMEContext].
  * This class processes raw key codes, determines the appropriate action based on the
  * current keyboard state and the key pressed, and delegates to specific handlers
- * or directly interacts with the [GeneralKeyboardIME] instance.
+ * or directly interacts with the [KeyboardIMEContext] instance.
  *
- * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
+ * @property ime The [KeyboardIMEContext] instance this handler is associated with.
  */
 @Suppress("TooManyFunctions")
 class KeyHandler(
@@ -42,12 +43,8 @@ class KeyHandler(
         code: Int,
         language: String,
     ) {
-        val inputConnection =
-            ime.getInputConnection() ?: run {
-                wasLastKeySpace = false
-                return
-            }
-        if (!isValidState(inputConnection)) {
+        val inputConnection = ime.getInputConnection()
+        if (inputConnection == null || ime.keyboard == null) {
             wasLastKeySpace = false
             return
         }
@@ -165,18 +162,6 @@ class KeyHandler(
     }
 
     /**
-     * Checks if the IME is in a valid state to process key events.
-     * A valid state requires a non-null keyboard instance and an active input connection.
-     *
-     * @param inputConnection The current input connection.
-     *
-     * @return true if the state is valid, false otherwise.
-     */
-    private fun isValidState(inputConnection: InputConnection?): Boolean =
-        ime.keyboard != null &&
-            inputConnection != null
-
-    /**
      * Resets the shift key's double-tap timestamp if the pressed key is not the shift key itself.
      * This is used to manage the "shift lock on double-tap" feature.
      *
@@ -194,7 +179,7 @@ class KeyHandler(
      * @param inputConnection The active input connection.
      */
     private fun commitTab(inputConnection: InputConnection) {
-        inputConnection.commitText("\t", GeneralKeyboardIME.COMMIT_TEXT_CURSOR_POSITION)
+        inputConnection.commitText("\t", COMMIT_TEXT_CURSOR_POSITION)
     }
 
     /**
@@ -277,10 +262,10 @@ class KeyHandler(
     private fun handleNavigationKey(code: Int) {
         val isRight = code == KeyboardBase.KEYCODE_RIGHT_ARROW
         ime.getInputConnection()?.let { ic ->
-            val currentPos = ic.getTextBeforeCursor(GeneralKeyboardIME.MAX_TEXT_LENGTH, 0)?.length ?: 0
+            val currentPos = ic.getTextBeforeCursor(MAX_TEXT_LENGTH, 0)?.length ?: 0
             val newPos =
                 if (isRight) {
-                    val textAfter = ic.getTextAfterCursor(GeneralKeyboardIME.MAX_TEXT_LENGTH, 0)?.toString() ?: ""
+                    val textAfter = ic.getTextAfterCursor(MAX_TEXT_LENGTH, 0)?.toString() ?: ""
                     (currentPos + 1).coerceAtMost(currentPos + textAfter.length)
                 } else {
                     (currentPos - 1).coerceAtLeast(0)

--- a/app/src/keyboards/java/be/scri/helpers/KeyHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/KeyHandler.kt
@@ -18,7 +18,7 @@ import be.scri.services.GeneralKeyboardIME
  */
 @Suppress("TooManyFunctions")
 class KeyHandler(
-    private val ime: GeneralKeyboardIME,
+    private val ime: KeyboardIMEContext,
 ) {
     private val suggestionHandler = ime.suggestionHandler
     private val spaceKeyProcessor = SpaceKeyProcessor(ime, suggestionHandler)
@@ -42,7 +42,11 @@ class KeyHandler(
         code: Int,
         language: String,
     ) {
-        val inputConnection = ime.currentInputConnection
+        val inputConnection =
+            ime.getInputConnection() ?: run {
+                wasLastKeySpace = false
+                return
+            }
         if (!isValidState(inputConnection)) {
             wasLastKeySpace = false
             return
@@ -230,8 +234,8 @@ class KeyHandler(
      * Handles the currency symbol key press. It outputs the user's selected currency symbol for the current language.
      */
     private fun handleCurrencyKey(language: String) {
-        val currencySymbol = PreferencesHelper.getDefaultCurrencySymbol(ime.applicationContext, language)
-        ime.currentInputConnection?.commitText(currencySymbol, 1)
+        val currencySymbol = PreferencesHelper.getDefaultCurrencySymbol(ime.imeContext, language)
+        ime.getInputConnection()?.commitText(currencySymbol, 1)
 
         // Process emoji suggestions if in idle state.
         if (ime.currentState == ScribeState.IDLE) {
@@ -261,7 +265,7 @@ class KeyHandler(
      * It delegates the logic to the IME and clears any active suggestions.
      */
     private fun handleModeChangeKey() {
-        ime.handleModeChange(ime.keyboardMode, ime.keyboardView, ime)
+        ime.handleModeChange(ime.keyboardMode, ime.keyboardView, ime.imeContext)
         suggestionHandler.clearAllSuggestionsAndHideButtonUI()
     }
 
@@ -272,7 +276,7 @@ class KeyHandler(
      */
     private fun handleNavigationKey(code: Int) {
         val isRight = code == KeyboardBase.KEYCODE_RIGHT_ARROW
-        ime.currentInputConnection?.let { ic ->
+        ime.getInputConnection()?.let { ic ->
             val currentPos = ic.getTextBeforeCursor(GeneralKeyboardIME.MAX_TEXT_LENGTH, 0)?.length ?: 0
             val newPos =
                 if (isRight) {
@@ -298,7 +302,7 @@ class KeyHandler(
     ) {
         when (code) {
             KeyboardBase.DISPLAY_LEFT, KeyboardBase.DISPLAY_RIGHT ->
-                handleConjugateCycleKeys(code, ime.applicationContext)
+                handleConjugateCycleKeys(code, ime.imeContext)
             else ->
                 handleConjugateSelectionKey(code, language)
         }
@@ -379,10 +383,10 @@ class KeyHandler(
         val isAutoSpaceEnabled =
             !isCommandBarActive &&
                 isPunctuation &&
-                PreferencesHelper.getAutoSpaceAfterPunctuationPreference(ime.applicationContext, language)
+                PreferencesHelper.getAutoSpaceAfterPunctuationPreference(ime.imeContext, language)
 
         if (isAutoSpaceEnabled) {
-            val ic = ime.currentInputConnection
+            val ic = ime.getInputConnection()
             val textBefore = ic?.getTextBeforeCursor(2, 0)?.toString()
             if (textBefore != null && textBefore.length == 2 && textBefore.endsWith(" ")) {
                 val charBeforeSpace = textBefore[0]
@@ -395,7 +399,7 @@ class KeyHandler(
         ime.handleElseCondition(code, ime.keyboardMode, isCommandBarActive)
 
         if (isAutoSpaceEnabled) {
-            val ic = ime.currentInputConnection
+            val ic = ime.getInputConnection()
             val textBefore = ic?.getTextBeforeCursor(2, 0)?.toString()
             if (textBefore != null && textBefore.length == 2) {
                 val prevChar = textBefore[0]

--- a/app/src/keyboards/java/be/scri/helpers/KeyboardIMEContext.kt
+++ b/app/src/keyboards/java/be/scri/helpers/KeyboardIMEContext.kt
@@ -21,6 +21,11 @@ import be.scri.views.KeyboardView
  */
 @Suppress("TooManyFunctions")
 interface KeyboardIMEContext {
+    companion object {
+        const val COMMIT_TEXT_CURSOR_POSITION = 1
+        const val MAX_TEXT_LENGTH = 1000
+    }
+
     val imeContext: Context
     val language: String
     val scribeLanguage: ScribeLanguage
@@ -67,7 +72,7 @@ interface KeyboardIMEContext {
     val suggestionWords: HashMap<String, List<String>>
     val emojiKeywords: HashMap<String, MutableList<String>>?
 
-    fun handleDelete(isRepeating: Boolean = false)
+    fun handleDelete(isLongPress: Boolean = false)
 
     fun isDeleteRepeating(): Boolean
 
@@ -89,7 +94,7 @@ interface KeyboardIMEContext {
         wordSuggestions: List<String>? = null,
     )
 
-    fun updateTypedWordSuggestion(currentWord: String?)
+    fun updateTypedWordSuggestion(word: String?)
 
     fun updateAutocompleteCompletions(completions: List<String>)
 
@@ -189,7 +194,7 @@ interface KeyboardIMEContext {
 
     fun getKeyboardWidth(): Int
 
-    fun recreateKeyboardPublic()
+    fun recreateKeyboard()
 
     fun setBackDisposition(disposition: Int)
 

--- a/app/src/keyboards/java/be/scri/helpers/KeyboardIMEContext.kt
+++ b/app/src/keyboards/java/be/scri/helpers/KeyboardIMEContext.kt
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package be.scri.helpers
+
+import android.app.Dialog
+import android.content.Context
+import android.content.res.Resources
+import android.view.inputmethod.InputConnection
+import be.scri.databinding.InputMethodViewBinding
+import be.scri.helpers.ui.KeyboardUIManager
+import be.scri.models.ScribeLanguage
+import be.scri.models.ScribeState
+import be.scri.views.KeyboardView
+
+/**
+ * Interface defining the contract between [be.scri.services.GeneralKeyboardIME]
+ * and its helper handlers.
+ *
+ * This explicit abstraction decouples helper handlers from the concrete IME service,
+ * restricts access to only required APIs, and enables clean unit testing.
+ */
+@Suppress("TooManyFunctions")
+interface KeyboardIMEContext {
+    val imeContext: Context
+    val language: String
+    val scribeLanguage: ScribeLanguage
+
+    fun getInputConnection(): InputConnection?
+
+    fun getImeResources(): Resources
+
+    fun getImeWindow(): Dialog?
+
+    var keyboard: KeyboardBase?
+    var keyboardView: KeyboardView?
+
+    val binding: InputMethodViewBinding
+    val uiManager: KeyboardUIManager
+    val isUiManagerInitialized: Boolean
+
+    val currentState: ScribeState
+    var keyboardMode: Int
+    val keyboardLetters: Int
+    val keyboardSymbols: Int
+    val keyboardSymbolShift: Int
+
+    var lastShiftPressTS: Long
+
+    val currentCommandBarHint: String
+    val commandBarHintColor: Int
+
+    val suggestionHandler: SuggestionHandler
+    val autocompletionHandler: AutocompletionHandler
+
+    var isSingularAndPlural: Boolean
+    var checkIfPluralWord: Boolean
+    var nounTypeSuggestion: List<String>?
+    var caseAnnotationSuggestion: MutableList<String>?
+    var wordSuggestions: List<String>?
+    var autoSuggestEmojis: MutableList<String>?
+    var lastWord: String?
+    val emojiAutoSuggestionEnabled: Boolean
+
+    val nounKeywords: HashMap<String, List<String>>
+    val pluralWords: Set<String>?
+    val caseAnnotation: HashMap<String, MutableList<String>>
+    val suggestionWords: HashMap<String, List<String>>
+    val emojiKeywords: HashMap<String, MutableList<String>>?
+
+    fun handleDelete(isRepeating: Boolean = false)
+
+    fun isDeleteRepeating(): Boolean
+
+    fun clearAutocomplete()
+
+    fun disableAutoSuggest()
+
+    fun updateButtonVisibility(enabled: Boolean)
+
+    fun updateEmojiSuggestion(
+        enabled: Boolean,
+        emojis: MutableList<String>?,
+    )
+
+    fun updateAutoSuggestText(
+        nounTypeSuggestion: List<String>? = null,
+        isPlural: Boolean = false,
+        caseAnnotationSuggestion: MutableList<String>? = null,
+        wordSuggestions: List<String>? = null,
+    )
+
+    fun updateTypedWordSuggestion(currentWord: String?)
+
+    fun updateAutocompleteCompletions(completions: List<String>)
+
+    fun getPreviousWordBeforeCursor(): String?
+
+    fun getLastWordBeforeCursor(): String?
+
+    fun getAutocompletions(
+        word: String,
+        previousWord: String?,
+        limit: Int = 3,
+    ): List<String>
+
+    fun findGenderForLastWord(
+        nounKeywords: HashMap<String, List<String>>,
+        lastWord: String?,
+    ): List<String>?
+
+    fun findWhetherWordIsPlural(
+        pluralWords: Set<String>?,
+        lastWord: String?,
+    ): Boolean
+
+    fun getCaseAnnotationForPreposition(
+        caseAnnotation: HashMap<String, MutableList<String>>,
+        lastWord: String?,
+    ): MutableList<String>?
+
+    fun getNextWordSuggestions(
+        wordSuggestions: HashMap<String, List<String>>,
+        lastWord: String?,
+    ): List<String>?
+
+    fun findEmojisForLastWord(
+        emojiKeywords: HashMap<String, MutableList<String>>?,
+        lastWord: String?,
+    ): MutableList<String>?
+
+    fun getCommandBarTextWithoutCursor(): String
+
+    fun setCommandBarTextWithCursor(
+        text: String,
+        cursorAtStart: Boolean = false,
+    )
+
+    fun commitPeriodAfterSpace()
+
+    fun handleElseCondition(
+        code: Int,
+        keyboardMode: Int,
+        commandBarState: Boolean = false,
+    )
+
+    fun handleKeyboardLetters(
+        keyboardMode: Int,
+        keyboardView: KeyboardView?,
+    )
+
+    fun handleKeycodeEnter()
+
+    fun handleModeChange(
+        keyboardMode: Int,
+        keyboardView: KeyboardView?,
+        context: Context,
+    )
+
+    fun hideClipboardSuggestionChip()
+
+    fun openClipboardPanel()
+
+    fun openEmojiKeyboard()
+
+    fun toggleFloatingMode()
+
+    fun updateUI()
+
+    fun returnIsSubsequentRequired(): Boolean
+
+    fun handleConjugateKeys(
+        code: Int,
+        isSubsequentRequired: Boolean = false,
+    ): String?
+
+    fun moveToIdleState()
+
+    fun saveConjugateModeType(
+        language: String = this.language,
+        isSubsequentArea: Boolean = false,
+    )
+
+    fun setupConjugateSubView(
+        data: List<List<String>>,
+        word: String?,
+    )
+
+    fun returnSubsequentData(): List<List<String>>
+
+    fun getKeyboardWidth(): Int
+
+    fun recreateKeyboardPublic()
+
+    fun setBackDisposition(disposition: Int)
+
+    fun applyNavBarColor()
+}

--- a/app/src/keyboards/java/be/scri/helpers/SpaceKeyProcessor.kt
+++ b/app/src/keyboards/java/be/scri/helpers/SpaceKeyProcessor.kt
@@ -3,14 +3,13 @@
 package be.scri.helpers
 
 import be.scri.models.ScribeState
-import be.scri.services.GeneralKeyboardIME
 
 /**
  * Processes key events specifically related to the space key.
  * This includes handling "period on double tap" logic, committing spaces
  * in normal input mode or command bar mode, and interacting with suggestions.
  *
- * @property ime The [GeneralKeyboardIME] instance this processor is associated with.
+ * @property ime The [KeyboardIMEContext] instance this processor is associated with.
  * @property suggestionHandler The [SuggestionHandler] to manage suggestions.
  */
 class SpaceKeyProcessor(

--- a/app/src/keyboards/java/be/scri/helpers/SpaceKeyProcessor.kt
+++ b/app/src/keyboards/java/be/scri/helpers/SpaceKeyProcessor.kt
@@ -14,7 +14,7 @@ import be.scri.services.GeneralKeyboardIME
  * @property suggestionHandler The [SuggestionHandler] to manage suggestions.
  */
 class SpaceKeyProcessor(
-    private val ime: GeneralKeyboardIME,
+    private val ime: KeyboardIMEContext,
     private val suggestionHandler: SuggestionHandler,
 ) {
     /**
@@ -61,8 +61,8 @@ class SpaceKeyProcessor(
      * @param wasLastKeySpace true if the previous key pressed was a space.
      */
     private fun handleSpaceOutsideCommandBar(wasLastKeySpace: Boolean) {
-        val periodOnDoubleTapEnabled = PreferencesHelper.getEnablePeriodOnSpaceBarDoubleTap(context = ime, ime.language)
-        val ic = ime.currentInputConnection ?: return
+        val periodOnDoubleTapEnabled = PreferencesHelper.getEnablePeriodOnSpaceBarDoubleTap(context = ime.imeContext, ime.language)
+        val ic = ime.getInputConnection() ?: return
         val wordBeforeSpace = ime.getLastWordBeforeCursor()
 
         val textBefore = ic.getTextBeforeCursor(2, 0)?.toString()

--- a/app/src/keyboards/java/be/scri/helpers/SuggestionHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/SuggestionHandler.kt
@@ -14,7 +14,7 @@ import be.scri.services.GeneralKeyboardIME
  * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
  */
 class SuggestionHandler(
-    private val ime: GeneralKeyboardIME,
+    private val ime: KeyboardIMEContext,
 ) {
     private val handler = Handler(Looper.getMainLooper())
     private var emojiSuggestionRunnable: Runnable? = null

--- a/app/src/keyboards/java/be/scri/helpers/SuggestionHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/SuggestionHandler.kt
@@ -6,12 +6,11 @@ package be.scri.helpers
 import android.os.Handler
 import android.os.Looper
 import be.scri.models.ScribeState
-import be.scri.services.GeneralKeyboardIME
 
 /**
  * Handles auto-suggestions such as noun gender, plurality, case, and emojis.
  *
- * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
+ * @property ime The [KeyboardIMEContext] instance this handler is associated with.
  */
 class SuggestionHandler(
     private val ime: KeyboardIMEContext,

--- a/app/src/keyboards/java/be/scri/helpers/clipboard/ClipboardHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/clipboard/ClipboardHandler.kt
@@ -6,14 +6,13 @@ import android.view.View
 import androidx.recyclerview.widget.GridLayoutManager
 import be.scri.helpers.KeyboardIMEContext
 import be.scri.models.ScribeState
-import be.scri.services.GeneralKeyboardIME
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**
  * Manages in-keyboard clipboard monitoring, suggestion chips, and history panel operations
- * for [GeneralKeyboardIME].
+ * for [KeyboardIMEContext].
  *
  * @property ime The [KeyboardIMEContext] instance this handler is associated with.
  */

--- a/app/src/keyboards/java/be/scri/helpers/clipboard/ClipboardHandler.kt
+++ b/app/src/keyboards/java/be/scri/helpers/clipboard/ClipboardHandler.kt
@@ -4,6 +4,7 @@ package be.scri.helpers.clipboard
 
 import android.view.View
 import androidx.recyclerview.widget.GridLayoutManager
+import be.scri.helpers.KeyboardIMEContext
 import be.scri.models.ScribeState
 import be.scri.services.GeneralKeyboardIME
 import kotlinx.coroutines.CoroutineScope
@@ -14,10 +15,10 @@ import kotlinx.coroutines.launch
  * Manages in-keyboard clipboard monitoring, suggestion chips, and history panel operations
  * for [GeneralKeyboardIME].
  *
- * @property ime The [GeneralKeyboardIME] instance this handler is associated with.
+ * @property ime The [KeyboardIMEContext] instance this handler is associated with.
  */
 class ClipboardHandler(
-    private val ime: GeneralKeyboardIME,
+    private val ime: KeyboardIMEContext,
 ) {
     var latestClipText: String? = null
         internal set
@@ -26,11 +27,11 @@ class ClipboardHandler(
 
     private lateinit var clipboardMonitor: ClipboardMonitor
     private var clipboardAdapter: ClipboardAdapter? = null
-    private val clipboardRepository by lazy { ClipboardRepository(ime) }
+    private val clipboardRepository by lazy { ClipboardRepository(ime.imeContext) }
 
     fun initClipboardMonitor() {
         clipboardMonitor =
-            ClipboardMonitor(ime) { text ->
+            ClipboardMonitor(ime.imeContext) { text ->
                 latestClipText = text
                 hasNewClip = true
                 if (ime.currentState == ScribeState.IDLE && ime.isUiManagerInitialized) {
@@ -53,7 +54,7 @@ class ClipboardHandler(
 
     fun onClipboardSuggestionClicked() {
         latestClipText?.let { text ->
-            ime.currentInputConnection?.commitText(text, 1)
+            ime.getInputConnection()?.commitText(text, 1)
         }
         hideClipboardSuggestionChip()
     }
@@ -77,7 +78,7 @@ class ClipboardHandler(
             ClipboardAdapter(
                 items = emptyList(),
                 onItemClick = { item ->
-                    ime.currentInputConnection?.commitText(item.text, 1)
+                    ime.getInputConnection()?.commitText(item.text, 1)
                     closeClipboardPanel()
                 },
                 onItemDelete = { item ->
@@ -94,7 +95,7 @@ class ClipboardHandler(
                 },
             )
         recyclerView.adapter = clipboardAdapter
-        recyclerView.layoutManager = GridLayoutManager(ime, 2)
+        recyclerView.layoutManager = GridLayoutManager(ime.imeContext, 2)
 
         ime.binding.clipboardPanelClose.setOnClickListener { closeClipboardPanel() }
         ime.binding.clipboardClearAll.setOnClickListener {

--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -78,11 +78,11 @@ abstract class GeneralKeyboardIME(
     constructor(languageName: String) : this(ScribeLanguage.fromDisplayName(languageName))
 
     override val imeContext: Context
-        get() = this
+        get() = applicationContext
 
     override fun getInputConnection(): InputConnection? = getCurrentInputConnection()
 
-    override fun getImeResources(): Resources = super.getResources()
+    override fun getImeResources(): Resources = resources
 
     override fun getImeWindow(): Dialog? = getWindow()
 
@@ -175,8 +175,6 @@ abstract class GeneralKeyboardIME(
         }
 
     override val isUiManagerInitialized: Boolean get() = this::uiManager.isInitialized
-
-    override fun recreateKeyboardPublic() = recreateKeyboard()
 
     override var emojiKeywords: HashMap<String, MutableList<String>>?
         get() = dataHandler.emojiKeywords
@@ -577,8 +575,9 @@ abstract class GeneralKeyboardIME(
             keyboardMode = keyboardLetters
             keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType, getKeyboardWidth())
             val editorInfo = currentInputEditorInfo
+            val inputConnection = currentInputConnection
             if (editorInfo != null && editorInfo.inputType != InputType.TYPE_NULL && keyboard?.mShiftState != SHIFT_ON_PERMANENT) {
-                if (currentInputConnection?.getCursorCapsMode(editorInfo.inputType) != 0) {
+                if (inputConnection != null && inputConnection.getCursorCapsMode(editorInfo.inputType) != 0) {
                     keyboard?.setShifted(SHIFT_ON_ONE_CHAR)
                 }
             }
@@ -2021,7 +2020,7 @@ abstract class GeneralKeyboardIME(
             resources.displayMetrics.widthPixels
         }
 
-    private fun recreateKeyboard() {
+    override fun recreateKeyboard() {
         if (!this::uiManager.isInitialized) return
         val xmlId = getCurrentKeyboardLayoutXML()
         val currentShiftState = keyboard?.mShiftState ?: SHIFT_OFF

--- a/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
+++ b/app/src/keyboards/java/be/scri/services/GeneralKeyboardIME.kt
@@ -3,8 +3,10 @@
 package be.scri.services
 
 import DataContract
+import android.app.Dialog
 import android.content.Context
 import android.content.Intent
+import android.content.res.Resources
 import android.graphics.Rect
 import android.inputmethodservice.InputMethodService
 import android.text.InputType
@@ -36,6 +38,7 @@ import be.scri.helpers.FloatingKeyboardHandler
 import be.scri.helpers.KeyHandler
 import be.scri.helpers.KeyboardBase
 import be.scri.helpers.KeyboardDataHandler
+import be.scri.helpers.KeyboardIMEContext
 import be.scri.helpers.KeyboardLanguageMappingConstants
 import be.scri.helpers.KeyboardStateManager
 import be.scri.helpers.LanguageMappingConstants.getLanguageAlias
@@ -66,12 +69,22 @@ private const val DATA_CONSTANT_3 = 3
 
 @Suppress("TooManyFunctions", "LargeClass")
 abstract class GeneralKeyboardIME(
-    val scribeLanguage: ScribeLanguage,
+    override val scribeLanguage: ScribeLanguage,
 ) : InputMethodService(),
     KeyboardView.OnKeyboardActionListener,
     KeyboardUIManager.KeyboardUIListener,
-    KeyboardBase.KeyboardContextProvider {
+    KeyboardBase.KeyboardContextProvider,
+    KeyboardIMEContext {
     constructor(languageName: String) : this(ScribeLanguage.fromDisplayName(languageName))
+
+    override val imeContext: Context
+        get() = this
+
+    override fun getInputConnection(): InputConnection? = getCurrentInputConnection()
+
+    override fun getImeResources(): Resources = super.getResources()
+
+    override fun getImeWindow(): Dialog? = getWindow()
 
     override val language: String
         get() = scribeLanguage.displayName
@@ -80,16 +93,16 @@ abstract class GeneralKeyboardIME(
     abstract override fun getKeyboardLayoutXML(): Int
 
     abstract override val keyboardLetters: Int
-    abstract val keyboardSymbols: Int
-    abstract val keyboardSymbolShift: Int
+    abstract override val keyboardSymbols: Int
+    abstract override val keyboardSymbolShift: Int
 
-    open var keyboard: KeyboardBase? = null
-    var keyboardView: KeyboardView? = null
+    override var keyboard: KeyboardBase? = null
+    override var keyboardView: KeyboardView? = null
 
     // UI Manager instance.
-    lateinit var uiManager: KeyboardUIManager
+    override lateinit var uiManager: KeyboardUIManager
 
-    abstract var lastShiftPressTS: Long
+    abstract override var lastShiftPressTS: Long
     abstract override var keyboardMode: Int
     abstract var inputTypeClass: Int
     abstract var enterKeyType: Int
@@ -118,7 +131,7 @@ abstract class GeneralKeyboardIME(
     private val backspaceHandler = BackspaceHandler(this)
 
     // Bridge for BackspaceHandler to access binding through UI Manager.
-    internal val binding: InputMethodViewBinding
+    override val binding: InputMethodViewBinding
         get() = uiManager.binding
 
     internal val clipboardHandler by lazy { ClipboardHandler(this) }
@@ -135,7 +148,7 @@ abstract class GeneralKeyboardIME(
 
     // MARK: State Variables
 
-    internal var isSingularAndPlural: Boolean = false
+    override var isSingularAndPlural: Boolean = false
     private var subsequentAreaRequired: Boolean = false
     private var subsequentData: MutableList<List<String>> = mutableListOf()
 
@@ -150,8 +163,8 @@ abstract class GeneralKeyboardIME(
         get() = dataHandler.autocompletionManager
 
     private lateinit var nativeSuggestionEngine: NativeSuggestionEngine
-    internal lateinit var suggestionHandler: SuggestionHandler
-    internal lateinit var autocompletionHandler: AutocompletionHandler
+    override lateinit var suggestionHandler: SuggestionHandler
+    override lateinit var autocompletionHandler: AutocompletionHandler
     internal lateinit var keyHandler: KeyHandler
     internal val floatingKeyboardHandler by lazy { FloatingKeyboardHandler(this) }
 
@@ -161,11 +174,11 @@ abstract class GeneralKeyboardIME(
             dataHandler.dataContract = value
         }
 
-    internal val isUiManagerInitialized: Boolean get() = this::uiManager.isInitialized
+    override val isUiManagerInitialized: Boolean get() = this::uiManager.isInitialized
 
-    internal fun recreateKeyboardPublic() = recreateKeyboard()
+    override fun recreateKeyboardPublic() = recreateKeyboard()
 
-    var emojiKeywords: HashMap<String, MutableList<String>>?
+    override var emojiKeywords: HashMap<String, MutableList<String>>?
         get() = dataHandler.emojiKeywords
         set(value) {
             dataHandler.emojiKeywords = value
@@ -189,44 +202,44 @@ abstract class GeneralKeyboardIME(
             dataHandler.emojiMaxKeywordLength = value
         }
 
-    internal var nounKeywords: HashMap<String, List<String>>
+    override var nounKeywords: HashMap<String, List<String>>
         get() = dataHandler.nounKeywords
         set(value) {
             dataHandler.nounKeywords = value
         }
 
-    internal var suggestionWords: HashMap<String, List<String>>
+    override var suggestionWords: HashMap<String, List<String>>
         get() = dataHandler.suggestionWords
         set(value) {
             dataHandler.suggestionWords = value
         }
 
-    var pluralWords: Set<String>?
+    override var pluralWords: Set<String>?
         get() = dataHandler.pluralWords
         set(value) {
             dataHandler.pluralWords = value
         }
 
-    internal var caseAnnotation: HashMap<String, MutableList<String>>
+    override var caseAnnotation: HashMap<String, MutableList<String>>
         get() = dataHandler.caseAnnotation
         set(value) {
             dataHandler.caseAnnotation = value
         }
 
-    var emojiAutoSuggestionEnabled: Boolean = false
-    var lastWord: String? = null
-    var autoSuggestEmojis: MutableList<String>? = null
-    var caseAnnotationSuggestion: MutableList<String>? = null
-    var nounTypeSuggestion: List<String>? = null
-    var wordSuggestions: List<String>? = null
-    var checkIfPluralWord: Boolean = false
+    override var emojiAutoSuggestionEnabled: Boolean = false
+    override var lastWord: String? = null
+    override var autoSuggestEmojis: MutableList<String>? = null
+    override var caseAnnotationSuggestion: MutableList<String>? = null
+    override var nounTypeSuggestion: List<String>? = null
+    override var wordSuggestions: List<String>? = null
+    override var checkIfPluralWord: Boolean = false
     private var currentEnterKeyType: Int? = null
     private var isNumericKeyboardActive: Boolean = false
 
     internal val stateManager = KeyboardStateManager()
     internal val themeManager = KeyboardThemeManager()
 
-    internal var currentState: ScribeState
+    override var currentState: ScribeState
         get() = stateManager.currentState
         set(value) {
             stateManager.currentState = value
@@ -239,13 +252,13 @@ abstract class GeneralKeyboardIME(
         }
 
     // Properties used by BackspaceHandler, delegated to UI Manager.
-    internal var currentCommandBarHint: String
+    override var currentCommandBarHint: String
         get() = uiManager.currentCommandBarHint
         set(value) {
             uiManager.currentCommandBarHint = value
         }
 
-    internal var commandBarHintColor: Int
+    override var commandBarHintColor: Int
         get() = uiManager.commandBarHintColor
         set(value) {
             uiManager.commandBarHintColor = value
@@ -565,7 +578,7 @@ abstract class GeneralKeyboardIME(
             keyboard = KeyboardBase(this, getKeyboardLayoutXML(), enterKeyType, getKeyboardWidth())
             val editorInfo = currentInputEditorInfo
             if (editorInfo != null && editorInfo.inputType != InputType.TYPE_NULL && keyboard?.mShiftState != SHIFT_ON_PERMANENT) {
-                if (currentInputConnection.getCursorCapsMode(editorInfo.inputType) != 0) {
+                if (currentInputConnection?.getCursorCapsMode(editorInfo.inputType) != 0) {
                     keyboard?.setShifted(SHIFT_ON_ONE_CHAR)
                 }
             }
@@ -591,7 +604,7 @@ abstract class GeneralKeyboardIME(
 
     // MARK: Helper Methods
 
-    fun openEmojiKeyboard() {
+    override fun openEmojiKeyboard() {
         uiManager.showEmojiPalette(language)
     }
 
@@ -627,7 +640,7 @@ abstract class GeneralKeyboardIME(
         dataHandler.loadLanguageData(language)
     }
 
-    internal fun applyNavBarColor() {
+    override fun applyNavBarColor() {
         themeManager.applyNavBarColor(
             service = this,
             window = window?.window,
@@ -642,9 +655,9 @@ abstract class GeneralKeyboardIME(
      * @param language The current keyboard language.
      * @param isSubsequentArea true if this is for a secondary view.
      */
-    internal fun saveConjugateModeType(
-        language: String = this.language,
-        isSubsequentArea: Boolean = false,
+    override fun saveConjugateModeType(
+        language: String,
+        isSubsequentArea: Boolean,
     ) {
         val sharedPref = applicationContext.getSharedPreferences("keyboard_preferences", MODE_PRIVATE)
         val mode =
@@ -666,7 +679,7 @@ abstract class GeneralKeyboardIME(
      * The main dispatcher for updating the entire keyboard UI. It calls the appropriate setup function
      * based on the current [ScribeState].
      */
-    internal fun updateUI() = refreshUI()
+    override fun updateUI() = refreshUI()
 
     private fun refreshUI() {
         if (!this::uiManager.isInitialized) return
@@ -687,7 +700,7 @@ abstract class GeneralKeyboardIME(
     /**
      * Transitions the keyboard to the `IDLE` state and updates the UI.
      */
-    internal fun moveToIdleState() {
+    override fun moveToIdleState() {
         clearSuggestionData()
         stateManager.moveToIdle()
         saveConjugateModeType("none")
@@ -757,7 +770,9 @@ abstract class GeneralKeyboardIME(
     override fun onEmojiSelected(emoji: String) {
         if (emoji.isNotEmpty()) {
             recordRecentEmoji(this, emoji)
-            insertEmoji(emoji, currentInputConnection, emojiKeywords, emojiMaxKeywordLength)
+            currentInputConnection?.let { ic ->
+                insertEmoji(emoji, ic, emojiKeywords, emojiMaxKeywordLength)
+            }
         }
     }
 
@@ -827,7 +842,7 @@ abstract class GeneralKeyboardIME(
      * Handles the logic for the Enter key press. This can either perform an editor action,
      * commit a newline, or execute a Scribe command depending on the current state.
      */
-    fun handleKeycodeEnter() {
+    override fun handleKeycodeEnter() {
         val inputConnection = currentInputConnection ?: return
 
         if (currentState == ScribeState.INVALID || currentState == ScribeState.ALREADY_PLURAL) {
@@ -983,10 +998,10 @@ abstract class GeneralKeyboardIME(
      * @param keyboardMode The current keyboard mode.
      * @param commandBarState true if input should go to the command bar.
      */
-    fun handleElseCondition(
+    override fun handleElseCondition(
         code: Int,
         keyboardMode: Int,
-        commandBarState: Boolean = false,
+        commandBarState: Boolean,
     ) {
         val currentShiftState = keyboardView?.mKeyboard?.mShiftState ?: SHIFT_OFF
         if (commandBarState) {
@@ -1038,7 +1053,7 @@ abstract class GeneralKeyboardIME(
      * @param isCommandBar true` if the deletion should happen in the command bar.
      * @param isLongPress true` if this is a long press/repeat action, false for single tap.
      */
-    fun handleDelete(isLongPress: Boolean = false) {
+    override fun handleDelete(isLongPress: Boolean) {
         val inputConnection = currentInputConnection ?: return
         val effectiveIsCommandBar =
             currentState != ScribeState.IDLE &&
@@ -1075,7 +1090,7 @@ abstract class GeneralKeyboardIME(
      * Returns whether the delete key is currently repeating (long press).
      * Delegated to BackspaceHandler.
      */
-    fun isDeleteRepeating() = backspaceHandler.isDeleteRepeating
+    override fun isDeleteRepeating() = backspaceHandler.isDeleteRepeating
 
     /**
      * Sets the flag to indicate that the delete key is currently repeating (long press).
@@ -1091,18 +1106,18 @@ abstract class GeneralKeyboardIME(
      * Safely fetches autocomplete suggestions for the given prefix.
      * Returns an empty list if a database or state error occurs.
      */
-    fun getAutocompletions(
-        prefix: String,
-        previousWord: String? = null,
-        limit: Int = 3,
+    override fun getAutocompletions(
+        word: String,
+        previousWord: String?,
+        limit: Int,
     ): List<String> {
         if (this::nativeSuggestionEngine.isInitialized) {
-            val nativeCompletions = nativeSuggestionEngine.getAutocompletions(language, prefix, previousWord, limit)
+            val nativeCompletions = nativeSuggestionEngine.getAutocompletions(language, word, previousWord, limit)
             if (nativeCompletions.isNotEmpty()) {
                 return nativeCompletions.map { it.substringBefore("-") }
             }
         }
-        return dataHandler.getAutocompletions(prefix, limit)
+        return dataHandler.getAutocompletions(word, limit)
     }
 
     /**
@@ -1110,7 +1125,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return The text content without the trailing cursor character.
      */
-    fun getCommandBarTextWithoutCursor() = uiManager.getCommandBarTextWithoutCursor()
+    override fun getCommandBarTextWithoutCursor() = uiManager.getCommandBarTextWithoutCursor()
 
     /**
      * Sets the command bar text and ensures it ends with the custom cursor.
@@ -1118,9 +1133,9 @@ abstract class GeneralKeyboardIME(
      * @param text The text to set (without cursor).
      * @param cursorAtStart The flag to check if the text in the EditText is empty to determine the position of the cursor
      */
-    fun setCommandBarTextWithCursor(
+    override fun setCommandBarTextWithCursor(
         text: String,
-        cursorAtStart: Boolean = false,
+        cursorAtStart: Boolean,
     ) = uiManager.setCommandBarTextWithCursor(text, cursorAtStart)
 
     /**
@@ -1128,7 +1143,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return The last word as a [String], or null if no word is found.
      */
-    fun getLastWordBeforeCursor(): String? = getText()?.trim()?.split("\\s+".toRegex())?.lastOrNull()
+    override fun getLastWordBeforeCursor(): String? = getText()?.trim()?.split("\\s+".toRegex())?.lastOrNull()
 
     /**
      * Extracts the word immediately before the one currently being composed, i.e. the last
@@ -1137,7 +1152,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return The previous completed word as a [String], or null if there isn't one.
      */
-    fun getPreviousWordBeforeCursor(): String? {
+    override fun getPreviousWordBeforeCursor(): String? {
         val words = getText()?.trim()?.split("\\s+".toRegex()) ?: return null
         return words.getOrNull(words.size - 2)
     }
@@ -1238,7 +1253,7 @@ abstract class GeneralKeyboardIME(
      * @param keyboardMode The current keyboard mode.
      * @param keyboardView The instance of the keyboard view.
      */
-    fun handleKeyboardLetters(
+    override fun handleKeyboardLetters(
         keyboardMode: Int,
         keyboardView: KeyboardView?,
     ) {
@@ -1275,7 +1290,7 @@ abstract class GeneralKeyboardIME(
      * @param keyboardView The instance of the keyboard view.
      * @param context The application context.
      */
-    fun handleModeChange(
+    override fun handleModeChange(
         keyboardMode: Int,
         keyboardView: KeyboardView?,
         context: Context,
@@ -1321,7 +1336,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return A mutable list of emoji suggestions, or null if none are found.
      */
-    fun findEmojisForLastWord(
+    override fun findEmojisForLastWord(
         emojiKeywords: HashMap<String, MutableList<String>>?,
         lastWord: String?,
     ) = lastWord?.let { emojiKeywords?.get(it.lowercase()) }
@@ -1334,7 +1349,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return A list of gender strings (e.g., "masculine", "neuter"), or null if not a known noun.
      */
-    fun findGenderForLastWord(
+    override fun findGenderForLastWord(
         nounKeywords: HashMap<String, List<String>>,
         lastWord: String?,
     ): List<String>? {
@@ -1356,7 +1371,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return true if the word is in the plural set, false otherwise.
      */
-    fun findWhetherWordIsPlural(
+    override fun findWhetherWordIsPlural(
         pluralWords: Set<String>?,
         lastWord: String?,
     ): Boolean = pluralWords?.contains(lastWord?.lowercase()) == true
@@ -1369,7 +1384,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return A list of gender strings (e.g., "masculine", "neuter"), or null if not a known noun.
      */
-    fun getNextWordSuggestions(
+    override fun getNextWordSuggestions(
         wordSuggestions: HashMap<String, List<String>>,
         lastWord: String?,
     ): List<String>? {
@@ -1391,7 +1406,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return A mutable list of case suggestions (e.g., "accusative case"), or null if not found.
      */
-    fun getCaseAnnotationForPreposition(
+    override fun getCaseAnnotationForPreposition(
         caseAnnotation: HashMap<String, MutableList<String>>,
         lastWord: String?,
     ) = lastWord?.let { caseAnnotation[it.lowercase()] }
@@ -1406,11 +1421,11 @@ abstract class GeneralKeyboardIME(
      * @param isPlural true if the last word is plural.
      * @param caseAnnotationSuggestion The detected case(s) required by the last word.
      */
-    fun updateAutoSuggestText(
-        nounTypeSuggestion: List<String>? = null,
-        isPlural: Boolean = false,
-        caseAnnotationSuggestion: MutableList<String>? = null,
-        wordSuggestions: List<String>? = null,
+    override fun updateAutoSuggestText(
+        nounTypeSuggestion: List<String>?,
+        isPlural: Boolean,
+        caseAnnotationSuggestion: MutableList<String>?,
+        wordSuggestions: List<String>?,
     ) {
         this.nounTypeSuggestion = nounTypeSuggestion
         this.checkIfPluralWord = isPlural
@@ -1781,7 +1796,7 @@ abstract class GeneralKeyboardIME(
      * rather than a dictionary suggestion. Called immediately on every keystroke
      * — unlike the completions, it needs no lookup, so it should never lag.
      */
-    fun updateTypedWordSuggestion(word: String?) {
+    override fun updateTypedWordSuggestion(word: String?) {
         if (currentState != ScribeState.IDLE || word.isNullOrEmpty()) {
             uiManager.disableAutoSuggest(language)
             if (!autoSuggestEmojis.isNullOrEmpty() && emojiAutoSuggestionEnabled) {
@@ -1807,7 +1822,7 @@ abstract class GeneralKeyboardIME(
      * Fills the remaining suggestion slots with dictionary/engine completions.
      * Clears them (leaving the typed word alone) if not idle.
      */
-    fun updateAutocompleteCompletions(completions: List<String>) {
+    override fun updateAutocompleteCompletions(completions: List<String>) {
         if (currentState != ScribeState.IDLE) return
 
         val completion1 = completions.getOrNull(0) ?: ""
@@ -1868,7 +1883,7 @@ abstract class GeneralKeyboardIME(
      * Clears autocomplete suggestions by resetting the suggestion strip
      * to the default command buttons via the UI Manager.
      */
-    fun clearAutocomplete() {
+    override fun clearAutocomplete() {
         if (this::uiManager.isInitialized) {
             uiManager.disableAutoSuggest(language)
         }
@@ -1880,9 +1895,9 @@ abstract class GeneralKeyboardIME(
      *
      * @return true if a subsequent selection screen is needed, false otherwise.
      */
-    fun returnIsSubsequentRequired(): Boolean = subsequentAreaRequired
+    override fun returnIsSubsequentRequired(): Boolean = subsequentAreaRequired
 
-    fun returnSubsequentData(): List<List<String>> = subsequentData
+    override fun returnSubsequentData(): List<List<String>> = subsequentData
 
     /**
      * Handles a key press on one of the special conjugation keys.
@@ -1893,7 +1908,7 @@ abstract class GeneralKeyboardIME(
      *
      * @return The label of the key that was pressed.
      */
-    fun handleConjugateKeys(
+    override fun handleConjugateKeys(
         code: Int,
         isSubsequentRequired: Boolean,
     ): String? {
@@ -1913,7 +1928,7 @@ abstract class GeneralKeyboardIME(
      * @param data The full dataset of subsequent options.
      * @param word The specific word selected from the primary view, used to filter the data.
      */
-    fun setupConjugateSubView(
+    override fun setupConjugateSubView(
         data: List<List<String>>,
         word: String?,
     ) {
@@ -1985,20 +2000,14 @@ abstract class GeneralKeyboardIME(
      *
      * @param enabled true if suggestions are available.
      */
-    fun updateButtonVisibility(enabled: Boolean) = uiManager.updateButtonVisibility(currentState, enabled, autoSuggestEmojis)
+    override fun updateButtonVisibility(enabled: Boolean) = uiManager.updateButtonVisibility(currentState, enabled, autoSuggestEmojis)
 
-    /**
-     * Updates the text of the suggestion buttons, primarily for displaying emoji suggestions.
-     *
-     * @param enabled true if suggestions are active.
-     * @param emojis The list of emojis to display.
-     */
-    fun updateEmojiSuggestion(
+    override fun updateEmojiSuggestion(
         enabled: Boolean,
         emojis: MutableList<String>?,
     ) = uiManager.updateEmojiSuggestion(currentState, enabled, emojis)
 
-    fun disableAutoSuggest() = uiManager.disableAutoSuggest(language)
+    override fun disableAutoSuggest() = uiManager.disableAutoSuggest(language)
 
     // MARK: Floating Keyboard Integration
 
@@ -2033,7 +2042,7 @@ abstract class GeneralKeyboardIME(
         floatingKeyboardHandler.initFloatingMode()
     }
 
-    fun toggleFloatingMode() {
+    override fun toggleFloatingMode() {
         floatingKeyboardHandler.toggleFloatingMode()
     }
 
@@ -2057,11 +2066,11 @@ abstract class GeneralKeyboardIME(
         clipboardHandler.onClipboardSuggestionClicked()
     }
 
-    fun hideClipboardSuggestionChip() {
+    override fun hideClipboardSuggestionChip() {
         clipboardHandler.hideClipboardSuggestionChip()
     }
 
-    fun openClipboardPanel() {
+    override fun openClipboardPanel() {
         clipboardHandler.openClipboardPanel()
     }
 

--- a/app/src/testKeyboards/kotlin/be/scri/helpers/BackspaceHandlerTest.kt
+++ b/app/src/testKeyboards/kotlin/be/scri/helpers/BackspaceHandlerTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package be.scri.helpers
+
+import android.view.inputmethod.InputConnection
+import be.scri.views.KeyboardView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class BackspaceHandlerTest {
+    private val ime = mockk<KeyboardIMEContext>(relaxed = true)
+    private val keyboard = mockk<KeyboardBase>(relaxed = true)
+    private val keyboardView = mockk<KeyboardView>(relaxed = true)
+    private val inputConnection = mockk<InputConnection>(relaxed = true)
+    private lateinit var backspaceHandler: BackspaceHandler
+
+    @Before
+    fun setUp() {
+        mockkObject(PreferencesHelper)
+        every { PreferencesHelper.getIsWordByWordDeletionEnabled(any(), any()) } returns false
+        every { ime.keyboard } returns keyboard
+        every { ime.keyboardView } returns keyboardView
+        every { ime.getInputConnection() } returns inputConnection
+        every { ime.language } returns "English"
+        backspaceHandler = BackspaceHandler(ime)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun handleBackspace_whenInputConnectionNull_doesNotCrash() {
+        every { ime.getInputConnection() } returns null
+
+        backspaceHandler.handleBackspace(isCommandBar = false, isLongPress = false)
+
+        verify(exactly = 0) { inputConnection.deleteSurroundingText(any(), any()) }
+    }
+
+    @Test
+    fun handleBackspace_singleCharacter_deletesOneCharacter() {
+        every { inputConnection.getSelectedText(any()) } returns null
+
+        backspaceHandler.handleBackspace(isCommandBar = false, isLongPress = false)
+
+        verify { inputConnection.deleteSurroundingText(1, 0) }
+    }
+}

--- a/app/src/testKeyboards/kotlin/be/scri/helpers/KeyHandlerTest.kt
+++ b/app/src/testKeyboards/kotlin/be/scri/helpers/KeyHandlerTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package be.scri.helpers
+
+import android.view.inputmethod.InputConnection
+import be.scri.models.ScribeState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class KeyHandlerTest {
+    private val ime = mockk<KeyboardIMEContext>(relaxed = true)
+    private val keyboard = mockk<KeyboardBase>(relaxed = true)
+    private val inputConnection = mockk<InputConnection>(relaxed = true)
+    private lateinit var keyHandler: KeyHandler
+
+    @Before
+    fun setUp() {
+        every { ime.keyboard } returns keyboard
+        every { ime.getInputConnection() } returns inputConnection
+        every { ime.currentState } returns ScribeState.IDLE
+        every { ime.language } returns "English"
+        keyHandler = KeyHandler(ime)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun handleKey_whenInputConnectionNull_returnsEarly() {
+        every { ime.getInputConnection() } returns null
+
+        keyHandler.handleKey(KeyboardBase.KEYCODE_DELETE, "English")
+
+        verify(exactly = 0) { ime.handleDelete(any()) }
+    }
+
+    @Test
+    fun handleKey_whenKeyboardNull_returnsEarly() {
+        every { ime.keyboard } returns null
+
+        keyHandler.handleKey(KeyboardBase.KEYCODE_DELETE, "English")
+
+        verify(exactly = 0) { ime.handleDelete(any()) }
+    }
+
+    @Test
+    fun handleKey_deleteKey_invokesHandleDelete() {
+        every { ime.isDeleteRepeating() } returns false
+
+        keyHandler.handleKey(KeyboardBase.KEYCODE_DELETE, "English")
+
+        verify { ime.handleDelete(false) }
+    }
+
+    @Test
+    fun handleKey_enterKey_invokesHandleKeycodeEnter() {
+        keyHandler.handleKey(KeyboardBase.KEYCODE_ENTER, "English")
+
+        verify { ime.handleKeycodeEnter() }
+    }
+}

--- a/app/src/testKeyboards/kotlin/be/scri/helpers/SpaceKeyProcessorTest.kt
+++ b/app/src/testKeyboards/kotlin/be/scri/helpers/SpaceKeyProcessorTest.kt
@@ -3,7 +3,6 @@
 package be.scri.helpers
 
 import android.view.inputmethod.InputConnection
-import be.scri.services.GeneralKeyboardIME
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -16,7 +15,7 @@ import org.junit.Before
 import org.junit.Test
 
 class SpaceKeyProcessorTest {
-    private val ime = mockk<GeneralKeyboardIME>(relaxed = true)
+    private val ime = mockk<KeyboardIMEContext>(relaxed = true)
     private val suggestionHandler = mockk<SuggestionHandler>(relaxed = true)
     private val inputConnection = mockk<InputConnection>(relaxed = true)
     private lateinit var spaceKeyProcessor: SpaceKeyProcessor

--- a/app/src/testKeyboards/kotlin/be/scri/helpers/SpaceKeyProcessorTest.kt
+++ b/app/src/testKeyboards/kotlin/be/scri/helpers/SpaceKeyProcessorTest.kt
@@ -27,7 +27,7 @@ class SpaceKeyProcessorTest {
         every { PreferencesHelper.getEnablePeriodOnSpaceBarDoubleTap(any(), any()) } returns true
         spaceKeyProcessor = SpaceKeyProcessor(ime, suggestionHandler)
         every { ime.language } returns "en"
-        every { ime.currentInputConnection } returns inputConnection
+        every { ime.getInputConnection() } returns inputConnection
     }
 
     @After


### PR DESCRIPTION
# Part 16: Introduce `KeyboardIMEContext` Interface Contract

### Description

Defines an explicit `KeyboardIMEContext` interface that `GeneralKeyboardIME` implements, replacing all direct handler dependencies on the concrete IME class. This prevents internal method/property visibilities from silently accumulating on `GeneralKeyboardIME` across extraction PRs (Parts 1-15) and strictly bounds the API contract exposed to handlers.

This was suggested by @Roniscend in [PR #689](https://github.com/scribe-org/Scribe-Android/pull/689#discussion): *"The 7 methods widened to internal here are adding up across the extraction PRs -- would it be worth defining an explicit interface that handlers receive instead, so the contract doesn't silently grow?"*

### Detailed Changes Table

| File / Component | Changes Applied | Detailed Impact |
|---|---|---|
| `KeyboardIMEContext.kt` [NEW] | Created interface declaring all handler-facing APIs (environment, state, UI, suggestion, clipboard, key dispatch) | Single source of truth for what handlers can access from the IME |
| `GeneralKeyboardIME.kt` | Implements `KeyboardIMEContext`; overrides `imeContext`, `getInputConnection()`, `getImeResources()`, `getImeWindow()` | Bridges interface contract to Android `InputMethodService` without JVM signature clashes |
| `BackspaceHandler.kt` | Constructor takes `KeyboardIMEContext`; uses `ime.getInputConnection()`, `ime.imeContext` | Decoupled from concrete `GeneralKeyboardIME` |
| `SpaceKeyProcessor.kt` | Constructor takes `KeyboardIMEContext`; uses `ime.getInputConnection()`, `ime.imeContext` | Decoupled from concrete `GeneralKeyboardIME` |
| `AutocompletionHandler.kt` | Constructor takes `KeyboardIMEContext` | Decoupled from concrete `GeneralKeyboardIME` |
| `SuggestionHandler.kt` | Constructor takes `KeyboardIMEContext` | Decoupled from concrete `GeneralKeyboardIME` |
| `KeyHandler.kt` | Constructor takes `KeyboardIMEContext`; null-safe `getInputConnection()` with early return; uses `ime.imeContext` for `handleModeChange` | Decoupled from concrete `GeneralKeyboardIME`; safer null handling |
| `ClipboardHandler.kt` | Constructor takes `KeyboardIMEContext`; uses `ime.imeContext` for `ClipboardRepository`, `ClipboardMonitor`, `GridLayoutManager` | Decoupled from concrete `GeneralKeyboardIME` |
| `FloatingKeyboardHandler.kt` | Constructor takes `KeyboardIMEContext`; uses `ime.imeContext`, `ime.getImeResources()`, `ime.getImeWindow()` throughout | Decoupled from concrete `GeneralKeyboardIME` |
| `SpaceKeyProcessorTest.kt` | Updated mock setup to use `getInputConnection()` instead of `currentInputConnection` | Test aligned with new interface |

### Key Benefits

- Strict API boundary: Handlers can only access explicitly declared contract members
- Prevents silent visibility widening on `GeneralKeyboardIME` across future extraction PRs
- Avoids Kotlin/Java JVM signature clashes by using renamed accessors (`imeContext`, `getInputConnection()`, `getImeResources()`, `getImeWindow()`) instead of property names that collide with `InputMethodService` getters
- Enables clean unit testing via mock `KeyboardIMEContext` implementations
- All 81 existing unit tests pass

### Related Issue

Refactors part of [#426](https://github.com/scribe-org/Scribe-Android/issues/426)
