### PR TITLE
additional i18n integrations

### DIFF
--- a/app/src/main/java/be/scri/helpers/ui/RatingHelper.kt
+++ b/app/src/main/java/be/scri/helpers/ui/RatingHelper.kt
@@ -84,7 +84,12 @@ object RatingHelper {
         try {
             context.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
-            Toast.makeText(context, "No browser found to open $storeName page", Toast.LENGTH_SHORT).show()
+            Toast
+                .makeText(
+                    context,
+                    context.getString(R.string.i18n_app_about_feedback_no_browser_found).replace("{store}", storeName),
+                    Toast.LENGTH_SHORT,
+                ).show()
             Log.e("RatingHelper", "Unable to open $storeName link", e)
         }
     }

--- a/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
+++ b/app/src/main/java/be/scri/ui/common/appcomponents/HintDialog.kt
@@ -197,7 +197,7 @@ fun HintDialogContent(
                         shape = RoundedCornerShape(8.dp),
                     ) {
                         Text(
-                            text = "OK",
+                            text = stringResource(R.string.i18n_app_settings_option_ok),
                             style = MaterialTheme.typography.headlineMedium,
                             modifier = Modifier,
                         )

--- a/app/src/main/java/be/scri/ui/screens/ConjugateScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ConjugateScreen.kt
@@ -434,7 +434,7 @@ fun ConjugateScreen(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
-                                text = "Clear all ✕",
+                                text = stringResource(R.string.i18n_app__global_clear_all) + " ✕",
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onPrimary,
                                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/be/scri/ui/screens/ConjugationSelectionScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/ConjugationSelectionScreen.kt
@@ -199,7 +199,7 @@ fun ConjugationSelectionScreen(
                             modifier = Modifier.fillMaxWidth(0.9f),
                         ) {
                             DropdownMenuItem(
-                                text = { Text("All tenses") },
+                                text = { Text(stringResource(R.string.i18n_app_conjugate_choose_conjugation_all_tenses)) },
                                 onClick = {
                                     selectedTenseGroup = null
                                     expanded = false

--- a/app/src/main/java/be/scri/ui/screens/tutorial/TutorialHomeScreen.kt
+++ b/app/src/main/java/be/scri/ui/screens/tutorial/TutorialHomeScreen.kt
@@ -156,7 +156,7 @@ fun TutorialHomeScreen(
                         )
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = "Go to ${chapter.title}",
+                            contentDescription = stringResource(R.string.i18n_app_accessibility_go_to_chapter).replace("{title}", chapter.title),
                             tint = secondaryTextColor,
                         )
                     }

--- a/app/src/main/res/values/string.xml
+++ b/app/src/main/res/values/string.xml
@@ -50,6 +50,7 @@
     <string name="i18n.app.about.community.wikimedia.text_2">Wikidata is a collaboratively edited multilingual knowledge graph hosted by the Wikimedia Foundation. It provides freely available data that anyone can use under a Creative Commons Public Domain license (CC0). Scribe uses language data from Wikidata to provide users with verb conjugations, noun-form annotations, noun plurals, and many other features.</string>
     <string name="i18n.app.about.community.wikimedia.text_3">Wikipedia is a multilingual free online encyclopedia written and maintained by a community of volunteers through open collaboration and a wiki-based editing system. Scribe uses data from Wikipedia to produce autosuggestions by deriving the most common words in a language as well as the most common words that follow them.</string>
     <string name="i18n.app.about.feedback.bug_report">Report a bug</string>
+    <string name="i18n.app.about.feedback.no_browser_found">No browser found to open {store} page</string>
     <string name="i18n.app.about.feedback.rate_conjugate">Rate Scribe Conjugate</string>
     <string name="i18n.app.about.feedback.rate_description_amazon">Rate us on Amazon Appstore</string>
     <string name="i18n.app.about.feedback.rate_description_f_droid">Rate us on F-Droid</string>
@@ -75,6 +76,7 @@
     <string name="i18n.app.accessibility.clear">Clear</string>
     <string name="i18n.app.accessibility.copy_conjugation">Copy conjugation</string>
     <string name="i18n.app.accessibility.expand_tenses">Expand tenses</string>
+    <string name="i18n.app.accessibility.go_to_chapter">Go to {title}</string>
     <string name="i18n.app.accessibility.leading_icon">Leading icon</string>
     <string name="i18n.app.accessibility.play_button">Play button</string>
     <string name="i18n.app.accessibility.right_arrow">Right Arrow</string>
@@ -87,6 +89,7 @@
     <string name="i18n.app.clipboard.copy_to_clipboard">Copy to clipboard</string>
     <string name="i18n.app.clipboard.title">Clipboard</string>
     <string name="i18n.app.conjugate.app_hint_tooltip">Download verb data with the menu below to start conjugating verbs.</string>
+    <string name="i18n.app.conjugate.choose_conjugation.all_tenses">All tenses</string>
     <string name="i18n.app.conjugate.choose_conjugation.select_tense">Select tense</string>
     <string name="i18n.app.conjugate.choose_conjugation.title">Choose a conjugation below</string>
     <string name="i18n.app.conjugate.data_not_present_in_wikidata">Data not present in Wikidata</string>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `./gradlew lintKotlin detekt test` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Android/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR integrates rest of the missing i18n string resources across the Android  codebase (text strings, toast messages, contentDescriptions, etc)

### Related issue

- Closes #694 
